### PR TITLE
fix(users,tickets): staff role classification — is_staff_user, validation, data migration (#150)

### DIFF
--- a/services/platform/apps/common/management/commands/generate_sample_data.py
+++ b/services/platform/apps/common/management/commands/generate_sample_data.py
@@ -708,7 +708,7 @@ class Command(BaseCommand):
                 "last_name": fake.last_name(),
                 "email": f"user{i + 1}@example.com",  # Use unique predictable emails
                 "is_active": True,
-                "staff_role": "customer",
+                "staff_role": "",
             }
 
             user = User.objects.create_user(password="testpass123", **user_data)
@@ -744,7 +744,7 @@ class Command(BaseCommand):
                 email=test_user_email,
                 password="testpass123",
                 is_active=True,
-                staff_role="customer",
+                staff_role="",
             )
             users.append(test_user)
             self.stdout.write(f"  ✓ Created test user: {test_user_email}")
@@ -1140,7 +1140,7 @@ class Command(BaseCommand):
                 "first_name": "Maria",
                 "last_name": "Ionescu",
                 "is_active": True,
-                "staff_role": "customer",
+                "staff_role": "",
             },
         )
         # Intentional: reset password on re-runs for idempotent fixture state
@@ -1154,7 +1154,7 @@ class Command(BaseCommand):
                 "first_name": "Andrei",
                 "last_name": "Popa",
                 "is_active": False,
-                "staff_role": "customer",
+                "staff_role": "",
             },
         )
         suspended_user.is_active = False

--- a/services/platform/apps/customers/customer_views.py
+++ b/services/platform/apps/customers/customer_views.py
@@ -325,7 +325,7 @@ def customer_detail(request: HttpRequest, customer_id: int) -> HttpResponse:
         "is_last_owner": owner_count <= 1,
         # Navigation and access
         "breadcrumb_items": breadcrumb_items,
-        "is_staff_user": user.is_staff or bool(user.staff_role),
+        "is_staff_user": user.is_staff_user,
     }
 
     return render(request, "customers/detail.html", context)

--- a/services/platform/apps/tickets/models.py
+++ b/services/platform/apps/tickets/models.py
@@ -122,7 +122,7 @@ class Ticket(models.Model):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        limit_choices_to={"staff_role__in": ["support", "admin", "manager"]},
+        limit_choices_to=models.Q(staff_role__in=["support", "admin", "manager"]) | models.Q(is_superuser=True),
         related_name="assigned_tickets",
         verbose_name=_("Assigned To"),
     )

--- a/services/platform/apps/tickets/views.py
+++ b/services/platform/apps/tickets/views.py
@@ -247,7 +247,7 @@ def _validate_internal_note_permission(
     request: HttpRequest, user: User, is_internal: bool, ticket_pk: int
 ) -> HttpResponse | None:
     """Validate user permission to create internal notes."""
-    if is_internal and not (user.is_staff or getattr(user, "staff_role", None)):
+    if is_internal and not user.is_staff_user:
         messages.error(request, _("❌ You do not have permission to create internal notes."))
         return redirect("tickets:detail", pk=ticket_pk)
     return None
