### PR TITLE
fix(api): send invite email when creating Portal user (#145)

### DIFF
--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -25,6 +25,7 @@ from apps.customers.contact_service import AddressData, ContactService
 from apps.customers.models import Customer, CustomerTaxProfile
 from apps.provisioning.service_models import Service
 from apps.users.models import CustomerMembership, User
+from apps.users.services import SecureCustomerUserService
 
 from .serializers import (
     CustomerBillingAddressUpdateSerializer,
@@ -1023,9 +1024,17 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
             status=status.HTTP_400_BAD_REQUEST,
         )
 
+    # Send invite email with password reset link
+    email_sent = SecureCustomerUserService._send_welcome_email_secure(new_user, customer)
+
     logger.info(f"✅ [User Management API] New user {email} created and added to customer {customer.id}")
     return Response(
-        {"success": True, "user_id": new_user.id, "message": f"User created and added as {role}."},
+        {
+            "success": True,
+            "user_id": new_user.id,
+            "message": f"User created and added as {role}.",
+            "invite_email_sent": email_sent,
+        },
         status=status.HTTP_201_CREATED,
     )
 

--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -20,6 +20,7 @@ from apps.api.core import ReadOnlyAPIViewSet
 from apps.api.core.permissions import IsAuthenticatedAndAccessible
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle
 from apps.api.secure_auth import public_api_endpoint, require_customer_authentication, require_portal_authentication
+from apps.common.request_ip import get_safe_client_ip
 from apps.customers.contact_models import CustomerAddress
 from apps.customers.contact_service import AddressData, ContactService
 from apps.customers.models import Customer, CustomerTaxProfile
@@ -1025,7 +1026,9 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
         )
 
     # Send invite email with password reset link
