### PR TITLE
fix(billing): fail-hard on refund aggregation error + typed DB exceptions (#119, #120)

### DIFF
--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -11,7 +11,7 @@ import uuid
 from decimal import Decimal
 from typing import Any, TypedDict
 
-from django.db import DatabaseError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.db.models import Count, Q, Sum
 from django_fsm import TransitionNotAllowed
 
@@ -818,21 +818,23 @@ class RefundService:
 
             return Ok(None)
 
-        except Exception as db_error:
-            error_msg = str(db_error)
+        except IntegrityError:
+            # FK constraint violated — catches both SQLite and PostgreSQL (#120)
             entity_label = "order" if order else "invoice"
             entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
-            if "FOREIGN KEY constraint failed" in error_msg:
-                logger.exception("Refund record creation failed: FK constraint for %s_id=%s", entity_label, entity_pk)
-                return Err("Failed to process bidirectional refund")
-            elif "Cannot assign" in error_msg:
-                logger.exception(
-                    "Refund record creation failed: assignment error for %s_id=%s", entity_label, entity_pk
-                )
-                return Err("Order update failed" if order else "Invoice update failed")
-            else:
-                logger.exception("Refund record creation failed for %s_id=%s", entity_label, entity_pk)
-                return Err("Failed to process bidirectional refund")
+            logger.exception("Refund record creation failed: FK constraint for %s_id=%s", entity_label, entity_pk)
+            return Err("Failed to process bidirectional refund")
+        except ValueError:
+            # Django ORM assignment error (e.g. assigning wrong type to FK field) (#120)
+            entity_label = "order" if order else "invoice"
+            entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
+            logger.exception("Refund record creation failed: assignment error for %s_id=%s", entity_label, entity_pk)
+            return Err("Order update failed" if order else "Invoice update failed")
+        except Exception:
+            entity_label = "order" if order else "invoice"
+            entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
+            logger.exception("Refund record creation failed for %s_id=%s", entity_label, entity_pk)
+            return Err("Failed to process bidirectional refund")
 
     @staticmethod
     def _process_entity_updates(
@@ -984,16 +986,16 @@ class RefundService:
             if refunds:
                 return sum(r.get("amount_cents", 0) for r in refunds)
 
-        # Check related refunds
+        # Check related refunds — must not silently return 0 on failure (over-refund risk, #119)
         try:
             return int(Refund.objects.filter(order=order).aggregate(total=Sum("amount_cents", default=0))["total"])
-        except (TypeError, AttributeError):
-            logger.warning(
-                "Refund amount aggregation failed for order_id=%s, defaulting to 0 — over-refund risk",
+        except (TypeError, AttributeError) as exc:
+            logger.error(
+                "Refund amount aggregation failed for order_id=%s — aborting to prevent over-refund",
                 getattr(order, "pk", "unknown"),
                 exc_info=True,
             )
-            return 0
+            raise RuntimeError(f"Cannot determine refunded amount for order {getattr(order, 'pk', 'unknown')}") from exc
 
     @staticmethod
     def _get_invoice_refunded_amount(invoice: Any) -> int:
@@ -1007,16 +1009,18 @@ class RefundService:
             if refunds:
                 return sum(r.get("amount_cents", 0) for r in refunds)
 
-        # Check related refunds
+        # Check related refunds — must not silently return 0 on failure (over-refund risk, #119)
         try:
             return int(Refund.objects.filter(invoice=invoice).aggregate(total=Sum("amount_cents", default=0))["total"])
-        except (TypeError, AttributeError):
-            logger.warning(
-                "Refund amount aggregation failed for invoice_id=%s, defaulting to 0 — over-refund risk",
+        except (TypeError, AttributeError) as exc:
+            logger.error(
+                "Refund amount aggregation failed for invoice_id=%s — aborting to prevent over-refund",
                 getattr(invoice, "pk", "unknown"),
                 exc_info=True,
             )
-            return 0
+            raise RuntimeError(
+                f"Cannot determine refunded amount for invoice {getattr(invoice, 'pk', 'unknown')}"
+            ) from exc
 
     @staticmethod
     def _create_order_refund_eligibility(

--- a/services/platform/tests/billing/test_refund_service_regressions.py
+++ b/services/platform/tests/billing/test_refund_service_regressions.py
@@ -959,9 +959,13 @@ class TestCreateRefundRecord(TestCase):
         assert r.is_ok()
 
     def test_foreign_key_error(self):
+        # #120: use IntegrityError (catches both SQLite + PostgreSQL), not string matching
+        from django.db import IntegrityError  # noqa: PLC0415
+
         from apps.billing.refund_service import RefundRecordParams  # noqa: PLC0415
+
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
-            mock_qs.create.side_effect = Exception("FOREIGN KEY constraint failed")
+            mock_qs.create.side_effect = IntegrityError("insert violates foreign key constraint")
             params = RefundRecordParams(
                 refund_id=uuid.uuid4(), order=MagicMock(), invoice=None,
                 refund_amount_cents=5000, original_cents=10000,
@@ -972,9 +976,10 @@ class TestCreateRefundRecord(TestCase):
             assert "bidirectional" in r.unwrap_err()
 
     def test_cannot_assign_error_order(self):
+        # #120: use ValueError (Django ORM assignment error type), not string matching
         from apps.billing.refund_service import RefundRecordParams  # noqa: PLC0415
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
-            mock_qs.create.side_effect = Exception("Cannot assign something")
+            mock_qs.create.side_effect = ValueError("Cannot assign value to FK field")
             params = RefundRecordParams(
                 refund_id=uuid.uuid4(), order=MagicMock(), invoice=None,
                 refund_amount_cents=5000, original_cents=10000,
@@ -985,9 +990,10 @@ class TestCreateRefundRecord(TestCase):
             assert "Order update failed" in r.unwrap_err()
 
     def test_cannot_assign_error_invoice(self):
+        # #120: use ValueError (Django ORM assignment error type), not string matching
         from apps.billing.refund_service import RefundRecordParams  # noqa: PLC0415
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
-            mock_qs.create.side_effect = Exception("Cannot assign something")
+            mock_qs.create.side_effect = ValueError("Cannot assign value to FK field")
             params = RefundRecordParams(
                 refund_id=uuid.uuid4(), order=None, invoice=MagicMock(),
                 refund_amount_cents=5000, original_cents=10000,
@@ -1034,10 +1040,12 @@ class TestCreateRefundRecord(TestCase):
 
     def test_fk_constraint_error_logs_exception(self):
         """FK constraint branch logs exception (was previously silent)."""
+        from django.db import IntegrityError  # noqa: PLC0415
+
         from apps.billing.refund_service import RefundRecordParams  # noqa: PLC0415
 
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
-            mock_qs.create.side_effect = Exception("FOREIGN KEY constraint failed")
+            mock_qs.create.side_effect = IntegrityError("insert violates foreign key constraint")
             order_mock = MagicMock()
             order_mock.pk = 888
             params = RefundRecordParams(
@@ -1285,11 +1293,13 @@ class TestGetRefundedAmounts(TestCase):
         o = _make_order(c, cur, status="completed", total_cents=10000)
         assert RefundService._get_order_refunded_amount(o) == 0
 
-    def test_order_db_error_returns_zero(self):
+    def test_order_db_error_raises(self):
+        # #119: aggregation failure must raise rather than silently return 0 (over-refund risk)
         order = MagicMock(meta={})
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
             mock_qs.filter.return_value.aggregate.side_effect = TypeError("bad")
-            assert RefundService._get_order_refunded_amount(order) == 0
+            with self.assertRaises(RuntimeError, msg="Should raise to abort refund, not return 0"):
+                RefundService._get_order_refunded_amount(order)
 
     def test_invoice_none(self):
         assert RefundService._get_invoice_refunded_amount(None) == 0
@@ -1309,11 +1319,13 @@ class TestGetRefundedAmounts(TestCase):
         )
         assert RefundService._get_invoice_refunded_amount(inv) == 6000
 
-    def test_invoice_db_error_returns_zero(self):
+    def test_invoice_db_error_raises(self):
+        # #119: aggregation failure must raise rather than silently return 0 (over-refund risk)
         inv = MagicMock(meta={})
         with patch("apps.billing.refund_service.Refund.objects") as mock_qs:
             mock_qs.filter.return_value.aggregate.side_effect = AttributeError("bad")
-            assert RefundService._get_invoice_refunded_amount(inv) == 0
+            with self.assertRaises(RuntimeError, msg="Should raise to abort refund, not return 0"):
+                RefundService._get_invoice_refunded_amount(inv)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Closes #119, #120.

Two bugs in `refund_service.py` that were discovered during code review of PR #114:

---

### #119 — Refund amount aggregation silently returns 0 (over-refund risk)

**Problem:** `_get_order_refunded_amount()` and `_get_invoice_refunded_amount()` caught `TypeError`/`AttributeError` from the ORM aggregation and returned `0`. In a billing context, `0` means "nothing has been refunded yet" — so if the query failed, the service would allow a full refund even when partial refunds already existed.

**Fix:** Re-raise as `RuntimeError` so callers abort the refund operation rather than proceed with a wrong baseline. Logged at `ERROR` level (was `WARNING`) to ensure visibility.

```python
# Before — silent over-refund risk
except (TypeError, AttributeError):
    logger.warning("... defaulting to 0 — over-refund risk", ...)
    return 0

# After — fail-hard, abort the refund
except (TypeError, AttributeError) as exc:
    logger.error("... aborting to prevent over-refund", ...)
    raise RuntimeError("Cannot determine refunded amount for order ...") from exc
```

---

### #120 — Refund error handling uses backend-specific string matching

**Problem:** `_create_refund_record()` branched on `str(db_error)` content:
- `"FOREIGN KEY constraint failed"` — SQLite-specific message
- `"Cannot assign"` — Django ORM text

PostgreSQL uses different error text (`"insert or update on table ... violates foreign key constraint ..."`), so the FK branch never matched in production.

**Fix:** Replaced the single `except Exception` + string parsing with three typed catches:

| Exception type | When | Maps to |
|---|---|---|
| `IntegrityError` | FK constraint violation (all backends) | `"Failed to process bidirectional refund"` |
| `ValueError` | ORM assignment error (all backends) | `"Order/Invoice update failed"` |
| `Exception` | Everything else | `"Failed to process bidirectional refund"` |

---

## Files changed

- `services/platform/apps/billing/refund_service.py` — 3 changes (import, 2× aggregation method, except block)
- `services/platform/tests/billing/test_refund_service_regressions.py` — tests updated to reflect new behavior

## Tests

- `test_order_db_error_raises` — asserts `RuntimeError` raised on aggregation failure (was: `== 0`)
- `test_invoice_db_error_raises` — same for invoice path
- `test_foreign_key_error` — mock updated to `IntegrityError` (was: `Exception("FOREIGN KEY..."`)
- `test_cannot_assign_error_order/invoice` — mock updated to `ValueError`
- `test_fk_constraint_error_logs_exception` — mock updated to `IntegrityError`

All 207 billing regression tests pass.

## Pre-commit

- [x] Ruff lint clean
- [x] MyPy type checks pass
- [x] All hooks pass
- [x] DCO sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)