@@ -255,9 +255,9 @@ def _validate_internal_note_permission(
 
 def _determine_comment_type(user: User, is_internal: bool) -> str:
     """Determine the appropriate comment type based on user permissions."""
-    if is_internal and (user.is_staff or getattr(user, "staff_role", None)):
+    if is_internal and user.is_staff_user:
         return "internal"
-    elif user.staff_role in ["support", "admin", "manager"]:
+    elif user.is_staff_user:
         return "support"
     else:
         return "customer"
@@ -426,7 +426,7 @@ def _handle_ticket_reply_post(request: HttpRequest, ticket: Ticket) -> HttpRespo
 
     # Create comment with reply action
     comment_type = _determine_comment_type(user, reply_data.is_internal)
-    is_public = not (reply_data.is_internal and (user.is_staff or getattr(user, "staff_role", None)))
+    is_public = not (reply_data.is_internal and user.is_staff_user)
 
     logger.debug(
         f"🔍 [Tickets] Reply processing: action={reply_data.reply_action}, is_internal={reply_data.is_internal}, comment_type={comment_type}, is_public={is_public}"
@@ -609,7 +609,7 @@ def download_attachment(request: HttpRequest, attachment_id: int) -> HttpRespons
         attachment.comment
         and hasattr(attachment.comment, "comment_type")
         and attachment.comment.comment_type == "internal"
-        and not user.is_staff
+        and not user.is_staff_user
     ):
         raise PermissionDenied("Access denied to internal attachments.")
 

--- a/services/platform/apps/users/migrations/0002_fix_staff_role_data.py
+++ b/services/platform/apps/users/migrations/0002_fix_staff_role_data.py
@@ -1,0 +1,40 @@
+"""Data migration: clean up invalid staff_role values.
+
+- Sets staff_role="" where staff_role="customer" (invalid value that caused security hole)
+- Sets staff_role="admin" on superusers with empty staff_role (ensures is_staff_user consistency)
+"""
+
+from django.db import migrations
+
+
+def fix_staff_role_data(apps, schema_editor):
+    User = apps.get_model("users", "User")
+
+    # Fix customers incorrectly marked with staff_role="customer"
+    updated_customers = User.objects.filter(staff_role="customer").update(staff_role="")
+
+    # Fix superusers with empty staff_role
+    updated_superusers = User.objects.filter(
+        is_superuser=True, staff_role=""
+    ).update(staff_role="admin")
+
+    if updated_customers or updated_superusers:
+        print(
+            f"\n  Fixed staff_role: {updated_customers} customer(s) cleared, "
+            f"{updated_superusers} superuser(s) set to 'admin'"
+        )
+
+
+def reverse_fix(apps, schema_editor):
+    # No safe reverse — clearing "customer" role is intentionally not reversible
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_staff_role_data, reverse_fix),
+    ]

--- a/services/platform/apps/users/models.py
+++ b/services/platform/apps/users/models.py
@@ -40,6 +40,13 @@ class UserManager(BaseUserManager["User"]):
         # Ensure safe defaults for nullable-but-not-null-constrained fields
         if "staff_role" not in extra_fields or extra_fields.get("staff_role") is None:
             extra_fields["staff_role"] = ""
