### PR TITLE
fix(notifications): atomicity, audit trail, and TOCTOU fixes for consent ops (#94)

### DIFF
--- a/services/platform/apps/notifications/models.py
+++ b/services/platform/apps/notifications/models.py
@@ -909,15 +909,18 @@ class EmailPreference(models.Model):
         return category_map.get(category, True)
 
     def update_marketing_consent(self, consent: bool, source: str = "") -> None:
-        """Update marketing consent with GDPR tracking."""
-        self.marketing = consent
-        if consent:
-            self.marketing_consent_date = timezone.now()
-            self.marketing_consent_source = source
-        else:
-            # Don't clear the date - keep for audit trail
-            pass
-        self.save(update_fields=["marketing", "marketing_consent_date", "marketing_consent_source", "updated_at"])
+        """Update marketing consent with GDPR tracking and row-level locking."""
+        with transaction.atomic():
+            locked = EmailPreference.objects.select_for_update(of=("self",)).get(pk=self.pk)
+            locked.marketing = consent
+            if consent:
+                locked.marketing_consent_date = timezone.now()
+                locked.marketing_consent_source = source
+            locked.save(update_fields=["marketing", "marketing_consent_date", "marketing_consent_source", "updated_at"])
+            # Refresh self from locked instance
+            self.marketing = locked.marketing
+            self.marketing_consent_date = locked.marketing_consent_date
+            self.marketing_consent_source = locked.marketing_consent_source
 
 
 # ===============================================================================
@@ -959,7 +962,11 @@ class UnsubscribeToken(models.Model):
         return timezone.now() > self.created_at + timedelta(days=TOKEN_EXPIRY_DAYS)
 
     def consume(self) -> bool:
-        """Mark token as consumed. Returns False if already used or expired."""
+        """Mark token as consumed. Returns False if already used or expired.
+
+        Caller must hold a select_for_update() lock on this row (or be inside
+        an atomic block that does) to prevent TOCTOU races.
+        """
         if self.used_at is not None:
             return False
         if self.is_expired():

--- a/services/platform/apps/notifications/services.py
+++ b/services/platform/apps/notifications/services.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.db import transaction
 from django.template import Context, Template
 from django.utils import timezone
 from django.utils.html import strip_tags
@@ -1383,21 +1384,30 @@ class EmailPreferenceService:
 
     @staticmethod
     def update_preferences(customer: Customer, preferences: dict[str, bool]) -> None:
-        """Update email preferences for a customer."""
-        if "marketing" in preferences:
-            customer.marketing_consent = preferences["marketing"]
-        if "newsletters" in preferences:
-            customer.marketing_consent = preferences["newsletters"]
-        customer.save(update_fields=["marketing_consent"])
+        """Update email preferences for a customer with atomic consent tracking."""
+        from apps.audit.services import AuditService  # noqa: PLC0415
+        from apps.customers.models import Customer as CustomerModel  # noqa: PLC0415
 
-        # Log the preference change
-        validators.log_security_event(
-            "email_preferences_updated",
-            {
-                "customer_id": str(customer.id),
-                "preferences": preferences,
-            },
-        )
+        with transaction.atomic():
+            locked = CustomerModel.objects.select_for_update(of=("self",)).get(id=customer.id)
+            old_marketing = locked.marketing_consent
+
+            if "marketing" in preferences:
+                locked.marketing_consent = preferences["marketing"]
+            if "newsletters" in preferences:
+                locked.marketing_consent = preferences["newsletters"]
+
+            locked.save(update_fields=["marketing_consent"])
+
+            if old_marketing != locked.marketing_consent:
+                AuditService.log_simple_event(
+                    "marketing_consent_granted" if locked.marketing_consent else "marketing_consent_withdrawn",
+                    content_object=locked,
+                    description=f"Email preferences updated for customer {locked.id}",
+                    old_values={"marketing_consent": old_marketing},
+                    new_values={"marketing_consent": locked.marketing_consent},
+                    metadata={"source": "preference_center"},
+                )
 
     @staticmethod
     def can_send_category(customer: Customer, category: str) -> bool:
@@ -1418,6 +1428,10 @@ class EmailPreferenceService:
         """
         Process an unsubscribe request using opaque DB token.
 
+        Token consumption and customer consent withdrawal are wrapped in a
+        single atomic block to prevent partial state (token consumed but
+        consent not withdrawn, or vice-versa).
+
         Args:
             token_id: UUID of the UnsubscribeToken
             category: Optional specific category to unsubscribe from
@@ -1425,44 +1439,50 @@ class EmailPreferenceService:
         Returns:
             True if unsubscribe was successful
         """
+        from apps.audit.services import AuditService  # noqa: PLC0415
         from apps.customers.models import (  # noqa: PLC0415  # Deferred: avoids circular import
             Customer,  # Circular: cross-app  # Deferred: avoids circular import
         )
         from apps.notifications.models import UnsubscribeToken  # noqa: PLC0415
 
         try:
-            token_obj = UnsubscribeToken.objects.get(id=token_id)
-        except (UnsubscribeToken.DoesNotExist, Exception):
-            logger.warning("⚠️ [Unsubscribe] Invalid or unknown token")
+            with transaction.atomic():
+                try:
+                    token_obj = UnsubscribeToken.objects.select_for_update().get(id=token_id)
+                except (UnsubscribeToken.DoesNotExist, Exception):
+                    logger.warning("⚠️ [Unsubscribe] Invalid or unknown token")
+                    return False
+
+                if not token_obj.consume():
+                    logger.warning("⚠️ [Unsubscribe] Token already used or expired")
+                    return False
+
+                email = token_obj.email
+
+                try:
+                    customer = Customer.objects.select_for_update(of=("self",)).get(primary_email=email)
+                except Customer.DoesNotExist:
+                    EmailSuppressionService.suppress_email(email, "unsubscribe")
+                    return True
+
+                old_marketing = customer.marketing_consent
+                if category == "marketing" or category is None:
+                    customer.marketing_consent = False
+                customer.save(update_fields=["marketing_consent"])
+
+                if old_marketing != customer.marketing_consent:
+                    AuditService.log_simple_event(
+                        "marketing_consent_withdrawn",
+                        content_object=customer,
+                        description=f"Unsubscribe via token for {email[:3]}***",
+                        old_values={"marketing_consent": old_marketing},
+                        new_values={"marketing_consent": False},
+                        metadata={"source": "unsubscribe_link", "category": category or "all_marketing"},
+                    )
+
+                logger.info(f"✅ [Unsubscribe] Processed for {email[:3]}***")
+                return True
+
+        except Exception:
+            logger.exception("🔥 [Unsubscribe] Failed to process token %s", token_id)
             return False
-
-        if not token_obj.consume():
-            logger.warning("⚠️ [Unsubscribe] Token already used or expired")
-            return False
-
-        email = token_obj.email
-
-        # Find customer
-        try:
-            customer = Customer.objects.get(primary_email=email)
-
-            if category == "marketing" or category is None:
-                customer.marketing_consent = False
-            customer.save(update_fields=["marketing_consent"])
-
-            # Log the unsubscribe
-            validators.log_security_event(
-                "email_unsubscribe",
-                {
-                    "customer_id": str(customer.id),
-                    "category": category or "all_marketing",
-                },
-            )
-
-            logger.info(f"✅ [Unsubscribe] Processed for {email[:3]}***")
-            return True
-
-        except Customer.DoesNotExist:
-            # Suppress the email address anyway
-            EmailSuppressionService.suppress_email(email, "unsubscribe")
-            return True

--- a/services/platform/apps/notifications/services.py
+++ b/services/platform/apps/notifications/services.py
@@ -1392,22 +1392,34 @@ class EmailPreferenceService:
             locked = CustomerModel.objects.select_for_update(of=("self",)).get(id=customer.id)
             old_marketing = locked.marketing_consent
 
+            # "marketing" is the canonical key; "newsletters" is accepted as an alias.
+            # If both are present, "marketing" wins so an explicit opt-out cannot be
+            # silently reversed by a concurrently-sent "newsletters": True.
             if "marketing" in preferences:
                 locked.marketing_consent = preferences["marketing"]
-            if "newsletters" in preferences:
+            elif "newsletters" in preferences:
                 locked.marketing_consent = preferences["newsletters"]
 
             locked.save(update_fields=["marketing_consent"])
 
             if old_marketing != locked.marketing_consent:
-                AuditService.log_simple_event(
-                    "marketing_consent_granted" if locked.marketing_consent else "marketing_consent_withdrawn",
-                    content_object=locked,
-                    description=f"Email preferences updated for customer {locked.id}",
-                    old_values={"marketing_consent": old_marketing},
-                    new_values={"marketing_consent": locked.marketing_consent},
-                    metadata={"source": "preference_center"},
-                )
+                # Audit is best-effort — never block a GDPR consent change (Art. 7(3))
+                # because of an audit-table failure. Savepoint isolates audit DB writes
+                # so a failure here does not mark the outer transaction for rollback.
+                try:
+                    with transaction.atomic():
+                        AuditService.log_simple_event(
+                            "marketing_consent_granted" if locked.marketing_consent else "marketing_consent_withdrawn",
+                            content_object=locked,
+                            description=f"Email preferences updated for customer {locked.id}",
+                            old_values={"marketing_consent": old_marketing},
+                            new_values={"marketing_consent": locked.marketing_consent},
+                            metadata={"source": "preference_center"},
+                        )
+                except Exception:
+                    logger.exception(
+                        "🔥 [Consent] Audit logging failed for marketing_consent change on customer %s", locked.id
+                    )
 
     @staticmethod
     def can_send_category(customer: Customer, category: str) -> bool:
@@ -1448,8 +1460,11 @@ class EmailPreferenceService:
         try:
             with transaction.atomic():
                 try:
-                    token_obj = UnsubscribeToken.objects.select_for_update().get(id=token_id)
-                except (UnsubscribeToken.DoesNotExist, Exception):
+                    token_obj = UnsubscribeToken.objects.select_for_update(of=("self",)).get(id=token_id)
+                except (UnsubscribeToken.DoesNotExist, ValueError):
+                    # DoesNotExist: unknown token. ValueError: malformed UUID.
+                    # Transient DB errors (OperationalError, lock timeouts) propagate
+                    # to the outer handler instead of being silently reported as invalid.
                     logger.warning("⚠️ [Unsubscribe] Invalid or unknown token")
                     return False
 
@@ -1471,14 +1486,20 @@ class EmailPreferenceService:
                 customer.save(update_fields=["marketing_consent"])
 
                 if old_marketing != customer.marketing_consent:
-                    AuditService.log_simple_event(
-                        "marketing_consent_withdrawn",
-                        content_object=customer,
-                        description=f"Unsubscribe via token for {email[:3]}***",
-                        old_values={"marketing_consent": old_marketing},
-                        new_values={"marketing_consent": False},
-                        metadata={"source": "unsubscribe_link", "category": category or "all_marketing"},
-                    )
+                    # Audit is best-effort — never block a GDPR consent withdrawal
+                    # (Art. 7(3)) because of an audit-table failure.
+                    try:
+                        with transaction.atomic():
+                            AuditService.log_simple_event(
+                                "marketing_consent_withdrawn",
+                                content_object=customer,
+                                description=f"Unsubscribe via token for {email[:3]}***",
+                                old_values={"marketing_consent": old_marketing},
+                                new_values={"marketing_consent": False},
+                                metadata={"source": "unsubscribe_link", "category": category or "all_marketing"},
+                            )
+                    except Exception:
+                        logger.exception("🔥 [Unsubscribe] Audit logging failed for customer %s", customer.id)
 
                 logger.info(f"✅ [Unsubscribe] Processed for {email[:3]}***")
                 return True

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -5,7 +5,7 @@ Verifies GDPR Art. 5(1)(c) data minimization — no email addresses in URLs.
 """
 
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -165,17 +165,16 @@ class ProcessUnsubscribeTests(TestCase):
     """Tests for the updated process_unsubscribe using DB tokens."""
 
     def test_valid_token_processes_unsubscribe(self) -> None:
-        """Test valid token triggers unsubscribe flow."""
+        """Test valid token triggers unsubscribe flow when no customer exists."""
         token = UnsubscribeToken.objects.create(
             email="unsub@example.com",
             template_key="marketing",
         )
 
-        with patch("apps.customers.models.Customer.objects") as mock_mgr:
-            mock_mgr.get.side_effect = Customer.DoesNotExist()
-            with patch("apps.notifications.services.EmailSuppressionService.suppress_email"):
-                result = EmailPreferenceService.process_unsubscribe(str(token.id))
-                self.assertTrue(result)
+        with patch("apps.notifications.services.EmailSuppressionService.suppress_email") as mock_suppress:
+            result = EmailPreferenceService.process_unsubscribe(str(token.id))
+            self.assertTrue(result)
+            mock_suppress.assert_called_once_with("unsub@example.com", "unsubscribe")
 
         # Token should be consumed
         token.refresh_from_db()
@@ -211,21 +210,21 @@ class ProcessUnsubscribeTests(TestCase):
 
     def test_unsubscribe_with_customer(self) -> None:
         """Test unsubscribe when customer exists updates preferences."""
+        customer = Customer.objects.create(
+            name="Unsubscribe Customer",
+            customer_type="individual",
+            primary_email="customer@example.com",
+            marketing_consent=True,
+        )
         token = UnsubscribeToken.objects.create(
             email="customer@example.com",
             template_key="marketing",
         )
 
-        mock_customer = MagicMock()
-        mock_customer.id = uuid4()
-        mock_customer.marketing_consent = True
-
-        with patch("apps.customers.models.Customer.objects") as mock_mgr:
-            mock_mgr.get.return_value = mock_customer
-            with patch("apps.notifications.services.validators"):
-                result = EmailPreferenceService.process_unsubscribe(
-                    str(token.id), "marketing"
-                )
-                self.assertTrue(result)
-                self.assertFalse(mock_customer.marketing_consent)
-                mock_customer.save.assert_called_once()
+        with patch("apps.audit.services.AuditService.log_simple_event"):
+            result = EmailPreferenceService.process_unsubscribe(
+                str(token.id), "marketing"
+            )
+            self.assertTrue(result)
+            customer.refresh_from_db()
+            self.assertFalse(customer.marketing_consent)

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -209,7 +209,7 @@ class ProcessUnsubscribeTests(TestCase):
         self.assertFalse(result)
 
     def test_unsubscribe_with_customer(self) -> None:
-        """Test unsubscribe when customer exists updates preferences."""
+        """Unsubscribe via token withdraws consent and emits a correct GDPR audit event."""
         customer = Customer.objects.create(
             name="Unsubscribe Customer",
             customer_type="individual",
@@ -221,10 +221,111 @@ class ProcessUnsubscribeTests(TestCase):
             template_key="marketing",
         )
 
-        with patch("apps.audit.services.AuditService.log_simple_event"):
+        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
             result = EmailPreferenceService.process_unsubscribe(
                 str(token.id), "marketing"
             )
-            self.assertTrue(result)
-            customer.refresh_from_db()
-            self.assertFalse(customer.marketing_consent)
+
+        self.assertTrue(result)
+        customer.refresh_from_db()
+        self.assertFalse(customer.marketing_consent)
+
+        mock_audit.assert_called_once()
+        call_args = mock_audit.call_args
+        self.assertEqual(call_args.args[0], "marketing_consent_withdrawn")
+        self.assertEqual(call_args.kwargs["content_object"], customer)
+        self.assertEqual(call_args.kwargs["old_values"], {"marketing_consent": True})
+        self.assertEqual(call_args.kwargs["new_values"], {"marketing_consent": False})
+        self.assertEqual(call_args.kwargs["metadata"]["source"], "unsubscribe_link")
+        self.assertEqual(call_args.kwargs["metadata"]["category"], "marketing")
+
+    def test_unsubscribe_audit_failure_does_not_block_consent_withdrawal(self) -> None:
+        """GDPR Art. 7(3): audit errors must never block a consent withdrawal."""
+        customer = Customer.objects.create(
+            name="Resilient Customer",
+            customer_type="individual",
+            primary_email="resilient@example.com",
+            marketing_consent=True,
+        )
+        token = UnsubscribeToken.objects.create(
+            email="resilient@example.com",
+            template_key="marketing",
+        )
+
+        with patch(
+            "apps.audit.services.AuditService.log_simple_event",
+            side_effect=RuntimeError("audit table down"),
+        ):
+            result = EmailPreferenceService.process_unsubscribe(str(token.id), "marketing")
+
+        self.assertTrue(result)
+        customer.refresh_from_db()
+        self.assertFalse(customer.marketing_consent)
+
+
+class UpdatePreferencesTests(TestCase):
+    """Tests for EmailPreferenceService.update_preferences."""
+
+    def _make_customer(self, *, marketing: bool = False) -> Customer:
+        return Customer.objects.create(
+            name="Pref Customer",
+            customer_type="individual",
+            primary_email="prefs@example.com",
+            marketing_consent=marketing,
+        )
+
+    def test_update_preferences_persists_marketing_consent(self) -> None:
+        """Setting marketing=True persists and emits a granted audit event."""
+        customer = self._make_customer(marketing=False)
+
+        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+            EmailPreferenceService.update_preferences(customer, {"marketing": True})
+
+        customer.refresh_from_db()
+        self.assertTrue(customer.marketing_consent)
+        mock_audit.assert_called_once()
+        self.assertEqual(mock_audit.call_args.args[0], "marketing_consent_granted")
+        self.assertEqual(mock_audit.call_args.kwargs["old_values"], {"marketing_consent": False})
+        self.assertEqual(mock_audit.call_args.kwargs["new_values"], {"marketing_consent": True})
+
+    def test_update_preferences_no_audit_when_unchanged(self) -> None:
+        """If consent value is unchanged, no audit event is emitted."""
+        customer = self._make_customer(marketing=True)
+
+        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+            EmailPreferenceService.update_preferences(customer, {"marketing": True})
+
+        mock_audit.assert_not_called()
+
+    def test_marketing_key_wins_over_newsletters_alias(self) -> None:
+        """Explicit marketing=False cannot be silently reversed by newsletters=True."""
+        customer = self._make_customer(marketing=True)
+
+        EmailPreferenceService.update_preferences(
+            customer, {"marketing": False, "newsletters": True}
+        )
+
+        customer.refresh_from_db()
+        self.assertFalse(customer.marketing_consent)
+
+    def test_newsletters_alias_applies_when_marketing_absent(self) -> None:
+        """Legacy clients sending only 'newsletters' still update marketing_consent."""
+        customer = self._make_customer(marketing=False)
+
+        EmailPreferenceService.update_preferences(customer, {"newsletters": True})
+
+        customer.refresh_from_db()
+        self.assertTrue(customer.marketing_consent)
+
+    def test_update_preferences_audit_failure_does_not_block_consent_change(self) -> None:
+        """GDPR Art. 7(3): audit errors must never block a consent change."""
+        customer = self._make_customer(marketing=False)
+
+        with patch(
+            "apps.audit.services.AuditService.log_simple_event",
+            side_effect=RuntimeError("audit table down"),
+        ):
+            EmailPreferenceService.update_preferences(customer, {"marketing": True})
+
+        customer.refresh_from_db()
+        self.assertTrue(customer.marketing_consent)


### PR DESCRIPTION
## Summary

- Wrap `update_preferences()` in `transaction.atomic()` + `select_for_update()` to prevent concurrent write clobber
- Wrap `process_unsubscribe()` atomically — token consumption + customer consent withdrawal in a single transaction
- Add `select_for_update()` to `UnsubscribeToken` lookup in `process_unsubscribe()` to prevent TOCTOU race on `used_at`
- Add `select_for_update()` to `EmailPreference.update_marketing_consent()`
- Replace `validators.log_security_event()` (Python logger) with `AuditService.log_simple_event()` for immutable GDPR Article 7 consent proof in the `AuditEvent` table
- Update tests to use real DB objects instead of MagicMock (aligns with project testing standards)

Closes #94

## Test plan

- [x] All 157 notification/unsubscribe/preference tests pass
- [x] Ruff lint clean
- [x] All pre-commit hooks pass (DCO signed)
- [ ] CI: platform, portal, integration, DCO check workflows
- [ ] Manual: verify unsubscribe flow still works end-to-end

Generated with [Claude Code](https://claude.com/claude-code)