-    email_sent = SecureCustomerUserService._send_welcome_email_secure(new_user, customer)
+    email_sent = SecureCustomerUserService._send_welcome_email_secure(
+        new_user, customer, request_ip=get_safe_client_ip(request)
+    )
 
     logger.info(f"✅ [User Management API] New user {email} created and added to customer {customer.id}")
     return Response(

--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -6,6 +6,8 @@ import json
 import logging
 from typing import Any, ClassVar, cast
 
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
@@ -1000,6 +1002,14 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
 
     if not email:
         return Response({"success": False, "error": "Email is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        validate_email(email)
+    except ValidationError:
+        return Response(
+            {"success": False, "error": "Invalid email address."},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
     valid_roles = [c[0] for c in CustomerMembership.CUSTOMER_ROLE_CHOICES]
     if role not in valid_roles:

--- a/services/platform/apps/customers/user_management_views.py
+++ b/services/platform/apps/customers/user_management_views.py
@@ -13,6 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods, require_POST
 
 from apps.common.decorators import staff_required
+from apps.common.request_ip import get_safe_client_ip
 from apps.customers.customer_service import CustomerService
 from apps.customers.models import Customer
 from apps.users.models import CustomerMembership, User
@@ -119,7 +120,9 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
         CustomerMembership.objects.create(customer=customer, user=user, role=role)
 
         # Send invite email with password reset link
-        email_sent = SecureCustomerUserService._send_welcome_email_secure(user, customer)
+        email_sent = SecureCustomerUserService._send_welcome_email_secure(
+            user, customer, request_ip=get_safe_client_ip(request)
+        )
         if not email_sent:
             messages.warning(request, _("User created but invite email could not be sent."))
 

--- a/services/platform/apps/customers/user_management_views.py
+++ b/services/platform/apps/customers/user_management_views.py
@@ -6,6 +6,9 @@ Handles user assignment, role changes, and access management.
 from typing import cast
 
 from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -88,7 +91,7 @@ def customer_add_user(request: HttpRequest, customer_id: int) -> HttpResponse:
 
 @staff_required
 @require_http_methods(["GET", "POST"])
-def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse:
+def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse:  # noqa: PLR0911
     """Create new user and assign to customer."""
     customer = _get_accessible_customer(request, customer_id)
 
@@ -102,22 +105,28 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
             messages.error(request, _("Email address is required."))
             return redirect("customers:detail", customer_id=customer.id)
 
+        try:
+            validate_email(email)
+        except ValidationError:
+            messages.error(request, _("Please enter a valid email address."))
+            return redirect("customers:detail", customer_id=customer.id)
+
         # Validate role against allowed choices
         valid_roles = [choice[0] for choice in CustomerMembership.CUSTOMER_ROLE_CHOICES]
         if role not in valid_roles:
             messages.error(request, _("Invalid role selected."))
             return redirect("customers:detail", customer_id=customer.id)
 
-        # Check if user already exists
-        if User.objects.filter(email=email).exists():
+        try:
+            with transaction.atomic():
+                if User.objects.filter(email=email).exists():
+                    messages.error(request, _("User with email '{}' already exists.").format(email))
+                    return redirect("customers:detail", customer_id=customer.id)
+                user = User.objects.create_user(email=email, first_name=first_name, last_name=last_name)
+                CustomerMembership.objects.create(customer=customer, user=user, role=role)
+        except IntegrityError:
             messages.error(request, _("User with email '{}' already exists.").format(email))
             return redirect("customers:detail", customer_id=customer.id)
-
-        # Create new user with proper password hashing
-        user = User.objects.create_user(email=email, first_name=first_name, last_name=last_name)
-
-        # Create membership
-        CustomerMembership.objects.create(customer=customer, user=user, role=role)
 
         # Send invite email with password reset link
         email_sent = SecureCustomerUserService._send_welcome_email_secure(

--- a/services/platform/apps/customers/user_management_views.py
+++ b/services/platform/apps/customers/user_management_views.py
@@ -16,6 +16,7 @@ from apps.common.decorators import staff_required
 from apps.customers.customer_service import CustomerService
 from apps.customers.models import Customer
 from apps.users.models import CustomerMembership, User
+from apps.users.services import SecureCustomerUserService
 
 
 def _get_accessible_customer(request: HttpRequest, customer_id: int) -> Customer:
@@ -116,6 +117,11 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
 
         # Create membership
         CustomerMembership.objects.create(customer=customer, user=user, role=role)
+
+        # Send invite email with password reset link
+        email_sent = SecureCustomerUserService._send_welcome_email_secure(user, customer)
+        if not email_sent:
+            messages.warning(request, _("User created but invite email could not be sent."))
 
         messages.success(request, _("New user '{}' created and assigned to customer.").format(user.email))
         return redirect("customers:detail", customer_id=customer.id)

--- a/services/platform/templates/customers/emails/welcome_email.html
+++ b/services/platform/templates/customers/emails/welcome_email.html
@@ -1,0 +1,33 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
+  <h2>{% blocktrans with customer_name=customer.company_name %}Welcome to PragmaticHost!{% endblocktrans %}</h2>
+
+  <p>{% blocktrans with customer_name=customer.company_name %}You have been invited to join {{ customer_name }}.{% endblocktrans %}</p>
+
+  <p>{% trans "To get started, please set your password by clicking the button below:" %}</p>
+
+  <p style="text-align: center; margin: 30px 0;">
+    <a href="{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}"
+       style="background-color: #2563eb; color: #fff; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">
+      {% trans "Set Your Password" %}
+    </a>
+  </p>
+
+  <p style="font-size: 0.9em; color: #666;">
+    {% trans "Or copy and paste this link into your browser:" %}<br>
+    {{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
+  </p>
+
+  <p style="font-size: 0.9em; color: #666;">
+    {% trans "This link will expire in 3 days." %}
+  </p>
+
+  <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
+
+  <p style="font-size: 0.85em; color: #999;">
+    {% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}
+  </p>
+</body>
+</html>

--- a/services/platform/templates/customers/emails/welcome_email.html
+++ b/services/platform/templates/customers/emails/welcome_email.html
@@ -21,7 +21,7 @@
   </p>
 
   <p style="font-size: 0.9em; color: #666;">
-    {% trans "This link will expire in 3 days." %}
+    {% trans "This link will expire in 2 hours." %}
   </p>
 
   <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">

--- a/services/platform/templates/customers/emails/welcome_email.html
+++ b/services/platform/templates/customers/emails/welcome_email.html
@@ -2,7 +2,7 @@
 <html>
 <head><meta charset="utf-8"></head>
 <body style="font-family: sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
-  <h2>{% blocktrans with customer_name=customer.company_name %}Welcome to PragmaticHost!{% endblocktrans %}</h2>
+  <h2>{% blocktrans with customer_name=customer.company_name %}Welcome to PRAHO!{% endblocktrans %}</h2>
 
   <p>{% blocktrans with customer_name=customer.company_name %}You have been invited to join {{ customer_name }}.{% endblocktrans %}</p>
 

--- a/services/platform/templates/customers/emails/welcome_email.txt
+++ b/services/platform/templates/customers/emails/welcome_email.txt
@@ -6,7 +6,7 @@ You have been invited to join {{ customer_name }}.{% endblocktrans %}
 
 {{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
 
-{% trans "This link will expire in 3 days. If it has expired, you can request a new one at:" %}
+{% trans "This link will expire in 2 hours. If it has expired, you can request a new one at:" %}
 {{ protocol }}://{{ domain }}{% url 'users:password_reset' %}
 
 {% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}

--- a/services/platform/templates/customers/emails/welcome_email.txt
+++ b/services/platform/templates/customers/emails/welcome_email.txt
@@ -1,0 +1,15 @@
+{% load i18n %}{% blocktrans with customer_name=customer.company_name %}Welcome to PragmaticHost!
+
+You have been invited to join {{ customer_name }}.{% endblocktrans %}
+
+{% trans "To get started, please set your password by clicking the link below:" %}
+
+{{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
+
+{% trans "This link will expire in 3 days. If it has expired, you can request a new one at:" %}
+{{ protocol }}://{{ domain }}{% url 'users:password_reset' %}
+
+{% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}
+
+{% trans "Best regards," %}
+{% trans "The PragmaticHost Team" %}

--- a/services/platform/templates/customers/emails/welcome_email.txt
+++ b/services/platform/templates/customers/emails/welcome_email.txt
@@ -1,4 +1,4 @@
-{% load i18n %}{% blocktrans with customer_name=customer.company_name %}Welcome to PragmaticHost!
+{% load i18n %}{% blocktrans with customer_name=customer.company_name %}Welcome to PRAHO!
 
 You have been invited to join {{ customer_name }}.{% endblocktrans %}
 
@@ -12,4 +12,4 @@ You have been invited to join {{ customer_name }}.{% endblocktrans %}
 {% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}
 
 {% trans "Best regards," %}
-{% trans "The PragmaticHost Team" %}
+{% trans "The PRAHO Team" %}

--- a/services/platform/tests/api/test_customer_api.py
+++ b/services/platform/tests/api/test_customer_api.py
@@ -131,10 +131,12 @@ class CustomerUsersCreateAPITests(TestCase):
         self.customer = Customer.objects.create(name="Create Test Co", customer_type="company", status="active")
         CustomerMembership.objects.create(customer=self.customer, user=self.owner_user, role="owner")
 
+    @patch("apps.api.customers.views.SecureCustomerUserService._send_welcome_email_secure")
     @patch("apps.api.secure_auth.get_authenticated_customer")
-    def test_create_user_success(self, mock_auth):
+    def test_create_user_success(self, mock_auth, mock_send_email):
         """Owner can create a new user and add to customer."""
         mock_auth.return_value = (self.customer, None)
+        mock_send_email.return_value = True
         request = _make_request(self.factory, "/api/customers/users/create/", {
             "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
             "email": "newuser@example.com", "first_name": "New", "last_name": "User",
@@ -146,6 +148,24 @@ class CustomerUsersCreateAPITests(TestCase):
         new_user = User.objects.get(email="newuser@example.com")
         self.assertTrue(CustomerMembership.objects.filter(customer=self.customer, user=new_user).exists())
         self.assertFalse(new_user.has_usable_password())
+        mock_send_email.assert_called_once_with(new_user, self.customer)
+        self.assertTrue(response.data["invite_email_sent"])
+
+    @patch("apps.api.customers.views.SecureCustomerUserService._send_welcome_email_secure")
+    @patch("apps.api.secure_auth.get_authenticated_customer")
+    def test_create_user_invite_email_failure_still_succeeds(self, mock_auth, mock_send_email):
+        """User creation succeeds even if invite email fails."""
+        mock_auth.return_value = (self.customer, None)
+        mock_send_email.return_value = False
+        request = _make_request(self.factory, "/api/customers/users/create/", {
+            "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
+            "email": "noemail@example.com", "first_name": "No", "last_name": "Email",
+            "role": "viewer", "timestamp": int(time.time()),
+        })
+        response = customer_users_create(request)
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(User.objects.filter(email="noemail@example.com").exists())
+        self.assertFalse(response.data["invite_email_sent"])
 
     @patch("apps.api.secure_auth.get_authenticated_customer")
     def test_create_user_duplicate_email_returns_400(self, mock_auth):

--- a/services/platform/tests/api/test_customer_api.py
+++ b/services/platform/tests/api/test_customer_api.py
@@ -148,7 +148,10 @@ class CustomerUsersCreateAPITests(TestCase):
         new_user = User.objects.get(email="newuser@example.com")
         self.assertTrue(CustomerMembership.objects.filter(customer=self.customer, user=new_user).exists())
         self.assertFalse(new_user.has_usable_password())
-        mock_send_email.assert_called_once_with(new_user, self.customer)
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        self.assertEqual(call_args[0], (new_user, self.customer))
+        self.assertIn("request_ip", call_args[1])
         self.assertTrue(response.data["invite_email_sent"])
 
     @patch("apps.api.customers.views.SecureCustomerUserService._send_welcome_email_secure")

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -91,6 +91,62 @@ class UserManagementStaffRequiredTests(TestCase):
             self.assertEqual(response.status_code, 200)
 
 
+class CustomerCreateUserInviteEmailTests(TestCase):
+    """Verify invite email is sent when staff creates a new user."""
+
+    def setUp(self):
+        self.staff_user = User.objects.create_user(
+            email="staff@example.com",
+            password="staffpass123",
+            is_staff=True,
+            staff_role="admin",
+        )
+        self.customer = Customer.objects.create(
+            name="Test Customer",
+            company_name="Test Co",
+            primary_email="test@co.com",
+            customer_type="company",
+        )
+        self.client = Client()
+        self.url = reverse("customers:create_user", kwargs={"customer_id": self.customer.id})
+
+    @patch("apps.customers.user_management_views.SecureCustomerUserService._send_welcome_email_secure")
+    def test_create_user_sends_invite_email(self, mock_send_email):
+        """Creating a new user should trigger an invite email."""
+        mock_send_email.return_value = True
+        self.client.force_login(self.staff_user)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            response = self.client.post(self.url, {
+                "email": "invited@example.com",
+                "first_name": "Invited",
+                "last_name": "User",
+                "role": "viewer",
+            })
+            self.assertEqual(response.status_code, 302)
+            self.assertTrue(User.objects.filter(email="invited@example.com").exists())
+            new_user = User.objects.get(email="invited@example.com")
+            mock_send_email.assert_called_once_with(new_user, self.customer)
+
+    @patch("apps.customers.user_management_views.SecureCustomerUserService._send_welcome_email_secure")
+    def test_create_user_warns_on_email_failure(self, mock_send_email):
+        """User is still created when invite email fails, with a warning message."""
+        mock_send_email.return_value = False
+        self.client.force_login(self.staff_user)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            response = self.client.post(self.url, {
+                "email": "noemail@example.com",
+                "first_name": "No",
+                "last_name": "Email",
+                "role": "viewer",
+            }, follow=True)
+            self.assertTrue(User.objects.filter(email="noemail@example.com").exists())
+            messages_list = list(response.context["messages"])
+            warning_messages = [m for m in messages_list if m.level_tag == "warning"]
+            self.assertTrue(len(warning_messages) >= 1)
+
+
 class CustomerDeleteConfirmationTests(TestCase):
     """Verify server-side delete confirmation (confirm_name must match)."""
 

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -126,7 +126,10 @@ class CustomerCreateUserInviteEmailTests(TestCase):
             self.assertEqual(response.status_code, 302)
             self.assertTrue(User.objects.filter(email="invited@example.com").exists())
             new_user = User.objects.get(email="invited@example.com")
-            mock_send_email.assert_called_once_with(new_user, self.customer)
+            mock_send_email.assert_called_once()
+            call_args = mock_send_email.call_args
+            self.assertEqual(call_args[0], (new_user, self.customer))
+            self.assertIn("request_ip", call_args[1])
 
     @patch("apps.customers.user_management_views.SecureCustomerUserService._send_welcome_email_secure")
     def test_create_user_warns_on_email_failure(self, mock_send_email):


### PR DESCRIPTION
## Summary

- New users created via Portal invite or staff "Create User" were left with unusable passwords and **no email sent** — permanently locked out
- Both `customer_users_create` (API) and `customer_create_user` (staff view) now call the existing `_send_welcome_email_secure()` to send a password-reset invite
- Email failure is non-blocking: user is still created, staff gets a warning, API response includes `invite_email_sent: false`
- Added bilingual (RO/EN) welcome email templates (`customers/emails/welcome_email.html` + `.txt`)

Closes #145

## Test plan

- [x] `test_create_user_success` — verifies invite email is called and `invite_email_sent: true` in response
- [x] `test_create_user_invite_email_failure_still_succeeds` — user created even if email fails
- [x] `test_create_user_sends_invite_email` — staff view triggers email
- [x] `test_create_user_warns_on_email_failure` — staff view shows warning on failure
- [x] Full lint suite (7 phases) passing
- [x] MyPy clean (468 source files)
- [x] All pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)