+        # Reject invalid staff_role values (e.g. "customer")
+        staff_role = extra_fields.get("staff_role", "")
+        valid_roles = {role for role, _ in User.STAFF_ROLE_CHOICES}
+        if staff_role and staff_role not in valid_roles:
+            raise ValueError(
+                f"Invalid staff_role '{staff_role}'. Must be one of: {', '.join(sorted(valid_roles))} or empty."
+            )
         user = self.model(email=email, **extra_fields)
         # SECURITY: validation done at form/serializer level per Django convention
         user.set_password(  # nosemgrep: unvalidated-password
@@ -52,6 +59,7 @@ class UserManager(BaseUserManager["User"]):
         """Create and return a superuser with email and password"""
         extra_fields.setdefault("is_staff", True)
         extra_fields.setdefault("is_superuser", True)
+        extra_fields.setdefault("staff_role", "admin")
 
         if extra_fields.get("is_staff") is not True:
             raise ValueError("Superuser must have is_staff=True.")
@@ -147,10 +155,12 @@ class User(AbstractUser):
         full_name = super().get_full_name()
         return full_name if full_name.strip() else self.email
 
+    VALID_STAFF_ROLES: ClassVar[frozenset[str]] = frozenset(role for role, _ in STAFF_ROLE_CHOICES)
+
     @property
     def is_staff_user(self) -> bool:
-        """Check if user is internal staff"""
-        return bool(self.staff_role)
+        """Check if user is internal staff (by role, Django flag, or superuser status)"""
+        return bool(self.staff_role) or self.is_staff or self.is_superuser
 
     @property
     def is_customer_user(self) -> bool:

--- a/services/platform/apps/users/views.py
+++ b/services/platform/apps/users/views.py
@@ -91,9 +91,7 @@ def _handle_account_lockout(
 def _handle_successful_login(request: HttpRequest, user: User, form: LoginForm) -> HttpResponse:
     """Handle successful login logic - staff only on platform"""
     # Check if user is staff - customers must use portal
-    is_staff_user = user.is_staff or getattr(user, "staff_role", None)
-
-    if not is_staff_user:
+    if not user.is_staff_user:
         # Log the rejected customer login attempt
         UserLoginLog.objects.create(
             user=user,

--- a/services/platform/tests/users/test_staff_role_classification.py
+++ b/services/platform/tests/users/test_staff_role_classification.py
@@ -1,0 +1,153 @@
+"""
+Tests for staff role classification fixes (#150).
+
+Covers:
+- is_staff_user property for all user types
+- create_superuser defaults staff_role="admin"
+- create_user rejects invalid staff_role values
+- _determine_comment_type for superusers
+- _validate_internal_note_permission for superusers
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.backends.db import SessionStore
+from django.test import RequestFactory, TestCase, override_settings
+
+from apps.tickets.views import _determine_comment_type, _validate_internal_note_permission
+
+User = get_user_model()
+
+
+@override_settings(DISABLE_AUDIT_SIGNALS=True)
+class IsStaffUserPropertyTests(TestCase):
+    """Test the is_staff_user property correctly identifies all staff types."""
+
+    def test_user_with_staff_role_is_staff_user(self):
+        user = User.objects.create_user(email="support@test.com", password="test123", staff_role="support")
+        self.assertTrue(user.is_staff_user)
+
+    def test_user_with_admin_role_is_staff_user(self):
+        user = User.objects.create_user(email="admin@test.com", password="test123", staff_role="admin")
+        self.assertTrue(user.is_staff_user)
+
+    def test_superuser_with_empty_role_is_staff_user(self):
+        """Superusers must be recognized as staff even without a staff_role."""
+        user = User.objects.create_user(
+            email="super@test.com", password="test123", is_superuser=True, is_staff=True
+        )
+        # Override the default staff_role="admin" that create_superuser sets —
+        # test the property directly with empty role
+        user.staff_role = ""
+        user.save()
+        self.assertTrue(user.is_staff_user)
+
+    def test_django_is_staff_flag_makes_staff_user(self):
+        """Users with is_staff=True but no staff_role should still be staff."""
+        user = User.objects.create_user(email="djstaff@test.com", password="test123")
+        user.is_staff = True
+        user.save()
+        self.assertTrue(user.is_staff_user)
+
+    def test_customer_user_is_not_staff_user(self):
+        user = User.objects.create_user(email="customer@test.com", password="test123")
+        self.assertFalse(user.is_staff_user)
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+        self.assertEqual(user.staff_role, "")
+
+
+@override_settings(DISABLE_AUDIT_SIGNALS=True)
+class CreateSuperuserTests(TestCase):
+    """Test create_superuser defaults and behavior."""
+
+    def test_create_superuser_defaults_staff_role_admin(self):
+        user = User.objects.create_superuser(email="super@test.com", password="test123")
+        self.assertEqual(user.staff_role, "admin")
+        self.assertTrue(user.is_staff)
+        self.assertTrue(user.is_superuser)
+        self.assertTrue(user.is_staff_user)
+
+    def test_create_superuser_respects_explicit_staff_role(self):
+        user = User.objects.create_superuser(
+            email="super2@test.com", password="test123", staff_role="manager"
+        )
+        self.assertEqual(user.staff_role, "manager")
+
+
+@override_settings(DISABLE_AUDIT_SIGNALS=True)
+class CreateUserValidationTests(TestCase):
+    """Test create_user rejects invalid staff_role values."""
+
+    def test_reject_staff_role_customer(self):
+        with self.assertRaises(ValueError) as ctx:
+            User.objects.create_user(
+                email="bad@test.com", password="test123", staff_role="customer"
+            )
+        self.assertIn("Invalid staff_role", str(ctx.exception))
+        self.assertIn("customer", str(ctx.exception))
+
+    def test_reject_arbitrary_staff_role(self):
+        with self.assertRaises(ValueError):
+            User.objects.create_user(
+                email="bad2@test.com", password="test123", staff_role="hacker"
+            )
+
+    def test_accept_valid_staff_roles(self):
+        for role in ("admin", "support", "billing", "manager"):
+            user = User.objects.create_user(
+                email=f"{role}@test.com", password="test123", staff_role=role
+            )
+            self.assertEqual(user.staff_role, role)
+
+    def test_accept_empty_staff_role(self):
+        user = User.objects.create_user(email="empty@test.com", password="test123", staff_role="")
+        self.assertEqual(user.staff_role, "")
+
+    def test_accept_none_staff_role_defaults_to_empty(self):
+        user = User.objects.create_user(email="none@test.com", password="test123")
+        self.assertEqual(user.staff_role, "")
+
+
+@override_settings(DISABLE_AUDIT_SIGNALS=True)
+class DetermineCommentTypeTests(TestCase):
+    """Test _determine_comment_type handles superusers correctly."""
+
+    def test_superuser_gets_support_comment_type(self):
+        user = User.objects.create_superuser(email="super@test.com", password="test123")
+        self.assertEqual(_determine_comment_type(user, is_internal=False), "support")
+
+    def test_superuser_gets_internal_comment_type(self):
+        user = User.objects.create_superuser(email="super@test.com", password="test123")
+        self.assertEqual(_determine_comment_type(user, is_internal=True), "internal")
+
+    def test_customer_gets_customer_comment_type(self):
+        user = User.objects.create_user(email="cust@test.com", password="test123")
+        self.assertEqual(_determine_comment_type(user, is_internal=False), "customer")
+
+    def test_support_agent_gets_support_comment_type(self):
+        user = User.objects.create_user(email="agent@test.com", password="test123", staff_role="support")
+        self.assertEqual(_determine_comment_type(user, is_internal=False), "support")
+
+
+@override_settings(DISABLE_AUDIT_SIGNALS=True)
+class ValidateInternalNotePermissionTests(TestCase):
+    """Test _validate_internal_note_permission allows superusers."""
+
+    def test_superuser_can_create_internal_notes(self):
+        user = User.objects.create_superuser(email="super@test.com", password="test123")
+        request = RequestFactory().post("/")
+        request.user = user
+        result = _validate_internal_note_permission(request, user, is_internal=True, ticket_pk=1)
+        self.assertIsNone(result)
+
+    def test_customer_cannot_create_internal_notes(self):
+        user = User.objects.create_user(email="cust@test.com", password="test123")
+        request = RequestFactory().post("/")
+        request.user = user
+        request.session = SessionStore()
+        request._messages = FallbackStorage(request)
+        result = _validate_internal_note_permission(request, user, is_internal=True, ticket_pk=1)
+        self.assertIsNotNone(result)


### PR DESCRIPTION
## Summary

- **Security fix**: `is_staff_user` only checked `bool(self.staff_role)` — superusers with `staff_role=""` were misclassified as customers, and sample data created customers with `staff_role="customer"` (invalid value) granting them staff access to internal notes, ticket closure, and agent assignment
- **Fix**: `is_staff_user` now checks `bool(self.staff_role) or self.is_staff or self.is_superuser`; `create_user()` validates `staff_role` against `STAFF_ROLE_CHOICES`; all ad-hoc staff checks normalized to use the property
- **Data migration**: clears `staff_role="customer"` → `""`, sets superusers with empty role to `"admin"`

### Files changed (8)

| File | Change |
|------|--------|
| `apps/users/models.py` | Fix `is_staff_user`, add `VALID_STAFF_ROLES`, default `staff_role="admin"` in `create_superuser`, validate in `create_user` |
| `apps/tickets/views.py` | `_determine_comment_type`, `_validate_internal_note_permission`, `is_public`, attachment access → `user.is_staff_user` |
| `apps/tickets/models.py` | `assigned_to.limit_choices_to` includes `Q(is_superuser=True)` |
| `apps/users/views.py` | Normalize ad-hoc `is_staff or staff_role` → `user.is_staff_user` |
| `apps/customers/customer_views.py` | Normalize ad-hoc `is_staff or bool(staff_role)` → `user.is_staff_user` |
| `apps/common/.../generate_sample_data.py` | `staff_role="customer"` → `""` (4 occurrences) |
| `apps/users/migrations/0002_fix_staff_role_data.py` | Data migration |
| `tests/users/test_staff_role_classification.py` | 18 regression tests |

## Test plan

- [x] `pytest tests/users/test_staff_role_classification.py` — 18 tests pass
- [x] `make lint` on all modified files — clean
- [x] All pre-commit hooks pass
- [x] Pre-existing test failures confirmed on master (9 ticket tests — unrelated)
- [x] Signed-off-by present (DCO)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)