### PR TITLE
fix(domains): implement HMAC-SHA256 webhook signature verification

### DIFF
--- a/scripts/code_health_allowlist.txt
+++ b/scripts/code_health_allowlist.txt
@@ -7,7 +7,4 @@
 # IMPORTANT: Do NOT add new entries without a linked issue/PR and review.
 # Adding allowlist entries for new findings defeats the purpose of the scan.
 
-# domains/services.py — verify_webhook_signature is a known placeholder (TODO: implement ROTLD webhook HMAC)
-# Issue: https://github.com/pragmatichost/praho/issues/TBD  — tracked for next sprint
-services/platform/apps/domains/services.py:676:always-true-auth
-services/platform/apps/domains/services.py:676:todo-stub
+# (empty — all known stubs resolved)

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -15,6 +15,8 @@ Provides business logic for domain operations including:
 
 from __future__ import annotations
 
+import hashlib
+import hmac as hmac_mod
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -25,6 +27,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from apps.common.encryption import DecryptionError
 from apps.settings.services import SettingsService
 
 from .models import TLD, Domain, DomainOrderItem, Registrar
@@ -674,9 +677,32 @@ class DomainRegistrarGateway:
 
     @staticmethod
     def verify_webhook_signature(registrar: Registrar, payload: str, signature: str) -> bool:
-        """🔐 Verify webhook signature using registrar's webhook secret"""
-        logger.info(f"🌐 [Gateway] Would verify webhook signature for {registrar.name}")
+        """Verify webhook signature using registrar's HMAC-SHA256 webhook secret.
 
-        # TODO: Implement actual signature verification
-        # For now, return True as placeholder (webhook verification disabled)
-        return True
+        Fail-closed: returns False on any error (missing secret, decryption failure, mismatch).
+        Uses timing-safe comparison to prevent side-channel attacks.
+        """
+        if not registrar.webhook_secret or not signature:
+            logger.warning(f"⚠️ [Gateway] Missing webhook secret or signature for {registrar.name}")
+            return False
+
+        try:
+            decrypted = registrar.get_decrypted_webhook_secret()
+        except DecryptionError:
+            logger.error(
+                f"🔥 [Gateway] Webhook secret decryption failed for {registrar.name} — encryption key may have rotated"
+            )
+            return False
+
+        if not decrypted or not decrypted.strip():
+            logger.error(f"🔥 [Gateway] Webhook secret for {registrar.name} decrypted to empty value")
+            return False
+
+        webhook_secret = decrypted.encode("utf-8")
+
+        try:
+            expected = hmac_mod.new(webhook_secret, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+            return hmac_mod.compare_digest(f"sha256={expected}", signature)
+        except Exception:
+            logger.exception(f"🔥 [Gateway] Signature verification error for {registrar.name}")
+            return False

--- a/services/platform/tests/domains/test_webhook_signature_verification.py
+++ b/services/platform/tests/domains/test_webhook_signature_verification.py
@@ -1,0 +1,182 @@
+"""Tests for DomainRegistrarGateway.verify_webhook_signature (issue #92).
+
+Verifies HMAC-SHA256 signature checking with timing-safe comparison,
+fail-closed behavior on missing/bad inputs, and DecryptionError handling.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+from django.test import TestCase
+
+from apps.domains.models import Registrar
+from apps.domains.services import DomainRegistrarGateway
+
+
+class WebhookSignatureVerificationTests(TestCase):
+    """Core HMAC-SHA256 verification tests for registrar webhooks."""
+
+    WEBHOOK_SECRET = "whsec_test_secret_abc123"
+
+    def setUp(self) -> None:
+        self.registrar = Registrar.objects.create(
+            name="test-registrar",
+            display_name="Test Registrar",
+            website_url="https://example.com",
+            api_endpoint="https://api.example.com",
+            status="active",
+        )
+        # Store encrypted webhook secret
+        self.registrar.set_encrypted_credentials(webhook_secret=self.WEBHOOK_SECRET)
+        self.registrar.save()
+
+        self.payload = json.dumps({"event_type": "domain.registered", "domain_name": "example.com"})
+
+    def _sign(self, payload: str, secret: str | None = None) -> str:
+        """Generate a valid sha256=<hex> signature for a payload."""
+        key = (secret or self.WEBHOOK_SECRET).encode("utf-8")
+        digest = hmac.new(key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        return f"sha256={digest}"
+
+    def test_valid_signature_accepted(self) -> None:
+        signature = self._sign(self.payload)
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, signature
+        )
+        self.assertTrue(result)
+
+    def test_invalid_signature_rejected(self) -> None:
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, "sha256=deadbeef1234567890"
+        )
+        self.assertFalse(result)
+
+    def test_wrong_secret_rejected(self) -> None:
+        bad_sig = self._sign(self.payload, secret="wrong_secret")
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, bad_sig
+        )
+        self.assertFalse(result)
+
+    def test_tampered_payload_rejected(self) -> None:
+        signature = self._sign(self.payload)
+        tampered = self.payload.replace("example.com", "evil.com")
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, tampered, signature
+        )
+        self.assertFalse(result)
+
+    def test_empty_signature_rejected(self) -> None:
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, ""
+        )
+        self.assertFalse(result)
+
+    def test_missing_webhook_secret_rejected(self) -> None:
+        registrar_no_secret = Registrar.objects.create(
+            name="no-secret-registrar",
+            display_name="No Secret",
+            website_url="https://example.com",
+            api_endpoint="https://api.example.com",
+            status="active",
+        )
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            registrar_no_secret, self.payload, "sha256=anything"
+        )
+        self.assertFalse(result)
+
+    def test_decryption_error_rejected(self) -> None:
+        # Simulate corrupted encrypted secret
+        self.registrar.webhook_secret = "aes:corrupted_data_not_valid_base64url"
+        self.registrar.save()
+
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, "sha256=anything"
+        )
+        self.assertFalse(result)
+
+    def test_empty_decrypted_secret_rejected(self) -> None:
+        """Unencrypted empty/whitespace value stored in DB should be rejected."""
+        # Store a raw (unencrypted) whitespace value — decrypt_value returns it as-is
+        self.registrar.webhook_secret = "   "
+        self.registrar.save()
+
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, "sha256=anything"
+        )
+        self.assertFalse(result)
+
+    def test_signature_without_prefix_rejected(self) -> None:
+        """Signatures must include the 'sha256=' prefix."""
+        raw_hex = self._sign(self.payload).removeprefix("sha256=")
+        result = DomainRegistrarGateway.verify_webhook_signature(
+            self.registrar, self.payload, raw_hex
+        )
+        self.assertFalse(result)
+
+
+class WebhookViewSignatureIntegrationTests(TestCase):
+    """Integration tests for RegistrarWebhookView signature enforcement via RequestFactory."""
+
+    WEBHOOK_SECRET = "whsec_integration_test_456"
+
+    def setUp(self) -> None:
+        from django.test import RequestFactory  # noqa: PLC0415
+
+        self.factory = RequestFactory()
+        self.registrar = Registrar.objects.create(
+            name="integration-registrar",
+            display_name="Integration Registrar",
+            website_url="https://example.com",
+            api_endpoint="https://api.example.com",
+            status="active",
+        )
+        self.registrar.set_encrypted_credentials(webhook_secret=self.WEBHOOK_SECRET)
+        self.registrar.save()
+
+        self.payload = json.dumps({
+            "event_type": "domain.registered",
+            "domain_name": "test-integration.com",
+        })
+
+    def _sign(self, payload: str) -> str:
+        key = self.WEBHOOK_SECRET.encode("utf-8")
+        digest = hmac.new(key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        return f"sha256={digest}"
+
+    def _post_webhook(self, payload: str, **extra_headers: str) -> Any:
+        from apps.domains.webhooks import RegistrarWebhookView  # noqa: PLC0415
+
+        request = self.factory.post(
+            f"/webhooks/{self.registrar.name}/",
+            data=payload,
+            content_type="application/json",
+            **extra_headers,
+        )
+        view = RegistrarWebhookView.as_view()
+        return view(request, registrar_slug=self.registrar.name)
+
+    def test_webhook_view_rejects_no_signature(self) -> None:
+        response = self._post_webhook(self.payload)
+        self.assertEqual(response.status_code, 403)
+
+    def test_webhook_view_rejects_bad_signature(self) -> None:
+        response = self._post_webhook(
+            self.payload,
+            HTTP_X_HUB_SIGNATURE_256="sha256=invalid",
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_webhook_view_accepts_valid_signature(self) -> None:
+        signature = self._sign(self.payload)
+        response = self._post_webhook(
+            self.payload,
+            HTTP_X_HUB_SIGNATURE_256=signature,
+        )
+        # Domain doesn't exist so we get 400 (not 403), proving signature passed
+        self.assertIn(response.status_code, [200, 400])
+        self.assertNotEqual(response.status_code, 403)


### PR DESCRIPTION
## Summary

Closes #92 — `DomainRegistrarGateway.verify_webhook_signature()` unconditionally returned `True`, allowing any attacker to forge domain events (registration, transfer, expiration, suspension) by posting to the webhook endpoint.

- Replace stub with real HMAC-SHA256 verification using registrar's encrypted `webhook_secret`
- Add empty-after-decryption guard (catches unencrypted/whitespace values stored via Django shell)
- Remove resolved entries from `code_health_allowlist.txt`
- Add 12 tests (9 unit + 3 integration via RequestFactory)

## Implementation Details

### `services/platform/apps/domains/services.py` — `verify_webhook_signature()`

Mirrors the proven pattern from `SecureServerGateway.verify_webhook_signature()` (provisioning app):

1. **Guard**: reject if `webhook_secret` field is empty or no signature header provided
2. **Decrypt**: call `registrar.get_decrypted_webhook_secret()`, catch `DecryptionError` (key rotation)
3. **Empty check**: reject if decrypted value is empty/whitespace (Finding 1 from silent-failure audit)
4. **HMAC**: compute `sha256=<hex>` with `hmac.new()` + `hashlib.sha256`
5. **Compare**: timing-safe `hmac.compare_digest()` prevents side-channel attacks

All error paths return `False` (fail-closed). Every rejection is logged with registrar name for debugging.

### `services/platform/tests/domains/test_webhook_signature_verification.py` — 12 tests

**Unit tests (9):**
- Valid signature accepted
- Invalid/wrong-secret/tampered-payload rejected
- Empty signature, missing webhook secret rejected
- Corrupted encrypted secret (DecryptionError) rejected
- Empty decrypted value (whitespace) rejected
- Signature without `sha256=` prefix rejected

**Integration tests (3):**
- `RegistrarWebhookView` rejects requests with no signature (403)
- Rejects requests with bad signature (403)
- Accepts valid signature (passes to domain lookup, not 403)

### `scripts/code_health_allowlist.txt`

Removed `always-true-auth` and `todo-stub` entries — the underlying issue is now fixed.

## Security Audit Findings (pre-existing, not introduced by this PR)

The silent-failure-hunter agent identified 6 additional issues in `webhooks.py` that predate this PR:
- Health check endpoint has no auth and leaks config state
- Handler errors return `str(e)` in HTTP responses (info disclosure)
- `get_object_or_404` leaks registrar existence via 404 vs 403
- Broad catch-all in `post()` with error truncation
- Unknown event types silently return 200
- Dual signature header fallback is undocumented

These should be tracked as follow-up work.

## Test plan

- [x] All 12 new tests pass (`pytest tests/domains/test_webhook_signature_verification.py`)
- [x] All 21 domain tests pass (`pytest tests/domains/`)
- [x] Full platform test suite passes (`make test-platform`)
- [x] Ruff lint clean
- [x] MyPy clean
- [x] All pre-commit hooks pass (including code health check, audit coverage, security credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)