### PR TITLE
feat(domains): Phase 2 — transfers, nameservers, lock, info, bulk availability, domain-sync (#93)

### DIFF
--- a/scripts/audit_model_allowlist.txt
+++ b/scripts/audit_model_allowlist.txt
@@ -61,6 +61,7 @@ billing.ProformaLine            # child of ProformaInvoice
 billing.ProformaSequence        # internal counter (no business significance)
 billing.SubscriptionChange      # child of Subscription
 billing.SubscriptionItem        # child of Subscription
+domains.DomainOperation         # operational task tracking (audited via gateway _audit_api_call)
 domains.DomainOrderItem         # child of Order (audited via Order signal)
 orders.OrderItem                # child of Order
 provisioning.ServiceDomain      # child of Service

--- a/services/platform/apps/common/types.py
+++ b/services/platform/apps/common/types.py
@@ -86,9 +86,15 @@ class Ok[T]:
 
 @dataclass(frozen=True)
 class Err[E]:
-    """Error result containing an error value"""
+    """Error result containing an error value.
+
+    The ``retriable`` flag signals whether the operation that produced this
+    error might succeed on retry (e.g. transient DB timeout, lock contention).
+    Callers such as Django-Q tasks can use this to decide whether to re-queue.
+    """
 
     error: E
+    retriable: bool = False
 
     def is_ok(self) -> bool:
         return False

--- a/services/platform/apps/domains/gateways/__init__.py
+++ b/services/platform/apps/domains/gateways/__init__.py
@@ -1,0 +1,38 @@
+"""
+Domain Registrar Gateways — PRAHO Platform
+
+Abstract gateway interface + concrete implementations for domain registrar APIs.
+Follows the billing gateway pattern (ABC + factory + Result types).
+"""
+
+from .base import (
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import (
+    RegistrarAPIError,
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+
+__all__ = [
+    "BaseRegistrarGateway",
+    "DomainAvailabilityResult",
+    "DomainRegistrationResult",
+    "DomainRenewalResult",
+    "RegistrarAPIError",
+    "RegistrarAuthError",
+    "RegistrarConflictError",
+    "RegistrarErrorCode",
+    "RegistrarGatewayFactory",
+    "RegistrarNotFoundError",
+    "RegistrarRateLimitError",
+    "RegistrarTransientError",
+]

--- a/services/platform/apps/domains/gateways/__init__.py
+++ b/services/platform/apps/domains/gateways/__init__.py
@@ -8,8 +8,12 @@ Follows the billing gateway pattern (ABC + factory + Result types).
 from .base import (
     BaseRegistrarGateway,
     DomainAvailabilityResult,
+    DomainInfoResult,
+    DomainLockResult,
     DomainRegistrationResult,
     DomainRenewalResult,
+    DomainTransferResult,
+    NameserverUpdateResult,
     RegistrarGatewayFactory,
 )
 from .errors import (
@@ -25,8 +29,12 @@ from .errors import (
 __all__ = [
     "BaseRegistrarGateway",
     "DomainAvailabilityResult",
+    "DomainInfoResult",
+    "DomainLockResult",
     "DomainRegistrationResult",
     "DomainRenewalResult",
+    "DomainTransferResult",
+    "NameserverUpdateResult",
     "RegistrarAPIError",
     "RegistrarAuthError",
     "RegistrarConflictError",

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -1,0 +1,459 @@
+"""
+Abstract base class for domain registrar gateways.
+
+Follows the billing gateway ABC + factory pattern and cloud gateway Result[T, E] pattern.
+All registrar HTTP goes through safe_request() with a per-registrar OutboundPolicy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.core.cache import cache
+
+from apps.common.outbound_http import OutboundPolicy, safe_request
+from apps.common.types import Err, Ok, Result
+
+from .errors import (
+    RegistrarAPIError,
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+
+if TYPE_CHECKING:
+    import requests
+
+    from apps.domains.models import Registrar
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker defaults
+CIRCUIT_BREAKER_THRESHOLD = 5  # failures before tripping
+CIRCUIT_BREAKER_RESET_SECONDS = 300  # 5 minutes
+IDEMPOTENCY_TTL_SECONDS = 3600  # 1 hour
+
+# Retry defaults
+MAX_RETRIES = 3
+BACKOFF_BASE_SECONDS = 0.5
+
+# HTTP status codes used in error mapping
+HTTP_OK = 200
+HTTP_CREATED = 201
+HTTP_ACCEPTED = 202
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+HTTP_NOT_FOUND = 404
+HTTP_CONFLICT = 409
+HTTP_RATE_LIMITED = 429
+HTTP_SERVER_ERROR = 500
+
+
+# ===============================================================================
+# RESULT TYPES
+# ===============================================================================
+
+
+@dataclass(frozen=True)
+class DomainRegistrationResult:
+    """Successful domain registration response from a registrar."""
+
+    registrar_domain_id: str
+    expires_at: datetime
+    nameservers: list[str]
+    epp_code: str = ""
+
+
+@dataclass(frozen=True)
+class DomainRenewalResult:
+    """Successful domain renewal response from a registrar."""
+
+    new_expires_at: datetime
+
+
+@dataclass(frozen=True)
+class DomainAvailabilityResult:
+    """Domain availability check response from a registrar."""
+
+    domain_name: str
+    available: bool
+    premium: bool = False
+    price_cents: int | None = None
+
+
+# ===============================================================================
+# ABSTRACT BASE GATEWAY
+# ===============================================================================
+
+
+class BaseRegistrarGateway(ABC):
+    """Abstract base class for all domain registrar gateways.
+
+    Subclasses implement the four core operations against a specific registrar API.
+    The base class provides: circuit breaker, idempotency, retry with backoff,
+    SSRF-safe HTTP via OutboundPolicy, and audit logging.
+    """
+
+    def __init__(self, registrar: Registrar) -> None:
+        self.registrar = registrar
+        self.logger = logging.getLogger(f"apps.domains.gateways.{self.gateway_name}")
+
+    # -- Abstract interface --------------------------------------------------
+
+    @property
+    @abstractmethod
+    def gateway_name(self) -> str:
+        """Machine-readable gateway identifier (e.g. 'gandi', 'rotld')."""
+
+    @abstractmethod
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        """Return the OutboundPolicy for this registrar's API."""
+
+    @abstractmethod
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        """Registrar-specific registration logic."""
+
+    @abstractmethod
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        """Registrar-specific renewal logic."""
+
+    @abstractmethod
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        """Registrar-specific availability check."""
+
+    @abstractmethod
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        """Registrar-specific webhook signature verification."""
+
+    # -- Public interface (with circuit breaker + idempotency) ----------------
+
+    def register_domain(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None = None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        """Register a domain, with circuit breaker and idempotency protection."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        # Idempotency: prevent duplicate registrations
+        idempotency_key = f"domain_reg:{self.gateway_name}:{domain_name}"
+        cached = cache.get(idempotency_key)
+        if cached is not None:
+            self.logger.info("Idempotency hit for %s registration", domain_name)
+            return Ok(cached)
+
+        result = self._retry(
+            lambda: self._do_register(domain_name, years, registrant_data, nameservers),
+            operation=f"register:{domain_name}",
+        )
+
+        if result.is_ok():
+            cache.set(idempotency_key, result.unwrap(), IDEMPOTENCY_TTL_SECONDS)
+            self._record_success()
+            self.logger.info("Registered %s via %s", domain_name, self.gateway_name)
+            self._audit_api_call("domain_registration", domain_name, success=True)
+        else:
+            self._record_failure(result.unwrap_err())
+            self.logger.error("Failed to register %s: %s", domain_name, result.unwrap_err())
+            self._audit_api_call("domain_registration", domain_name, success=False, error=str(result.unwrap_err()))
+
+        return result
+
+    def renew_domain(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        """Renew a domain, with circuit breaker and idempotency protection."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        idempotency_key = f"domain_renew:{self.gateway_name}:{domain_name}:{years}"
+        cached = cache.get(idempotency_key)
+        if cached is not None:
+            self.logger.info("Idempotency hit for %s renewal", domain_name)
+            return Ok(cached)
+
+        result = self._retry(
+            lambda: self._do_renew(registrar_domain_id, domain_name, years),
+            operation=f"renew:{domain_name}",
+        )
+
+        if result.is_ok():
+            cache.set(idempotency_key, result.unwrap(), IDEMPOTENCY_TTL_SECONDS)
+            self._record_success()
+            self.logger.info("Renewed %s via %s", domain_name, self.gateway_name)
+            self._audit_api_call("domain_renewal", domain_name, success=True, metadata={"years": years})
+        else:
+            self._record_failure(result.unwrap_err())
+            self.logger.error("Failed to renew %s: %s", domain_name, result.unwrap_err())
+            self._audit_api_call("domain_renewal", domain_name, success=False, error=str(result.unwrap_err()))
+
+        return result
+
+    def check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        """Check domain availability (no idempotency needed, but respects circuit breaker)."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        result = self._retry(
+            lambda: self._do_check_availability(domain_name),
+            operation=f"check:{domain_name}",
+        )
+
+        if result.is_ok():
+            self._record_success()
+        else:
+            self._record_failure(result.unwrap_err())
+            self._audit_api_call(
+                "domain_availability_check", domain_name, success=False, error=str(result.unwrap_err())
+            )
+
+        return result
+
+    def verify_webhook_signature(self, payload: str, signature: str) -> bool:
+        """Verify webhook signature. Fail-closed: returns False on any error."""
+        if not signature:
+            return False
+
+        try:
+            secret = self.registrar.get_decrypted_webhook_secret()
+        except Exception:
+            self.logger.error("Webhook secret decryption failed for %s", self.registrar.name)
+            return False
+
+        if not secret or not secret.strip():
+            self.logger.error("Webhook secret for %s is empty", self.registrar.name)
+            return False
+
+        return self._do_verify_webhook(payload, signature, secret.strip())
+
+    # -- HTTP helper for subclasses ------------------------------------------
+
+    def _api_request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Make an API request using safe_request() with this gateway's OutboundPolicy.
+
+        Raises requests.RequestException on transport errors.
+        """
+        return safe_request(method, url, policy=self._get_outbound_policy(), **kwargs)
+
+    # -- Audit logging -------------------------------------------------------
+
+    def _audit_api_call(
+        self,
+        event_type: str,
+        domain_name: str,
+        *,
+        success: bool,
+        error: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Log an audit event for a registrar API call."""
+        try:
+            from apps.audit.services import AuditService  # noqa: PLC0415
+
+            audit_metadata: dict[str, Any] = {
+                "registrar": self.registrar.name,
+                "gateway": self.gateway_name,
+                "domain_name": domain_name,
+                "success": success,
+            }
+            if error:
+                audit_metadata["error"] = error[:500]
+            if metadata:
+                audit_metadata.update(metadata)
+
+            AuditService.log_simple_event(
+                f"registrar_api_{event_type}",
+                description=f"{'OK' if success else 'FAIL'}: {event_type} for {domain_name} via {self.gateway_name}",
+                metadata=audit_metadata,
+                actor_type="system",
+            )
+        except Exception:
+            self.logger.warning("Audit logging failed for %s:%s", event_type, domain_name, exc_info=True)
+
+    # -- Circuit breaker (Django cache-backed) -------------------------------
+
+    def _circuit_breaker_key(self) -> str:
+        return f"cb:{self.gateway_name}:failures"
+
+    def _check_circuit_breaker(self) -> Err[RegistrarAPIError] | None:
+        failures = cache.get(self._circuit_breaker_key(), 0)
+        if failures >= CIRCUIT_BREAKER_THRESHOLD:
+            self.logger.warning("Circuit breaker OPEN for %s (%d failures)", self.gateway_name, failures)
+            return Err(
+                RegistrarTransientError(
+                    self.registrar.name,
+                    f"Circuit breaker open for {self.gateway_name} ({failures} consecutive failures)",
+                ),
+                retriable=True,
+            )
+        return None
+
+    def _record_failure(self, error: RegistrarAPIError) -> None:
+        key = self._circuit_breaker_key()
+        try:
+            cache.incr(key)
+        except ValueError:
+            cache.set(key, 1, CIRCUIT_BREAKER_RESET_SECONDS)
+        else:
+            cache.touch(key, CIRCUIT_BREAKER_RESET_SECONDS)
+
+    def _record_success(self) -> None:
+        cache.delete(self._circuit_breaker_key())
+
+    # -- Retry with exponential backoff --------------------------------------
+
+    def _retry(
+        self,
+        fn: Any,
+        operation: str,
+        max_retries: int = MAX_RETRIES,
+    ) -> Result[Any, RegistrarAPIError]:
+        last_result: Result[Any, RegistrarAPIError] = Err(
+            RegistrarAPIError("No attempts made", code=RegistrarErrorCode.INTERNAL_ERROR)
+        )
+
+        for attempt in range(max_retries):
+            last_result = fn()
+
+            if last_result.is_ok():
+                return last_result
+
+            error = last_result.unwrap_err()
+            is_retryable = isinstance(error, RegistrarTransientError | RegistrarRateLimitError)
+            if not is_retryable or attempt == max_retries - 1:
+                break
+
+            backoff = BACKOFF_BASE_SECONDS * (2**attempt)
+            self.logger.info(
+                "Retrying %s (attempt %d/%d, backoff %.1fs): %s",
+                operation,
+                attempt + 1,
+                max_retries,
+                backoff,
+                error,
+            )
+            time.sleep(backoff)
+
+        return last_result
+
+    # -- Default webhook HMAC-SHA256 verification ----------------------------
+
+    @staticmethod
+    def _verify_hmac_sha256(payload: str, signature: str, secret: str) -> bool:
+        """Standard HMAC-SHA256 verification with timing-safe comparison."""
+        expected = hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(f"sha256={expected}", signature)
+
+    # -- Shared HTTP error mapping -------------------------------------------
+
+    def _handle_error_response(self, response: requests.Response, operation: str) -> Err[RegistrarAPIError]:
+        """Map HTTP error status codes to typed RegistrarAPIError variants."""
+        status = response.status_code
+
+        try:
+            data = response.json()
+            message = data.get("message", data.get("error", response.text[:200]))
+        except Exception:
+            message = response.text[:200]
+
+        if status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
+            detail = message if status == HTTP_UNAUTHORIZED else f"Forbidden: {message}"
+            return Err(RegistrarAuthError(self.registrar.name, detail=detail))
+
+        if status == HTTP_NOT_FOUND:
+            return Err(RegistrarNotFoundError(operation, self.registrar.name))
+
+        if status == HTTP_CONFLICT:
+            return Err(RegistrarConflictError(operation, self.registrar.name))
+
+        if status == HTTP_RATE_LIMITED:
+            retry_after = response.headers.get("Retry-After")
+            return Err(
+                RegistrarRateLimitError(self.registrar.name, int(retry_after) if retry_after else None),
+                retriable=True,
+            )
+
+        if status >= HTTP_SERVER_ERROR:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"{self.gateway_name} server error ({status}): {message}"),
+                retriable=True,
+            )
+
+        return Err(
+            RegistrarAPIError(
+                f"{self.gateway_name} API error for {operation}: {status} {message}",
+                code=RegistrarErrorCode.INTERNAL_ERROR,
+                registrar_name=self.registrar.name,
+            )
+        )
+
+
+# ===============================================================================
+# GATEWAY FACTORY
+# ===============================================================================
+
+
+class RegistrarGatewayFactory:
+    """Factory for creating registrar gateway instances.
+
+    Follows the PaymentGatewayFactory pattern from apps/billing/gateways/.
+    """
+
+    _gateways: ClassVar[dict[str, type[BaseRegistrarGateway]]] = {}
+
+    @classmethod
+    def register_gateway(cls, name: str, gateway_cls: type[BaseRegistrarGateway]) -> None:
+        cls._gateways[name] = gateway_cls
+
+    @classmethod
+    def create_gateway(cls, registrar: Registrar) -> BaseRegistrarGateway:
+        """Create a gateway instance for the given registrar.
+
+        The registrar's `name` field must match a registered gateway name.
+        """
+        gateway_cls = cls._gateways.get(registrar.name)
+        if not gateway_cls:
+            raise ValueError(f"No gateway registered for registrar: {registrar.name}")
+        return gateway_cls(registrar)
+
+    @classmethod
+    def list_available_gateways(cls) -> list[str]:
+        return list(cls._gateways.keys())

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -91,6 +91,46 @@ class DomainAvailabilityResult:
     price_cents: int | None = None
 
 
+# -- Phase 2 result types ---------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DomainTransferResult:
+    """Result from initiating a domain transfer."""
+
+    transfer_id: str
+    status: str  # e.g. "pending", "approved", "rejected"
+    expected_completion: datetime | None = None
+
+
+@dataclass(frozen=True)
+class DomainInfoResult:
+    """Current domain state at the registrar."""
+
+    registrar_domain_id: str
+    domain_name: str
+    status: str
+    expires_at: datetime | None
+    nameservers: list[str]
+    locked: bool = False
+    whois_privacy: bool = False
+    epp_code: str = ""
+
+
+@dataclass(frozen=True)
+class NameserverUpdateResult:
+    """Result from a nameserver update operation."""
+
+    nameservers: list[str]
+
+
+@dataclass(frozen=True)
+class DomainLockResult:
+    """Result from a lock/unlock operation."""
+
+    locked: bool
+
+
 # ===============================================================================
 # ABSTRACT BASE GATEWAY
 # ===============================================================================
@@ -148,6 +188,54 @@ class BaseRegistrarGateway(ABC):
     @abstractmethod
     def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
         """Registrar-specific webhook signature verification."""
+
+    # -- Phase 2 optional interface (override to enable) ---------------------
+
+    def _do_initiate_transfer(
+        self,
+        domain_name: str,
+        epp_code: str,
+    ) -> Result[DomainTransferResult, RegistrarAPIError]:
+        """Registrar-specific transfer initiation. Override to enable."""
+        raise NotImplementedError(f"{self.gateway_name} does not support transfers")
+
+    def _do_get_domain_info(
+        self,
+        domain_name: str,
+    ) -> Result[DomainInfoResult, RegistrarAPIError]:
+        """Registrar-specific domain info retrieval. Override to enable."""
+        raise NotImplementedError(f"{self.gateway_name} does not support domain info")
+
+    def _do_update_nameservers(
+        self,
+        domain_name: str,
+        nameservers: list[str],
+    ) -> Result[NameserverUpdateResult, RegistrarAPIError]:
+        """Registrar-specific nameserver update. Override to enable."""
+        raise NotImplementedError(f"{self.gateway_name} does not support nameserver updates")
+
+    def _do_set_lock(
+        self,
+        domain_name: str,
+        locked: bool,
+    ) -> Result[DomainLockResult, RegistrarAPIError]:
+        """Registrar-specific lock/unlock. Override to enable."""
+        raise NotImplementedError(f"{self.gateway_name} does not support lock/unlock")
+
+    def _do_check_availability_bulk(
+        self,
+        domain_names: list[str],
+    ) -> Result[list[DomainAvailabilityResult], RegistrarAPIError]:
+        """Bulk availability check. Override for registrar-native batch API."""
+        # Default: sequential fallback
+        results: list[DomainAvailabilityResult] = []
+        for name in domain_names:
+            r = self._do_check_availability(name)
+            if r.is_ok():
+                results.append(r.unwrap())
+            else:
+                results.append(DomainAvailabilityResult(domain_name=name, available=False))
+        return Ok(results)
 
     # -- Public interface (with circuit breaker + idempotency) ----------------
 
@@ -258,6 +346,160 @@ class BaseRegistrarGateway(ABC):
             return False
 
         return self._do_verify_webhook(payload, signature, secret.strip())
+
+    # -- Phase 2 public interface --------------------------------------------
+
+    def initiate_transfer(
+        self,
+        domain_name: str,
+        epp_code: str,
+    ) -> Result[DomainTransferResult, RegistrarAPIError]:
+        """Initiate domain transfer with circuit breaker and idempotency."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        idempotency_key = f"domain_transfer:{self.gateway_name}:{domain_name}"
+        cached = cache.get(idempotency_key)
+        if cached is not None:
+            self.logger.info("Idempotency hit for %s transfer", domain_name)
+            return Ok(cached)
+
+        try:
+            result = self._retry(
+                lambda: self._do_initiate_transfer(domain_name, epp_code),
+                operation=f"transfer:{domain_name}",
+            )
+        except NotImplementedError:
+            return Err(
+                RegistrarAPIError(
+                    f"{self.gateway_name} does not support transfers",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                )
+            )
+
+        if result.is_ok():
+            cache.set(idempotency_key, result.unwrap(), IDEMPOTENCY_TTL_SECONDS)
+            self._record_success()
+            self._audit_api_call("domain_transfer", domain_name, success=True)
+        else:
+            self._record_failure(result.unwrap_err())
+            self._audit_api_call("domain_transfer", domain_name, success=False, error=str(result.unwrap_err()))
+
+        return result
+
+    def get_domain_info(
+        self,
+        domain_name: str,
+    ) -> Result[DomainInfoResult, RegistrarAPIError]:
+        """Get current domain state from the registrar."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        try:
+            result = self._retry(
+                lambda: self._do_get_domain_info(domain_name),
+                operation=f"info:{domain_name}",
+            )
+        except NotImplementedError:
+            return Err(
+                RegistrarAPIError(
+                    f"{self.gateway_name} does not support domain info",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                )
+            )
+
+        if result.is_ok():
+            self._record_success()
+        else:
+            self._record_failure(result.unwrap_err())
+
+        return result
+
+    def update_nameservers(
+        self,
+        domain_name: str,
+        nameservers: list[str],
+    ) -> Result[NameserverUpdateResult, RegistrarAPIError]:
+        """Update domain nameservers at the registrar."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        try:
+            result = self._retry(
+                lambda: self._do_update_nameservers(domain_name, nameservers),
+                operation=f"ns_update:{domain_name}",
+            )
+        except NotImplementedError:
+            return Err(
+                RegistrarAPIError(
+                    f"{self.gateway_name} does not support nameserver updates",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                )
+            )
+
+        if result.is_ok():
+            self._record_success()
+            self._audit_api_call("nameserver_update", domain_name, success=True, metadata={"nameservers": nameservers})
+        else:
+            self._record_failure(result.unwrap_err())
+            self._audit_api_call("nameserver_update", domain_name, success=False, error=str(result.unwrap_err()))
+
+        return result
+
+    def set_lock(
+        self,
+        domain_name: str,
+        locked: bool,
+    ) -> Result[DomainLockResult, RegistrarAPIError]:
+        """Lock or unlock a domain at the registrar."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        try:
+            result = self._retry(
+                lambda: self._do_set_lock(domain_name, locked),
+                operation=f"lock:{domain_name}",
+            )
+        except NotImplementedError:
+            return Err(
+                RegistrarAPIError(
+                    f"{self.gateway_name} does not support lock/unlock",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                )
+            )
+
+        if result.is_ok():
+            self._record_success()
+            self._audit_api_call("domain_lock", domain_name, success=True, metadata={"locked": locked})
+        else:
+            self._record_failure(result.unwrap_err())
+            self._audit_api_call("domain_lock", domain_name, success=False, error=str(result.unwrap_err()))
+
+        return result
+
+    def check_availability_bulk(
+        self,
+        domain_names: list[str],
+    ) -> Result[list[DomainAvailabilityResult], RegistrarAPIError]:
+        """Check availability of multiple domains in one call."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        result = self._retry(
+            lambda: self._do_check_availability_bulk(domain_names),
+            operation=f"bulk_check:{len(domain_names)}_domains",
+        )
+
+        if result.is_ok():
+            self._record_success()
+        else:
+            self._record_failure(result.unwrap_err())
+
+        return result
 
     # -- HTTP helper for subclasses ------------------------------------------
 

--- a/services/platform/apps/domains/gateways/errors.py
+++ b/services/platform/apps/domains/gateways/errors.py
@@ -1,0 +1,104 @@
+"""
+Domain registrar error types.
+
+Modeled after the Virtualmin gateway exception hierarchy.
+Each error carries a machine-readable code and optional registrar-specific detail.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RegistrarErrorCode(StrEnum):
+    """Machine-readable error codes for registrar operations."""
+
+    AUTH_FAILED = "auth_failed"
+    DOMAIN_ALREADY_REGISTERED = "domain_already_registered"
+    DOMAIN_NOT_FOUND = "domain_not_found"
+    DOMAIN_LOCKED = "domain_locked"
+    DOMAIN_NOT_ELIGIBLE = "domain_not_eligible"
+    INVALID_REGISTRANT_DATA = "invalid_registrant_data"
+    INVALID_NAMESERVERS = "invalid_nameservers"
+    RATE_LIMITED = "rate_limited"
+    TIMEOUT = "timeout"
+    NETWORK_ERROR = "network_error"
+    INVALID_RESPONSE = "invalid_response"
+    WEBHOOK_SIGNATURE_INVALID = "webhook_signature_invalid"
+    INTERNAL_ERROR = "internal_error"
+
+
+class RegistrarAPIError(Exception):
+    """Base exception for all registrar API errors."""
+
+    def __init__(
+        self,
+        message: str,
+        code: RegistrarErrorCode = RegistrarErrorCode.INTERNAL_ERROR,
+        registrar_name: str = "",
+        detail: str = "",
+    ) -> None:
+        self.code = code
+        self.registrar_name = registrar_name
+        self.detail = detail
+        super().__init__(message)
+
+
+class RegistrarAuthError(RegistrarAPIError):
+    """Authentication or authorization failure with the registrar API."""
+
+    def __init__(self, registrar_name: str, detail: str = "") -> None:
+        super().__init__(
+            f"Authentication failed for registrar '{registrar_name}'",
+            code=RegistrarErrorCode.AUTH_FAILED,
+            registrar_name=registrar_name,
+            detail=detail,
+        )
+
+
+class RegistrarConflictError(RegistrarAPIError):
+    """Domain already exists at the registrar (registration conflict)."""
+
+    def __init__(self, domain_name: str, registrar_name: str) -> None:
+        super().__init__(
+            f"Domain '{domain_name}' already registered at '{registrar_name}'",
+            code=RegistrarErrorCode.DOMAIN_ALREADY_REGISTERED,
+            registrar_name=registrar_name,
+        )
+
+
+class RegistrarNotFoundError(RegistrarAPIError):
+    """Domain not found at the registrar."""
+
+    def __init__(self, domain_name: str, registrar_name: str) -> None:
+        super().__init__(
+            f"Domain '{domain_name}' not found at '{registrar_name}'",
+            code=RegistrarErrorCode.DOMAIN_NOT_FOUND,
+            registrar_name=registrar_name,
+        )
+
+
+class RegistrarRateLimitError(RegistrarAPIError):
+    """Registrar API rate limit exceeded."""
+
+    def __init__(self, registrar_name: str, retry_after: int | None = None) -> None:
+        self.retry_after = retry_after
+        detail = f"retry_after={retry_after}s" if retry_after else ""
+        super().__init__(
+            f"Rate limit exceeded for registrar '{registrar_name}'",
+            code=RegistrarErrorCode.RATE_LIMITED,
+            registrar_name=registrar_name,
+            detail=detail,
+        )
+
+
+class RegistrarTransientError(RegistrarAPIError):
+    """Transient/retryable error (timeout, network issue, 5xx)."""
+
+    def __init__(self, registrar_name: str, message: str, detail: str = "") -> None:
+        super().__init__(
+            message,
+            code=RegistrarErrorCode.NETWORK_ERROR,
+            registrar_name=registrar_name,
+            detail=detail,
+        )

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -22,8 +22,12 @@ from .base import (
     HTTP_OK,
     BaseRegistrarGateway,
     DomainAvailabilityResult,
+    DomainInfoResult,
+    DomainLockResult,
     DomainRegistrationResult,
     DomainRenewalResult,
+    DomainTransferResult,
+    NameserverUpdateResult,
     RegistrarGatewayFactory,
 )
 from .errors import RegistrarAPIError, RegistrarTransientError
@@ -185,6 +189,90 @@ class GandiGateway(BaseRegistrarGateway):
 
     def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
         return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Phase 2 operations --------------------------------------------------
+
+    def _do_initiate_transfer(self, domain_name: str, epp_code: str) -> Result[DomainTransferResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/transferin"
+        body: dict[str, Any] = {"fqdn": domain_name, "auth_info": epp_code}
+
+        sharing_id = self._get_sharing_id()
+        if sharing_id:
+            body["sharing_id"] = sharing_id
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during transfer: {exc}"), retriable=True
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            data = response.json()
+            return Ok(
+                DomainTransferResult(
+                    transfer_id=data.get("id", ""),
+                    status=data.get("status", "pending"),
+                    expected_completion=_parse_gandi_date(data.get("expected_completion", "")),
+                )
+            )
+        return self._handle_error_response(response, f"transfer {domain_name}")
+
+    def _do_get_domain_info(self, domain_name: str) -> Result[DomainInfoResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}"
+
+        try:
+            response = self._api_request("GET", url, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code == HTTP_OK:
+            data = response.json()
+            return Ok(
+                DomainInfoResult(
+                    registrar_domain_id=data.get("id", domain_name),
+                    domain_name=data.get("fqdn", domain_name),
+                    status=data.get("status", "unknown"),
+                    expires_at=_parse_gandi_date(data.get("dates", {}).get("registry_ends_at", "")),
+                    nameservers=data.get("nameservers", []),
+                    locked="clientTransferProhibited" in data.get("status", [])
+                    if isinstance(data.get("status"), list)
+                    else False,
+                    whois_privacy=data.get("whois_privacy", False),
+                    epp_code=data.get("auth_info", ""),
+                )
+            )
+        return self._handle_error_response(response, f"info {domain_name}")
+
+    def _do_update_nameservers(
+        self, domain_name: str, nameservers: list[str]
+    ) -> Result[NameserverUpdateResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}/nameservers"
+
+        try:
+            response = self._api_request("PUT", url, json=nameservers, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            return Ok(NameserverUpdateResult(nameservers=nameservers))
+        return self._handle_error_response(response, f"update nameservers for {domain_name}")
+
+    def _do_set_lock(self, domain_name: str, locked: bool) -> Result[DomainLockResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}"
+        # Gandi uses PATCH on domain to toggle transfer lock
+        body = {"autorenew": None}  # Gandi lock is via domain status update
+        if locked:
+            body = {"tags": ["locked"]}
+
+        try:
+            response = self._api_request("PATCH", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            return Ok(DomainLockResult(locked=locked))
+        return self._handle_error_response(response, f"{'lock' if locked else 'unlock'} {domain_name}")
 
     # -- Helpers -------------------------------------------------------------
 

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -261,9 +261,7 @@ class GandiGateway(BaseRegistrarGateway):
     def _do_set_lock(self, domain_name: str, locked: bool) -> Result[DomainLockResult, RegistrarAPIError]:
         url = f"{GANDI_API_BASE}/domain/domains/{domain_name}"
         # Gandi uses PATCH on domain to toggle transfer lock
-        body = {"autorenew": None}  # Gandi lock is via domain status update
-        if locked:
-            body = {"tags": ["locked"]}
+        body: dict[str, Any] = {"tags": ["locked"]} if locked else {"autorenew": None}
 
         try:
             response = self._api_request("PATCH", url, json=body, headers=self._auth_headers())

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -1,0 +1,220 @@
+"""
+Gandi REST API gateway for international domain registration.
+
+API docs: https://api.gandi.net/docs/domains/
+Auth: Personal Access Token via Authorization header.
+Rate limit: 30 requests / 2 seconds (negotiable for resellers).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from apps.common.outbound_http import OutboundPolicy
+from apps.common.types import Err, Ok, Result
+
+from .base import (
+    HTTP_ACCEPTED,
+    HTTP_OK,
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import RegistrarAPIError, RegistrarTransientError
+
+logger = logging.getLogger(__name__)
+
+GANDI_API_BASE = "https://api.gandi.net/v5"
+
+GANDI_POLICY = OutboundPolicy(
+    name="gandi_registrar",
+    allowed_domains=frozenset({"api.gandi.net"}),
+    timeout_seconds=30.0,
+    connect_timeout_seconds=10.0,
+    verify_tls=True,
+    max_retries=0,  # we handle retries in base class
+)
+
+
+class GandiGateway(BaseRegistrarGateway):
+    """Gandi REST API gateway for international domains (.com, .net, .org, .eu, etc.)."""
+
+    @property
+    def gateway_name(self) -> str:
+        return "gandi"
+
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        return GANDI_POLICY
+
+    def _auth_headers(self) -> dict[str, str]:
+        _, api_key = self.registrar.get_api_credentials()
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_sharing_id(self) -> str | None:
+        """Reseller sharing_id for per-customer billing (stored in api_username)."""
+        username = self.registrar.api_username
+        return username if username else None
+
+    # -- Core operations -----------------------------------------------------
+
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains"
+
+        body: dict[str, Any] = {
+            "fqdn": domain_name,
+            "duration": years,
+            "owner": self._map_registrant_to_gandi(registrant_data),
+        }
+
+        if nameservers:
+            body["nameservers"] = nameservers
+
+        sharing_id = self._get_sharing_id()
+        if sharing_id:
+            body["sharing_id"] = sharing_id
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during registration: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code == HTTP_ACCEPTED:
+            data = response.json()
+            return Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id=data.get("id", domain_name),
+                    expires_at=_parse_gandi_date(data.get("expires_at", "")),
+                    nameservers=nameservers or self.registrar.default_nameservers or [],
+                    epp_code=data.get("auth_info", ""),
+                )
+            )
+
+        return self._handle_error_response(response, f"register {domain_name}")
+
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}/renew"
+
+        body = {"duration": years}
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during renewal: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            data = response.json()
+            return Ok(
+                DomainRenewalResult(
+                    new_expires_at=_parse_gandi_date(data.get("expires_at", "")),
+                )
+            )
+
+        return self._handle_error_response(response, f"renew {domain_name}")
+
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/check"
+        params = {"name": domain_name}
+
+        try:
+            response = self._api_request("GET", url, params=params, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during availability check: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code == HTTP_OK:
+            data = response.json()
+            products = data.get("products", [])
+            if products:
+                product = products[0]
+                status = product.get("status", "unavailable")
+                price_data = product.get("prices", [{}])
+                price_cents = None
+                if price_data:
+                    price_raw = price_data[0].get("price_after_taxes")
+                    if price_raw is not None:
+                        price_cents = int(float(price_raw) * 100)
+
+                return Ok(
+                    DomainAvailabilityResult(
+                        domain_name=domain_name,
+                        available=status == "available",
+                        premium=product.get("premium", False),
+                        price_cents=price_cents,
+                    )
+                )
+
+            return Ok(
+                DomainAvailabilityResult(
+                    domain_name=domain_name,
+                    available=False,
+                )
+            )
+
+        return self._handle_error_response(response, f"check availability for {domain_name}")
+
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _map_registrant_to_gandi(self, registrant_data: dict[str, Any]) -> dict[str, Any]:
+        """Map PRAHO registrant data to Gandi's owner contact format."""
+        return {
+            "given": registrant_data.get("first_name", ""),
+            "family": registrant_data.get("last_name", ""),
+            "email": registrant_data.get("email", ""),
+            "phone": registrant_data.get("phone", ""),
+            "streetaddr": registrant_data.get("address", ""),
+            "city": registrant_data.get("city", ""),
+            "zip": registrant_data.get("postal_code", ""),
+            "country": registrant_data.get("country_code", "RO"),
+            "type": registrant_data.get("entity_type", "individual"),
+            "orgname": registrant_data.get("company_name", ""),
+        }
+
+
+def _parse_gandi_date(date_str: str) -> datetime:
+    """Parse ISO 8601 date from Gandi API response."""
+    from django.utils import timezone  # noqa: PLC0415
+
+    if not date_str:
+        return timezone.now()
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return timezone.now()
+
+
+# Register with factory
+RegistrarGatewayFactory.register_gateway("gandi", GandiGateway)

--- a/services/platform/apps/domains/gateways/rotld.py
+++ b/services/platform/apps/domains/gateways/rotld.py
@@ -28,8 +28,12 @@ from .base import (
     HTTP_OK,
     BaseRegistrarGateway,
     DomainAvailabilityResult,
+    DomainInfoResult,
+    DomainLockResult,
     DomainRegistrationResult,
     DomainRenewalResult,
+    DomainTransferResult,
+    NameserverUpdateResult,
     RegistrarGatewayFactory,
 )
 from .errors import RegistrarAPIError, RegistrarTransientError
@@ -173,6 +177,86 @@ class ROTLDGateway(BaseRegistrarGateway):
 
     def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
         return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Phase 2 operations --------------------------------------------------
+
+    def _do_initiate_transfer(self, domain_name: str, epp_code: str) -> Result[DomainTransferResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/transfer"
+        body = {"domain": domain_name, "authcode": epp_code}
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during transfer: {exc}"), retriable=True
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_CREATED, HTTP_ACCEPTED):
+            data = response.json()
+            return Ok(
+                DomainTransferResult(
+                    transfer_id=str(data.get("id", "")),
+                    status=data.get("status", "pending"),
+                    expected_completion=_parse_rotld_date(data.get("expected_at", "")),
+                )
+            )
+        return self._handle_error_response(response, f"transfer {domain_name}")
+
+    def _do_get_domain_info(self, domain_name: str) -> Result[DomainInfoResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/info"
+        params = {"domain": domain_name}
+
+        try:
+            response = self._api_request("GET", url, params=params, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code == HTTP_OK:
+            data = response.json()
+            domain_data = data.get("domain", data)
+            ns_data = domain_data.get("nameservers", [])
+            nameservers = [ns.get("hostname", ns) if isinstance(ns, dict) else ns for ns in ns_data]
+            return Ok(
+                DomainInfoResult(
+                    registrar_domain_id=str(domain_data.get("id", domain_name)),
+                    domain_name=domain_name,
+                    status=domain_data.get("status", "unknown"),
+                    expires_at=_parse_rotld_date(domain_data.get("expire_at", "")),
+                    nameservers=nameservers,
+                    locked=domain_data.get("locked", False),
+                    whois_privacy=False,  # ROTLD doesn't support WHOIS privacy for .ro
+                    epp_code=domain_data.get("authcode", ""),
+                )
+            )
+        return self._handle_error_response(response, f"info {domain_name}")
+
+    def _do_update_nameservers(
+        self, domain_name: str, nameservers: list[str]
+    ) -> Result[NameserverUpdateResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/nameservers"
+        body = {"domain": domain_name, "nameservers": [{"hostname": ns} for ns in nameservers]}
+
+        try:
+            response = self._api_request("PUT", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            return Ok(NameserverUpdateResult(nameservers=nameservers))
+        return self._handle_error_response(response, f"update nameservers for {domain_name}")
+
+    def _do_set_lock(self, domain_name: str, locked: bool) -> Result[DomainLockResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/lock"
+        body = {"domain": domain_name, "locked": locked}
+
+        try:
+            response = self._api_request("PUT", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"), retriable=True)
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            return Ok(DomainLockResult(locked=locked))
+        return self._handle_error_response(response, f"{'lock' if locked else 'unlock'} {domain_name}")
 
     # -- Helpers -------------------------------------------------------------
 

--- a/services/platform/apps/domains/gateways/rotld.py
+++ b/services/platform/apps/domains/gateways/rotld.py
@@ -1,0 +1,217 @@
+"""
+ROTLD REST API v2.0 gateway for .ro domain registration.
+
+ROTLD is the sole authority for Romanian domains (.ro, .com.ro, etc.).
+Test environment: registrar2-test.rotld.ro
+Production: rest2.rotld.ro
+
+Romanian-specific requirements:
+- CUI (Company Unique Identifier) for businesses
+- CNP (Personal Numeric Code) for individuals
+- Registrar accreditation from ICI-Bucharest required
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from apps.common.outbound_http import OutboundPolicy
+from apps.common.types import Err, Ok, Result
+
+from .base import (
+    HTTP_ACCEPTED,
+    HTTP_CREATED,
+    HTTP_OK,
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import RegistrarAPIError, RegistrarTransientError
+
+logger = logging.getLogger(__name__)
+
+ROTLD_POLICY = OutboundPolicy(
+    name="rotld_registrar",
+    allowed_domains=frozenset({"rest2.rotld.ro", "registrar2-test.rotld.ro"}),
+    timeout_seconds=30.0,
+    connect_timeout_seconds=10.0,
+    verify_tls=True,
+    max_retries=0,
+)
+
+
+class ROTLDGateway(BaseRegistrarGateway):
+    """ROTLD REST API gateway for .ro domains."""
+
+    @property
+    def gateway_name(self) -> str:
+        return "rotld"
+
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        return ROTLD_POLICY
+
+    def _auth_headers(self) -> dict[str, str]:
+        _username, api_key = self.registrar.get_api_credentials()
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    @property
+    def _api_base(self) -> str:
+        """Use the registrar's configured API endpoint."""
+        return self.registrar.api_endpoint.rstrip("/")
+
+    # -- Core operations -----------------------------------------------------
+
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/register"
+
+        body: dict[str, Any] = {
+            "domain": domain_name,
+            "period": years,
+            "registrant": self._map_registrant_to_rotld(registrant_data),
+        }
+
+        if nameservers:
+            body["nameservers"] = [{"hostname": ns} for ns in nameservers]
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during registration: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_CREATED, HTTP_ACCEPTED):
+            data = response.json()
+            domain_data = data.get("domain", data)
+            return Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id=str(domain_data.get("id", domain_name)),
+                    expires_at=_parse_rotld_date(domain_data.get("expire_at", "")),
+                    nameservers=nameservers or self.registrar.default_nameservers or [],
+                    epp_code=domain_data.get("authcode", ""),
+                )
+            )
+
+        return self._handle_error_response(response, f"register {domain_name}")
+
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/renew"
+
+        body = {
+            "domain": domain_name,
+            "period": years,
+        }
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during renewal: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            data = response.json()
+            domain_data = data.get("domain", data)
+            return Ok(
+                DomainRenewalResult(
+                    new_expires_at=_parse_rotld_date(domain_data.get("expire_at", "")),
+                )
+            )
+
+        return self._handle_error_response(response, f"renew {domain_name}")
+
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/check"
+        params = {"domain": domain_name}
+
+        try:
+            response = self._api_request("GET", url, params=params, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"Network error during availability check: {exc}"),
+                retriable=True,
+            )
+
+        if response.status_code == HTTP_OK:
+            data = response.json()
+            return Ok(
+                DomainAvailabilityResult(
+                    domain_name=domain_name,
+                    available=data.get("available", False),
+                    premium=False,
+                    price_cents=None,
+                )
+            )
+
+        return self._handle_error_response(response, f"check availability for {domain_name}")
+
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _map_registrant_to_rotld(self, registrant_data: dict[str, Any]) -> dict[str, Any]:
+        """Map PRAHO registrant data to ROTLD's registrant format.
+
+        Romanian domains require CUI for businesses or CNP for individuals.
+        """
+        entity_type = registrant_data.get("entity_type", "individual")
+        result: dict[str, Any] = {
+            "name": f"{registrant_data.get('first_name', '')} {registrant_data.get('last_name', '')}".strip(),
+            "email": registrant_data.get("email", ""),
+            "phone": registrant_data.get("phone", ""),
+            "address": registrant_data.get("address", ""),
+            "city": registrant_data.get("city", ""),
+            "postal_code": registrant_data.get("postal_code", ""),
+            "country": registrant_data.get("country_code", "RO"),
+        }
+
+        if entity_type == "company":
+            result["org"] = registrant_data.get("company_name", "")
+            result["fiscal_code"] = registrant_data.get("cui", "")
+        else:
+            result["cnp"] = registrant_data.get("cnp", "")
+
+        return result
+
+
+def _parse_rotld_date(date_str: str) -> datetime:
+    """Parse date from ROTLD API response."""
+    from django.utils import timezone  # noqa: PLC0415
+
+    if not date_str:
+        return timezone.now()
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return timezone.now()
+
+
+# Register with factory
+RegistrarGatewayFactory.register_gateway("rotld", ROTLDGateway)

--- a/services/platform/apps/domains/management/commands/domain_sync.py
+++ b/services/platform/apps/domains/management/commands/domain_sync.py
@@ -1,0 +1,80 @@
+"""Pull current domain status from registrars and detect drift.
+
+Usage:
+    python manage.py domain_sync                  # sync all active domains
+    python manage.py domain_sync --domain example.com  # sync one domain
+    python manage.py domain_sync --registrar gandi     # sync all domains at a registrar
+    python manage.py domain_sync --dry-run             # show what would change
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.core.management.base import BaseCommand, CommandParser
+
+from apps.domains.models import Domain
+from apps.domains.services import DomainLifecycleService
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Sync domain status from registrar APIs to detect drift"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--domain", type=str, help="Sync a specific domain by name")
+        parser.add_argument("--registrar", type=str, help="Sync all domains at a specific registrar")
+        parser.add_argument("--dry-run", action="store_true", help="Show what would change without applying")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        domain_name = options.get("domain")
+        registrar_name = options.get("registrar")
+        dry_run = options.get("dry_run", False)
+
+        domains = self._get_domains(domain_name, registrar_name)
+
+        if not domains.exists():
+            self.stdout.write(self.style.WARNING("No domains found matching criteria."))
+            return
+
+        total = domains.count()
+        self.stdout.write(f"Syncing {total} domain(s){'  [DRY RUN]' if dry_run else ''}...")
+
+        synced = 0
+        failed = 0
+        drifted = 0
+
+        for domain in domains.select_related("registrar"):
+            if dry_run:
+                self.stdout.write(f"  Would sync: {domain.name} ({domain.registrar.name})")
+                synced += 1
+                continue
+
+            result = DomainLifecycleService.sync_domain_info(domain)
+            if result.is_ok():
+                op = result.unwrap()
+                if op.result:
+                    drifted += 1
+                    self.stdout.write(self.style.WARNING(f"  Synced (drift detected): {domain.name}"))
+                else:
+                    self.stdout.write(self.style.SUCCESS(f"  Synced: {domain.name}"))
+                synced += 1
+            else:
+                self.stdout.write(self.style.ERROR(f"  Failed: {domain.name} — {result.unwrap_err()}"))
+                failed += 1
+
+        self.stdout.write("")
+        self.stdout.write(f"Results: {synced} synced, {drifted} with drift, {failed} failed")
+
+    def _get_domains(self, domain_name: str | None, registrar_name: str | None) -> Any:
+        qs = Domain.objects.filter(status="active")
+
+        if domain_name:
+            qs = Domain.objects.filter(name=domain_name.lower())
+
+        if registrar_name:
+            qs = qs.filter(registrar__name=registrar_name)
+
+        return qs

--- a/services/platform/apps/domains/migrations/0003_add_domain_operation_model.py
+++ b/services/platform/apps/domains/migrations/0003_add_domain_operation_model.py
@@ -1,0 +1,90 @@
+"""Add DomainOperation model for async registrar operation tracking."""
+
+from __future__ import annotations
+
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("domains", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DomainOperation",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                (
+                    "operation_type",
+                    models.CharField(
+                        choices=[
+                            ("transfer_in", "Transfer In"),
+                            ("transfer_out", "Transfer Out"),
+                            ("nameserver_update", "Nameserver Update"),
+                            ("lock_update", "Lock Status Update"),
+                            ("whois_update", "WHOIS Privacy Update"),
+                            ("domain_info", "Domain Info Sync"),
+                        ],
+                        max_length=30,
+                    ),
+                ),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("submitted", "Submitted to Registrar"),
+                            ("completed", "Completed"),
+                            ("failed", "Failed"),
+                            ("retrying", "Retrying"),
+                            ("cancelled", "Cancelled"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                    ),
+                ),
+                ("parameters", models.JSONField(blank=True, default=dict)),
+                ("submitted_at", models.DateTimeField(blank=True, null=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("registrar_operation_id", models.CharField(blank=True, max_length=200)),
+                ("result", models.JSONField(blank=True, default=dict)),
+                ("error_message", models.TextField(blank=True)),
+                ("retry_count", models.PositiveIntegerField(default=0)),
+                ("max_retries", models.PositiveIntegerField(default=3)),
+                ("next_retry_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "domain",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="operations",
+                        to="domains.domain",
+                    ),
+                ),
+                (
+                    "registrar",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="domain_operations",
+                        to="domains.registrar",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Domain Operation",
+                "verbose_name_plural": "Domain Operations",
+                "db_table": "domain_operations",
+                "ordering": ("-created_at",),
+                "indexes": [
+                    models.Index(fields=["state", "created_at"], name="domainop_state_created_idx"),
+                    models.Index(fields=["domain", "operation_type"], name="domainop_domain_type_idx"),
+                    models.Index(fields=["state", "next_retry_at"], name="domainop_retry_idx"),
+                ],
+            },
+        ),
+    ]

--- a/services/platform/apps/domains/models.py
+++ b/services/platform/apps/domains/models.py
@@ -480,6 +480,110 @@ class Domain(ConcurrentTransitionMixin, models.Model):
 
 
 # ===============================================================================
+# DOMAIN OPERATIONS (ASYNC TASK TRACKING)
+# ===============================================================================
+
+
+class DomainOperation(models.Model):
+    """Tracks async domain operations submitted to registrar APIs.
+
+    Mirrors the ProvisioningTask pattern from apps/provisioning.
+    Two-phase: create record + submit to registrar (phase 1),
+    confirm via webhook or polling (phase 2).
+    """
+
+    OPERATION_TYPE_CHOICES: ClassVar[tuple[tuple[str, Any], ...]] = (
+        ("transfer_in", _("Transfer In")),
+        ("transfer_out", _("Transfer Out")),
+        ("nameserver_update", _("Nameserver Update")),
+        ("lock_update", _("Lock Status Update")),
+        ("whois_update", _("WHOIS Privacy Update")),
+        ("domain_info", _("Domain Info Sync")),
+    )
+
+    STATUS_CHOICES: ClassVar[tuple[tuple[str, Any], ...]] = (
+        ("pending", _("Pending")),
+        ("submitted", _("Submitted to Registrar")),
+        ("completed", _("Completed")),
+        ("failed", _("Failed")),
+        ("retrying", _("Retrying")),
+        ("cancelled", _("Cancelled")),
+    )
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    domain = models.ForeignKey(Domain, on_delete=models.CASCADE, related_name="operations")
+    registrar = models.ForeignKey(Registrar, on_delete=models.PROTECT, related_name="domain_operations")
+
+    operation_type = models.CharField(max_length=30, choices=OPERATION_TYPE_CHOICES)
+    state = models.CharField(max_length=20, choices=STATUS_CHOICES, default="pending")
+
+    # Operation parameters (e.g. nameservers list, lock state, epp_code)
+    parameters = models.JSONField(default=dict, blank=True)
+
+    # Execution tracking
+    submitted_at = models.DateTimeField(null=True, blank=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+
+    # Registrar reference (e.g. transfer ID, operation ID)
+    registrar_operation_id = models.CharField(max_length=200, blank=True)
+
+    # Results and errors
+    result = models.JSONField(default=dict, blank=True)
+    error_message = models.TextField(blank=True)
+
+    # Retry logic
+    retry_count = models.PositiveIntegerField(default=0)
+    max_retries = models.PositiveIntegerField(default=3)
+    next_retry_at = models.DateTimeField(null=True, blank=True)
+
+    # Metadata
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "domain_operations"
+        verbose_name = _("Domain Operation")
+        verbose_name_plural = _("Domain Operations")
+        ordering: ClassVar[tuple[str, ...]] = ("-created_at",)
+        indexes: ClassVar[tuple[models.Index, ...]] = (
+            models.Index(fields=["state", "created_at"], name="domainop_state_created_idx"),
+            models.Index(fields=["domain", "operation_type"], name="domainop_domain_type_idx"),
+            models.Index(fields=["state", "next_retry_at"], name="domainop_retry_idx"),
+        )
+
+    def __str__(self) -> str:
+        return f"{self.get_operation_type_display()} {self.domain.name} [{self.state}]"
+
+    @property
+    def can_retry(self) -> bool:
+        return self.state == "failed" and self.retry_count < self.max_retries
+
+    @property
+    def duration_seconds(self) -> int:
+        if self.submitted_at and self.completed_at:
+            return int((self.completed_at - self.submitted_at).total_seconds())
+        return 0
+
+    def mark_submitted(self, registrar_operation_id: str = "") -> None:
+        """Transition to submitted state."""
+        self.state = "submitted"
+        self.submitted_at = timezone.now()
+        self.registrar_operation_id = registrar_operation_id
+
+    def mark_completed(self, result_data: dict[str, Any] | None = None) -> None:
+        """Transition to completed state."""
+        self.state = "completed"
+        self.completed_at = timezone.now()
+        if result_data:
+            self.result = result_data
+
+    def mark_failed(self, error: str) -> None:
+        """Transition to failed state."""
+        self.state = "failed"
+        self.error_message = error
+
+
+# ===============================================================================
 # DOMAIN ORDER ITEMS
 # ===============================================================================
 

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -15,8 +15,6 @@ Provides business logic for domain operations including:
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -27,7 +25,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.encryption import DecryptionError
+from apps.common.types import Err, Ok, Result
 from apps.settings.services import SettingsService
 
 from .models import TLD, Domain, DomainOrderItem, Registrar
@@ -342,20 +340,22 @@ class DomainLifecycleService:
     @staticmethod
     def create_domain_registration(
         customer: Customer, domain_name: str, years: int = 1, whois_privacy: bool = False, auto_renew: bool = True
-    ) -> tuple[bool, Domain | str]:
-        """🆕 Create new domain registration"""
+    ) -> Result[Domain, str]:
+        """Create new domain registration.
 
+        Returns Ok(Domain) on success, Err(message) on failure.
+        """
         # Run all validation checks
         validation_result = DomainLifecycleService._validate_registration_preconditions(domain_name, years)
         if validation_result is not None:
-            return False, validation_result
+            return Err(validation_result)
 
         # Get validated components
-        components_result = DomainLifecycleService._get_registration_components(domain_name)
-        if isinstance(components_result, str):
-            return False, components_result
+        components = DomainLifecycleService._get_registration_components(domain_name)
+        if components.is_err():
+            return Err(components.unwrap_err())
 
-        tld, registrar = components_result
+        tld, registrar = components.unwrap()
 
         # Execute registration
         config = DomainRegistrationConfig(
@@ -370,13 +370,11 @@ class DomainLifecycleService:
 
     @staticmethod
     def _validate_registration_preconditions(domain_name: str, years: int) -> str | None:
-        """Validate all preconditions for domain registration"""
-        # Validate domain name format
+        """Validate all preconditions for domain registration."""
         is_valid, error_msg = DomainValidationService.validate_domain_name(domain_name)
         if not is_valid:
             return error_msg
 
-        # Validate registration period
         if years < MIN_REGISTRATION_YEARS or years > MAX_REGISTRATION_YEARS:
             return str(
                 _("Registration period must be between {min} and {max} years").format(
@@ -384,31 +382,28 @@ class DomainLifecycleService:
                 )
             )
 
-        # Check if domain already exists
         if Domain.objects.filter(name=domain_name.lower()).exists():
             return cast(str, _("Domain is already registered in the system"))
 
         return None
 
     @staticmethod
-    def _get_registration_components(domain_name: str) -> tuple[Any, Any] | str:
-        """Get TLD and registrar for domain registration"""
-        # Extract and validate TLD
+    def _get_registration_components(domain_name: str) -> Result[tuple[Any, Any], str]:
+        """Get TLD and registrar for domain registration."""
         tld_extension = DomainValidationService.extract_tld_from_domain(domain_name)
         tld = TLDService.get_tld_pricing(tld_extension)
         if not tld:
-            return cast(str, _(f"TLD '.{tld_extension}' is not supported"))
+            return Err(cast(str, _(f"TLD '.{tld_extension}' is not supported")))
 
-        # Select registrar
         registrar = RegistrarService.select_best_registrar_for_tld(tld)
         if not registrar:
-            return cast(str, _("No available registrar for this TLD"))
+            return Err(cast(str, _("No available registrar for this TLD")))
 
-        return tld, registrar
+        return Ok((tld, registrar))
 
     @staticmethod
-    def _execute_domain_registration(config: DomainRegistrationConfig) -> tuple[bool, Domain | str]:
-        """Execute the actual domain registration"""
+    def _execute_domain_registration(config: DomainRegistrationConfig) -> Result[Domain, str]:
+        """Execute the actual domain registration."""
         try:
             with transaction.atomic():
                 domain = Domain.objects.create(
@@ -421,55 +416,52 @@ class DomainLifecycleService:
                     auto_renew=config.auto_renew,
                 )
 
-                logger.info(
-                    f"🆕 [Domain] Created domain registration record: {config.domain_name} for customer {config.customer.id}"
-                )
-                return True, domain
+                logger.info("Created domain registration: %s for customer %s", config.domain_name, config.customer.id)
+                return Ok(domain)
 
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to create domain registration: {e}")
-            return False, cast(str, _("Failed to create domain registration"))
+            logger.error("Failed to create domain registration: %s", e)
+            return Err(cast(str, _("Failed to create domain registration")))
 
     @staticmethod
-    def process_domain_renewal(domain: Domain, years: int = 1) -> tuple[bool, str]:
-        """🔄 Process domain renewal"""
+    def process_domain_renewal(domain: Domain, years: int = 1) -> Result[str, str]:
+        """Process domain renewal.
+
+        Returns Ok(success_message) on success, Err(error_message) on failure.
+        """
         if domain.status != "active":
-            return False, cast(str, _("Domain must be active to renew"))
+            return Err(cast(str, _("Domain must be active to renew")))
 
         if not domain.expires_at:
-            return False, cast(str, _("Domain expiration date is not set"))
+            return Err(cast(str, _("Domain expiration date is not set")))
 
         try:
             with transaction.atomic():
-                # Calculate new expiration date
                 new_expiration = domain.expires_at + timedelta(days=365 * years)
-
-                # Update domain
                 domain.expires_at = new_expiration
-                domain.renewal_notices_sent = 0  # Reset renewal notices
+                domain.renewal_notices_sent = 0
                 domain.save(update_fields=["expires_at", "renewal_notices_sent", "updated_at"])
 
-                logger.info(f"🔄 [Domain] Renewed domain {domain.name} for {years} years, expires: {new_expiration}")
-
-                return True, cast(str, _("Domain renewed successfully"))
+                logger.info("Renewed domain %s for %d years, expires: %s", domain.name, years, new_expiration)
+                return Ok(cast(str, _("Domain renewed successfully")))
 
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to renew domain {domain.name}: {e}")
-            return False, cast(str, _("Failed to renew domain"))
+            logger.error("Failed to renew domain %s: %s", domain.name, e)
+            return Err(cast(str, _("Failed to renew domain")))
 
     @staticmethod
-    def update_domain_expiration(domain: Domain, new_expiration: datetime) -> bool:
-        """📅 Update domain expiration date (from registrar sync)"""
+    def update_domain_expiration(domain: Domain, new_expiration: datetime) -> Result[bool, str]:
+        """Update domain expiration date (from registrar sync)."""
         try:
             domain.expires_at = new_expiration
             domain.save(update_fields=["expires_at", "updated_at"])
 
-            logger.info(f"📅 [Domain] Updated expiration for {domain.name}: {new_expiration}")
-            return True
+            logger.info("Updated expiration for %s: %s", domain.name, new_expiration)
+            return Ok(True)
 
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to update expiration for {domain.name}: {e}")
-            return False
+            logger.error("Failed to update expiration for %s: %s", domain.name, e)
+            return Err(cast(str, _("Failed to update domain expiration")))
 
 
 # ===============================================================================
@@ -596,7 +588,7 @@ class DomainOrderService:
 
         for item in domain_items:
             if item.action == "register":
-                success, result = DomainLifecycleService.create_domain_registration(
+                result = DomainLifecycleService.create_domain_registration(
                     customer=order.customer,
                     domain_name=item.domain_name,
                     years=item.years,
@@ -604,23 +596,23 @@ class DomainOrderService:
                     auto_renew=item.auto_renew,
                 )
 
-                if success and isinstance(result, Domain):
-                    item.domain = result
+                if result.is_ok():
+                    domain = result.unwrap()
+                    item.domain = domain
                     item.save(update_fields=["domain"])
-                    processed_domains.append(result)
-
-                    logger.info(f"✅ [Domain] Processed registration: {item.domain_name}")
+                    processed_domains.append(domain)
+                    logger.info("Processed registration: %s", item.domain_name)
                 else:
-                    logger.error(f"🔥 [Domain] Failed to process registration: {item.domain_name}")
+                    logger.error("Failed to process registration %s: %s", item.domain_name, result.unwrap_err())
 
             elif item.action == "renew" and item.domain:
-                success, _msg = DomainLifecycleService.process_domain_renewal(domain=item.domain, years=item.years)
+                renewal_result = DomainLifecycleService.process_domain_renewal(domain=item.domain, years=item.years)
 
-                if success:
+                if renewal_result.is_ok():
                     processed_domains.append(item.domain)
-                    logger.info(f"✅ [Domain] Processed renewal: {item.domain_name}")
+                    logger.info("Processed renewal: %s", item.domain_name)
                 else:
-                    logger.error(f"🔥 [Domain] Failed to process renewal: {item.domain_name}")
+                    logger.error("Failed to process renewal %s: %s", item.domain_name, renewal_result.unwrap_err())
 
         return processed_domains
 
@@ -631,75 +623,89 @@ class DomainOrderService:
 
 
 class DomainRegistrarGateway:
-    """
-    🌐 External registrar API integration gateway
+    """Backward-compatible facade that delegates to the gateway layer.
 
-    Provides abstraction layer for different registrar APIs (Namecheap, GoDaddy, ROTLD).
-    This is a placeholder implementation for future registrar integrations.
+    The real implementations live in apps.domains.gateways (Gandi, ROTLD, etc.).
+    This class preserves the existing tuple-based return types so callers
+    (webhooks.py, DomainOrderService) don't need to change yet.
     """
 
     @staticmethod
     def register_domain(
         registrar: Registrar, domain_name: str, years: int, customer_data: dict[str, Any]
     ) -> tuple[bool, dict[str, Any]]:
-        """🆕 Register domain with external registrar"""
-        logger.info(f"🌐 [Gateway] Would register {domain_name} via {registrar.name}")
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual registrar API calls
-        # This is a placeholder implementation
-        return True, {
-            "registrar_domain_id": f"DOM_{domain_name}_{timezone.now().timestamp()}",
-            "expires_at": timezone.now() + timedelta(days=365 * years),
-            "nameservers": registrar.default_nameservers or [],
-            "epp_code": f"EPP_{domain_name[:10].upper()}",
-        }
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot register %s", registrar.name, domain_name)
+            return False, {"error": f"No gateway for registrar {registrar.name}"}
+
+        result = gateway.register_domain(domain_name, years, customer_data)
+        if result.is_ok():
+            reg = result.unwrap()
+            return True, {
+                "registrar_domain_id": reg.registrar_domain_id,
+                "expires_at": reg.expires_at,
+                "nameservers": reg.nameservers,
+                "epp_code": reg.epp_code,
+            }
+        return False, {"error": str(result.unwrap_err())}
 
     @staticmethod
     def renew_domain(registrar: Registrar, domain: Domain, years: int) -> tuple[bool, dict[str, Any]]:
-        """🔄 Renew domain with external registrar"""
-        logger.info(f"🌐 [Gateway] Would renew {domain.name} via {registrar.name}")
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual registrar API calls
-        return True, {
-            "new_expires_at": (domain.expires_at or timezone.now()) + timedelta(days=365 * years),
-        }
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot renew %s", registrar.name, domain.name)
+            return False, {"error": f"No gateway for registrar {registrar.name}"}
+
+        result = gateway.renew_domain(domain.registrar_domain_id, domain.name, years)
+        if result.is_ok():
+            renewal = result.unwrap()
+            return True, {"new_expires_at": renewal.new_expires_at}
+        return False, {"error": str(result.unwrap_err())}
 
     @staticmethod
-    def check_domain_availability(registrar: Registrar, domain_name: str) -> tuple[bool, bool]:  # (success, available)
-        """🔍 Check domain availability with registrar"""
-        logger.info(f"🌐 [Gateway] Would check availability for {domain_name} via {registrar.name}")
+    def check_domain_availability(registrar: Registrar, domain_name: str) -> tuple[bool, bool]:
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual availability check
-        # For now, assume domain is available if not in our database
-        is_available = not Domain.objects.filter(name=domain_name.lower()).exists()
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot check %s", registrar.name, domain_name)
+            return False, False
 
-        return True, is_available
+        result = gateway.check_availability(domain_name)
+        if result.is_ok():
+            return True, result.unwrap().available
+        return False, False
 
     @staticmethod
     def verify_webhook_signature(registrar: Registrar, payload: str, signature: str) -> bool:
-        """🔐 Verify webhook signature using registrar's HMAC-SHA256 webhook secret.
+        import hashlib  # noqa: PLC0415
+        import hmac as hmac_mod  # noqa: PLC0415
 
-        Fail-closed: returns False on any error (missing secret, missing signature,
-        decryption failure, empty secret, mismatch, or unexpected exception).
-        Uses timing-safe comparison to prevent side-channel attacks.
-        """
-        if not registrar.webhook_secret or not signature:
-            logger.warning(f"⚠️ [Gateway] Missing webhook secret or signature for {registrar.name}")
-            return False
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
         try:
-            decrypted = registrar.get_decrypted_webhook_secret()
-        except DecryptionError:
-            logger.error(
-                f"🔥 [Gateway] Webhook secret decryption failed for {registrar.name} — encryption key may have rotated"
-            )
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+            return gateway.verify_webhook_signature(payload, signature)
+        except ValueError:
+            pass
+
+        # Fallback: direct HMAC-SHA256 for registrars without a gateway
+        if not registrar.webhook_secret or not signature:
             return False
-
-        if not decrypted or not decrypted.strip():
-            logger.error(f"🔥 [Gateway] Webhook secret for {registrar.name} decrypted to empty value")
+        try:
+            secret = registrar.get_decrypted_webhook_secret()
+        except Exception:
             return False
-
-        webhook_secret = decrypted.strip().encode("utf-8")
-
-        expected = hmac.new(webhook_secret, payload.encode("utf-8"), hashlib.sha256).hexdigest()
-        return hmac.compare_digest(f"sha256={expected}", signature)
+        if not secret or not secret.strip():
+            return False
+        webhook_secret = secret.strip().encode("utf-8")
+        expected = hmac_mod.new(webhook_secret, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac_mod.compare_digest(f"sha256={expected}", signature)

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -28,7 +28,7 @@ from django.utils.translation import gettext_lazy as _
 from apps.common.types import Err, Ok, Result
 from apps.settings.services import SettingsService
 
-from .models import TLD, Domain, DomainOrderItem, Registrar
+from .models import TLD, Domain, DomainOperation, DomainOrderItem, Registrar
 
 if TYPE_CHECKING:
     from apps.customers.models import Customer
@@ -462,6 +462,170 @@ class DomainLifecycleService:
         except Exception as e:
             logger.error("Failed to update expiration for %s: %s", domain.name, e)
             return Err(cast(str, _("Failed to update domain expiration")))
+
+    # -- Phase 2: Transfer, nameservers, lock --------------------------------
+
+    @staticmethod
+    def initiate_transfer(
+        domain_name: str, epp_code: str, customer: Customer, registrar: Registrar
+    ) -> Result[DomainOperation, str]:
+        """Initiate inbound domain transfer (two-phase: DB record + registrar submit)."""
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
+
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            return Err(f"No gateway for registrar {registrar.name}")
+
+        # Phase 1: create Domain + DomainOperation records
+        try:
+            with transaction.atomic():
+                tld_ext = DomainValidationService.extract_tld_from_domain(domain_name)
+                tld = TLDService.get_tld_pricing(tld_ext)
+                if not tld:
+                    return Err(cast(str, _(f"TLD '.{tld_ext}' is not supported")))
+
+                domain = Domain.objects.create(
+                    name=domain_name.lower(),
+                    tld=tld,
+                    registrar=registrar,
+                    customer=customer,
+                    status="pending",
+                )
+                domain.start_transfer_in()
+                domain.save()
+
+                op = DomainOperation.objects.create(
+                    domain=domain,
+                    registrar=registrar,
+                    operation_type="transfer_in",
+                    parameters={"epp_code": "***"},  # never store plaintext EPP
+                )
+        except Exception as e:
+            logger.error("Failed to create transfer records for %s: %s", domain_name, e)
+            return Err(cast(str, _("Failed to initiate transfer")))
+
+        # Phase 2: submit to registrar
+        result = gateway.initiate_transfer(domain_name, epp_code)
+        if result.is_ok():
+            transfer = result.unwrap()
+            op.mark_submitted(registrar_operation_id=transfer.transfer_id)
+            op.save(update_fields=["state", "registrar_operation_id", "submitted_at", "updated_at"])
+            logger.info("Transfer initiated for %s: %s", domain_name, transfer.transfer_id)
+        else:
+            op.mark_failed(str(result.unwrap_err()))
+            op.save(update_fields=["state", "error_message", "updated_at"])
+            logger.error("Transfer submission failed for %s: %s", domain_name, result.unwrap_err())
+
+        return Ok(op)
+
+    @staticmethod
+    def update_nameservers(domain: Domain, nameservers: list[str]) -> Result[DomainOperation, str]:
+        """Update nameservers at the registrar (two-phase)."""
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
+
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(domain.registrar)
+        except ValueError:
+            return Err(f"No gateway for registrar {domain.registrar.name}")
+
+        op = DomainOperation.objects.create(
+            domain=domain,
+            registrar=domain.registrar,
+            operation_type="nameserver_update",
+            parameters={"nameservers": nameservers},
+        )
+
+        result = gateway.update_nameservers(domain.name, nameservers)
+        if result.is_ok():
+            domain.nameservers = nameservers
+            domain.save(update_fields=["nameservers", "updated_at"])
+            op.mark_completed()
+            op.save(update_fields=["state", "completed_at", "updated_at"])
+        else:
+            op.mark_failed(str(result.unwrap_err()))
+            op.save(update_fields=["state", "error_message", "updated_at"])
+
+        return Ok(op)
+
+    @staticmethod
+    def set_domain_lock(domain: Domain, locked: bool) -> Result[DomainOperation, str]:
+        """Lock or unlock a domain at the registrar."""
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
+
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(domain.registrar)
+        except ValueError:
+            return Err(f"No gateway for registrar {domain.registrar.name}")
+
+        op = DomainOperation.objects.create(
+            domain=domain,
+            registrar=domain.registrar,
+            operation_type="lock_update",
+            parameters={"locked": locked},
+        )
+
+        result = gateway.set_lock(domain.name, locked)
+        if result.is_ok():
+            domain.locked = locked
+            domain.save(update_fields=["locked", "updated_at"])
+            op.mark_completed()
+            op.save(update_fields=["state", "completed_at", "updated_at"])
+        else:
+            op.mark_failed(str(result.unwrap_err()))
+            op.save(update_fields=["state", "error_message", "updated_at"])
+
+        return Ok(op)
+
+    @staticmethod
+    def sync_domain_info(domain: Domain) -> Result[DomainOperation, str]:
+        """Pull current domain state from registrar and update local record."""
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
+
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(domain.registrar)
+        except ValueError:
+            return Err(f"No gateway for registrar {domain.registrar.name}")
+
+        op = DomainOperation.objects.create(
+            domain=domain,
+            registrar=domain.registrar,
+            operation_type="domain_info",
+        )
+
+        result = gateway.get_domain_info(domain.name)
+        if result.is_ok():
+            info = result.unwrap()
+            domain.nameservers = info.nameservers
+            domain.locked = info.locked
+            domain.whois_privacy = info.whois_privacy
+            if info.expires_at:
+                domain.expires_at = info.expires_at
+            if info.registrar_domain_id:
+                domain.registrar_domain_id = info.registrar_domain_id
+            domain.save(
+                update_fields=[
+                    "nameservers",
+                    "locked",
+                    "whois_privacy",
+                    "expires_at",
+                    "registrar_domain_id",
+                    "updated_at",
+                ]
+            )
+            op.mark_completed(
+                result_data={
+                    "nameservers": info.nameservers,
+                    "locked": info.locked,
+                    "expires_at": str(info.expires_at) if info.expires_at else None,
+                }
+            )
+            op.save(update_fields=["state", "completed_at", "result", "updated_at"])
+        else:
+            op.mark_failed(str(result.unwrap_err()))
+            op.save(update_fields=["state", "error_message", "updated_at"])
+
+        return Ok(op)
 
 
 # ===============================================================================

--- a/services/platform/apps/domains/views.py
+++ b/services/platform/apps/domains/views.py
@@ -372,7 +372,7 @@ def domain_register(  # Complexity: multi-step workflow  # noqa: PLR0912  # Comp
                     messages.error(request, _("❌ You do not have permission for this customer"))
                 else:
                     # Validate domain and create registration
-                    success, result = DomainLifecycleService.create_domain_registration(
+                    result = DomainLifecycleService.create_domain_registration(
                         customer=customer,
                         domain_name=domain_name,
                         years=years,
@@ -380,14 +380,12 @@ def domain_register(  # Complexity: multi-step workflow  # noqa: PLR0912  # Comp
                         auto_renew=auto_renew,
                     )
 
-                    if success:
+                    if result.is_ok():
                         messages.success(request, _(f"✅ Domain {domain_name} registered successfully!"))
-                        # result is a Domain object when success is True
-                        domain = cast(Domain, result)
+                        domain = result.unwrap()
                         return redirect("domains:detail", domain_id=domain.id)
                     else:
-                        # result is a string error message when success is False
-                        messages.error(request, _(f"❌ Registration failed: {result}"))
+                        messages.error(request, _(f"❌ Registration failed: {result.unwrap_err()}"))
 
             except Customer.DoesNotExist:
                 messages.error(request, _("Invalid customer selected"))
@@ -494,13 +492,13 @@ def domain_renew(request: HttpRequest, domain_id: str) -> HttpResponse:
     if request.method == "POST":
         years = int(request.POST.get("years", 1))
 
-        success, message = DomainLifecycleService.process_domain_renewal(domain=domain, years=years)
+        renewal_result = DomainLifecycleService.process_domain_renewal(domain=domain, years=years)
 
-        if success:
+        if renewal_result.is_ok():
             messages.success(request, _(f"✅ Domain renewed for {years} year(s)!"))
             return redirect("domains:detail", domain_id=domain_id)
         else:
-            messages.error(request, _(f"❌ Renewal failed: {message}"))
+            messages.error(request, _(f"❌ Renewal failed: {renewal_result.unwrap_err()}"))
 
     # Calculate renewal costs
     renewal_costs = []

--- a/services/platform/tests/common/test_result_types.py
+++ b/services/platform/tests/common/test_result_types.py
@@ -1,0 +1,127 @@
+"""
+Tests for the Result pattern (Ok/Err) in apps.common.types.
+
+Covers the retriable signal on Err (issue #121) and core Result behavior.
+"""
+
+from django.test import TestCase
+
+from apps.common.types import Err, Ok
+
+
+class OkTests(TestCase):
+    """Tests for the Ok result type."""
+
+    def test_ok_is_ok(self) -> None:
+        self.assertTrue(Ok(42).is_ok())
+
+    def test_ok_is_not_err(self) -> None:
+        self.assertFalse(Ok(42).is_err())
+
+    def test_ok_unwrap(self) -> None:
+        self.assertEqual(Ok("hello").unwrap(), "hello")
+
+    def test_ok_unwrap_or_returns_value(self) -> None:
+        self.assertEqual(Ok(42).unwrap_or(0), 42)
+
+    def test_ok_map_transforms_value(self) -> None:
+        result = Ok(5).map(lambda x: x * 2)
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), 10)
+
+    def test_ok_map_exception_returns_err(self) -> None:
+        result = Ok(5).map(lambda x: 1 / 0)
+        self.assertTrue(result.is_err())
+
+    def test_ok_and_then_chains(self) -> None:
+        result = Ok(5).and_then(lambda x: Ok(x + 1))
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), 6)
+
+    def test_ok_and_then_to_err(self) -> None:
+        result = Ok(5).and_then(lambda _x: Err("fail"))
+        self.assertTrue(result.is_err())
+
+    def test_ok_unwrap_err_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            Ok(42).unwrap_err()
+
+
+class ErrTests(TestCase):
+    """Tests for the Err result type."""
+
+    def test_err_is_err(self) -> None:
+        self.assertTrue(Err("oops").is_err())
+
+    def test_err_is_not_ok(self) -> None:
+        self.assertFalse(Err("oops").is_ok())
+
+    def test_err_unwrap_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            Err("oops").unwrap()
+
+    def test_err_unwrap_or_returns_default(self) -> None:
+        self.assertEqual(Err("oops").unwrap_or(99), 99)
+
+    def test_err_unwrap_err(self) -> None:
+        self.assertEqual(Err("oops").unwrap_err(), "oops")
+
+    def test_err_map_is_noop(self) -> None:
+        err = Err("fail")
+        result = err.map(lambda x: x * 2)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err(), "fail")
+
+    def test_err_and_then_is_noop(self) -> None:
+        err = Err("fail")
+        result = err.and_then(Ok)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err(), "fail")
+
+
+class ErrRetriableTests(TestCase):
+    """Tests for the retriable signal on Err (issue #121)."""
+
+    def test_err_defaults_to_not_retriable(self) -> None:
+        """Existing Err('msg') calls default to retriable=False."""
+        err = Err("database timeout")
+        self.assertFalse(err.retriable)
+
+    def test_err_explicit_retriable_true(self) -> None:
+        err = Err("lock contention", retriable=True)
+        self.assertTrue(err.retriable)
+
+    def test_err_explicit_retriable_false(self) -> None:
+        err = Err("validation failed", retriable=False)
+        self.assertFalse(err.retriable)
+
+    def test_retriable_preserved_through_map(self) -> None:
+        """Err.map() returns self, so retriable must survive."""
+        err = Err("timeout", retriable=True)
+        result = err.map(lambda x: x)
+        self.assertTrue(result.is_err())
+        self.assertTrue(result.retriable)
+
+    def test_retriable_preserved_through_and_then(self) -> None:
+        """Err.and_then() returns self, so retriable must survive."""
+        err = Err("timeout", retriable=True)
+        result = err.and_then(Ok)
+        self.assertTrue(result.is_err())
+        self.assertTrue(result.retriable)
+
+    def test_non_retriable_preserved_through_map(self) -> None:
+        err = Err("bad input", retriable=False)
+        result = err.map(lambda x: x)
+        self.assertFalse(result.retriable)
+
+    def test_frozen_dataclass_prevents_mutation(self) -> None:
+        """Err is frozen — retriable cannot be changed after creation."""
+        err = Err("fail", retriable=True)
+        with self.assertRaises(AttributeError):
+            err.retriable = False  # type: ignore[misc]  # intentional: testing frozen dataclass rejects mutation
+
+    def test_ok_map_exception_creates_non_retriable_err(self) -> None:
+        """When Ok.map() catches an exception, the resulting Err should not be retriable."""
+        result = Ok(1).map(lambda x: 1 / 0)
+        self.assertTrue(result.is_err())
+        self.assertFalse(result.retriable)

--- a/services/platform/tests/domains/test_domains_security.py
+++ b/services/platform/tests/domains/test_domains_security.py
@@ -8,9 +8,8 @@ from django.urls import reverse
 
 from apps.common.encryption import decrypt_sensitive_data, is_encrypted
 from apps.domains.forms import RegistrarForm
-from apps.domains.models import Registrar, TLD, Domain
+from apps.domains.models import TLD, Registrar
 from apps.domains.services import DomainLifecycleService
-
 
 User = get_user_model()
 
@@ -125,29 +124,29 @@ class DomainRegistrationRaceConditionTests(TestCase):
         )
 
     def test_duplicate_registration_returns_already_registered(self) -> None:
-        ok, res = DomainLifecycleService.create_domain_registration(
+        result = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="example.com",
             years=1,
         )
-        self.assertTrue(ok, res)
+        self.assertTrue(result.is_ok(), result)
 
-        ok2, res2 = DomainLifecycleService.create_domain_registration(
+        result2 = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="example.com",
             years=1,
         )
-        self.assertFalse(ok2)
-        self.assertIn("already registered", str(res2).lower())
+        self.assertTrue(result2.is_err())
+        self.assertIn("already registered", str(result2.unwrap_err()).lower())
 
     def test_years_out_of_range_rejected(self) -> None:
-        ok, res = DomainLifecycleService.create_domain_registration(
+        result = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="too.com",
             years=20,
         )
-        self.assertFalse(ok)
-        self.assertIn("period", str(res).lower())
+        self.assertTrue(result.is_err())
+        self.assertIn("period", str(result.unwrap_err()).lower())
 
 
 class RegistrarAdminAuthorizationTests(TestCase):

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -1,0 +1,383 @@
+"""Tests for Phase 2 domain registrar gateway features.
+
+Covers: DomainOperation model, transfer/nameserver/lock/info gateway methods,
+DomainLifecycleService Phase 2 operations, bulk availability.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from apps.common.types import Err, Ok
+from apps.domains.gateways.base import (
+    DomainAvailabilityResult,
+    DomainInfoResult,
+)
+from apps.domains.gateways.errors import RegistrarTransientError
+from apps.domains.gateways.gandi import GandiGateway
+from apps.domains.gateways.rotld import ROTLDGateway
+from apps.domains.models import DomainOperation, Registrar
+
+
+def _make_registrar(name: str = "gandi", **kwargs: Any) -> Registrar:
+    defaults = {
+        "display_name": name.upper(),
+        "website_url": f"https://{name}.net",
+        "api_endpoint": f"https://api.{name}.net/v5",
+        "api_username": "",
+        "api_key": "test-key",
+        "api_secret": "",
+        "webhook_secret": "",
+        "status": "active",
+    }
+    defaults.update(kwargs)
+    return Registrar(name=name, **defaults)
+
+
+def _mock_response(status_code: int, json_data: dict | None = None, text: str = "") -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or json.dumps(json_data or {})
+    resp.headers = {}
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("No JSON")
+    return resp
+
+
+# ===============================================================================
+# DOMAIN OPERATION MODEL
+# ===============================================================================
+
+
+class DomainOperationModelTests(TestCase):
+    """DomainOperation model basic behavior."""
+
+    def test_can_retry_when_failed_under_max(self) -> None:
+        op = DomainOperation(state="failed", retry_count=1, max_retries=3)
+        self.assertTrue(op.can_retry)
+
+    def test_cannot_retry_when_at_max(self) -> None:
+        op = DomainOperation(state="failed", retry_count=3, max_retries=3)
+        self.assertFalse(op.can_retry)
+
+    def test_cannot_retry_when_completed(self) -> None:
+        op = DomainOperation(state="completed", retry_count=0, max_retries=3)
+        self.assertFalse(op.can_retry)
+
+    def test_duration_seconds(self) -> None:
+        op = DomainOperation(
+            submitted_at=datetime(2027, 1, 1, 0, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2027, 1, 1, 0, 0, 5, tzinfo=UTC),
+        )
+        self.assertEqual(op.duration_seconds, 5)
+
+    def test_duration_zero_when_not_completed(self) -> None:
+        op = DomainOperation(submitted_at=datetime(2027, 1, 1, tzinfo=UTC))
+        self.assertEqual(op.duration_seconds, 0)
+
+
+# ===============================================================================
+# GANDI PHASE 2 GATEWAY
+# ===============================================================================
+
+
+class GandiTransferTests(TestCase):
+    """Gandi domain transfer operations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_transfer(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            202,
+            {
+                "id": "transfer-123",
+                "status": "pending",
+            },
+        )
+
+        result = self.gateway.initiate_transfer("example.com", "EPP-CODE")
+
+        self.assertTrue(result.is_ok())
+        transfer = result.unwrap()
+        self.assertEqual(transfer.transfer_id, "transfer-123")
+        self.assertEqual(transfer.status, "pending")
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_transfer_auth_failure(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(401, {"message": "Bad auth"})
+
+        result = self.gateway.initiate_transfer("example.com", "BAD-EPP")
+
+        self.assertTrue(result.is_err())
+
+
+class GandiDomainInfoTests(TestCase):
+    """Gandi domain info retrieval."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_info(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "id": "gandi-123",
+                "fqdn": "example.com",
+                "status": "active",
+                "dates": {"registry_ends_at": "2028-01-01T00:00:00Z"},
+                "nameservers": ["ns1.gandi.net", "ns2.gandi.net"],
+                "whois_privacy": True,
+                "auth_info": "EPP-CODE",
+            },
+        )
+
+        result = self.gateway.get_domain_info("example.com")
+
+        self.assertTrue(result.is_ok())
+        info = result.unwrap()
+        self.assertEqual(info.registrar_domain_id, "gandi-123")
+        self.assertEqual(info.nameservers, ["ns1.gandi.net", "ns2.gandi.net"])
+        self.assertTrue(info.whois_privacy)
+
+
+class GandiNameserverTests(TestCase):
+    """Gandi nameserver update operations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_ns_update(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {})
+
+        result = self.gateway.update_nameservers("example.com", ["ns1.new.com", "ns2.new.com"])
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap().nameservers, ["ns1.new.com", "ns2.new.com"])
+
+
+class GandiLockTests(TestCase):
+    """Gandi domain lock operations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_lock_domain(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {})
+
+        result = self.gateway.set_lock("example.com", locked=True)
+
+        self.assertTrue(result.is_ok())
+        self.assertTrue(result.unwrap().locked)
+
+
+# ===============================================================================
+# ROTLD PHASE 2 GATEWAY
+# ===============================================================================
+
+
+class ROTLDTransferTests(TestCase):
+    """ROTLD domain transfer operations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_transfer(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            201,
+            {
+                "id": "rotld-tx-456",
+                "status": "pending",
+            },
+        )
+
+        result = self.gateway.initiate_transfer("exemplu.ro", "EPP-CODE")
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap().transfer_id, "rotld-tx-456")
+
+
+class ROTLDDomainInfoTests(TestCase):
+    """ROTLD domain info retrieval."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_info(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "domain": {
+                    "id": "rotld-123",
+                    "status": "active",
+                    "expire_at": "2028-01-01T00:00:00Z",
+                    "nameservers": [{"hostname": "ns1.rotld.ro"}, {"hostname": "ns2.rotld.ro"}],
+                    "locked": True,
+                },
+            },
+        )
+
+        result = self.gateway.get_domain_info("exemplu.ro")
+
+        self.assertTrue(result.is_ok())
+        info = result.unwrap()
+        self.assertTrue(info.locked)
+        self.assertEqual(info.nameservers, ["ns1.rotld.ro", "ns2.rotld.ro"])
+        self.assertFalse(info.whois_privacy)  # ROTLD doesn't support WHOIS privacy
+
+
+# ===============================================================================
+# BULK AVAILABILITY
+# ===============================================================================
+
+
+class BulkAvailabilityTests(TestCase):
+    """Bulk availability check with sequential fallback."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_bulk_check_uses_sequential_fallback(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+
+        with patch.object(self.gateway, "_do_check_availability") as mock_check:
+            mock_check.side_effect = [
+                Ok(DomainAvailabilityResult("a.com", True)),
+                Ok(DomainAvailabilityResult("b.com", False)),
+            ]
+
+            result = self.gateway.check_availability_bulk(["a.com", "b.com"])
+
+        self.assertTrue(result.is_ok())
+        results = result.unwrap()
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0].available)
+        self.assertFalse(results[1].available)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_bulk_check_handles_failures_gracefully(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+
+        with patch.object(self.gateway, "_do_check_availability") as mock_check:
+            mock_check.side_effect = [
+                Ok(DomainAvailabilityResult("a.com", True)),
+                Err(RegistrarTransientError("gandi", "timeout")),
+            ]
+
+            result = self.gateway.check_availability_bulk(["a.com", "fail.com"])
+
+        self.assertTrue(result.is_ok())
+        results = result.unwrap()
+        self.assertEqual(len(results), 2)
+        self.assertTrue(results[0].available)
+        self.assertFalse(results[1].available)  # failed check defaults to unavailable
+
+
+# ===============================================================================
+# LIFECYCLE SERVICE PHASE 2 (with mocked gateway)
+# ===============================================================================
+
+
+class LifecycleServicePhase2Tests(TestCase):
+    """DomainLifecycleService Phase 2 operations with mocked gateways."""
+
+    def test_sync_domain_info_updates_local_record(self) -> None:
+        from apps.domains.services import DomainLifecycleService  # noqa: PLC0415
+
+        # Create test data
+        registrar = Registrar.objects.create(
+            name="gandi",
+            display_name="Gandi",
+            website_url="https://gandi.net",
+            api_endpoint="https://api.gandi.net/v5",
+            status="active",
+        )
+        from apps.customers.models import Customer  # noqa: PLC0415
+        from apps.domains.models import TLD  # noqa: PLC0415
+
+        tld = TLD.objects.create(
+            extension="com",
+            description="Commercial",
+            registration_price_cents=1200,
+            renewal_price_cents=1200,
+            transfer_price_cents=1200,
+        )
+        customer = Customer.objects.create(
+            name="Test Customer",
+            primary_email="test@example.com",
+            company_name="Test Co",
+            customer_type="individual",
+        )
+        from apps.domains.models import Domain  # noqa: PLC0415
+
+        domain = Domain.objects.create(
+            name="example.com",
+            tld=tld,
+            registrar=registrar,
+            customer=customer,
+            status="active",
+            nameservers=["old-ns1.com", "old-ns2.com"],
+            locked=False,
+        )
+
+        mock_info = DomainInfoResult(
+            registrar_domain_id="gandi-999",
+            domain_name="example.com",
+            status="active",
+            expires_at=datetime(2028, 6, 1, tzinfo=UTC),
+            nameservers=["ns1.gandi.net", "ns2.gandi.net"],
+            locked=True,
+            whois_privacy=True,
+        )
+
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway") as mock_factory:
+            mock_gw = MagicMock()
+            mock_gw.get_domain_info.return_value = Ok(mock_info)
+            mock_factory.return_value = mock_gw
+
+            result = DomainLifecycleService.sync_domain_info(domain)
+
+        self.assertTrue(result.is_ok())
+        op = result.unwrap()
+        self.assertEqual(op.state, "completed")
+
+        domain.refresh_from_db()
+        self.assertEqual(domain.nameservers, ["ns1.gandi.net", "ns2.gandi.net"])
+        self.assertTrue(domain.locked)
+        self.assertTrue(domain.whois_privacy)
+        self.assertEqual(domain.registrar_domain_id, "gandi-999")

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -1,0 +1,466 @@
+"""Tests for domain registrar gateway layer (issue #93).
+
+Tests the ABC, factory, circuit breaker, idempotency, error mapping,
+and the Gandi/ROTLD concrete gateways with mocked HTTP responses.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from apps.common.types import Ok
+from apps.domains.gateways import (
+    RegistrarGatewayFactory,
+)
+from apps.domains.gateways.base import (
+    CIRCUIT_BREAKER_THRESHOLD,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+)
+from apps.domains.gateways.errors import (
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+from apps.domains.gateways.gandi import GandiGateway
+from apps.domains.gateways.rotld import ROTLDGateway
+from apps.domains.models import Registrar
+
+
+def _make_registrar(name: str = "gandi", **kwargs: Any) -> Registrar:
+    """Create a Registrar instance for testing (not saved to DB)."""
+    defaults = {
+        "display_name": name.upper(),
+        "website_url": f"https://{name}.net",
+        "api_endpoint": f"https://api.{name}.net/v5",
+        "api_username": "",
+        "api_key": "test-api-key-encrypted",
+        "api_secret": "",
+        "webhook_secret": "",
+        "status": "active",
+    }
+    defaults.update(kwargs)
+    return Registrar(name=name, **defaults)
+
+
+def _mock_response(status_code: int, json_data: dict | None = None, text: str = "") -> MagicMock:
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or json.dumps(json_data or {})
+    resp.headers = {}
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("No JSON")
+    return resp
+
+
+# ===============================================================================
+# ERROR TYPES
+# ===============================================================================
+
+
+class RegistrarErrorTests(TestCase):
+    """Error hierarchy carries correct codes and messages."""
+
+    def test_auth_error_has_code(self) -> None:
+        err = RegistrarAuthError("gandi")
+        self.assertEqual(err.code, RegistrarErrorCode.AUTH_FAILED)
+        self.assertEqual(err.registrar_name, "gandi")
+
+    def test_conflict_error_has_domain(self) -> None:
+        err = RegistrarConflictError("example.com", "gandi")
+        self.assertEqual(err.code, RegistrarErrorCode.DOMAIN_ALREADY_REGISTERED)
+        self.assertIn("example.com", str(err))
+
+    def test_not_found_error(self) -> None:
+        err = RegistrarNotFoundError("example.com", "rotld")
+        self.assertEqual(err.code, RegistrarErrorCode.DOMAIN_NOT_FOUND)
+
+    def test_rate_limit_error_with_retry_after(self) -> None:
+        err = RegistrarRateLimitError("gandi", retry_after=60)
+        self.assertEqual(err.retry_after, 60)
+        self.assertEqual(err.code, RegistrarErrorCode.RATE_LIMITED)
+
+    def test_transient_error_is_retryable(self) -> None:
+        err = RegistrarTransientError("gandi", "timeout")
+        self.assertEqual(err.code, RegistrarErrorCode.NETWORK_ERROR)
+
+
+# ===============================================================================
+# FACTORY
+# ===============================================================================
+
+
+class RegistrarGatewayFactoryTests(TestCase):
+    """Factory creates correct gateway instances."""
+
+    def test_creates_gandi_gateway(self) -> None:
+        registrar = _make_registrar("gandi")
+        gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        self.assertIsInstance(gateway, GandiGateway)
+
+    def test_creates_rotld_gateway(self) -> None:
+        registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        self.assertIsInstance(gateway, ROTLDGateway)
+
+    def test_unknown_registrar_raises(self) -> None:
+        registrar = _make_registrar("unknown_registrar")
+        with self.assertRaises(ValueError, msg="No gateway registered"):
+            RegistrarGatewayFactory.create_gateway(registrar)
+
+    def test_list_available_gateways(self) -> None:
+        gateways = RegistrarGatewayFactory.list_available_gateways()
+        self.assertIn("gandi", gateways)
+        self.assertIn("rotld", gateways)
+
+
+# ===============================================================================
+# GANDI GATEWAY
+# ===============================================================================
+
+
+class GandiGatewayRegisterTests(TestCase):
+    """Gandi domain registration."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "email": "ion@example.com",
+            "phone": "+40721000000",
+            "address": "Str. Exemplu 1",
+            "city": "Bucuresti",
+            "postal_code": "010101",
+            "country_code": "RO",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_registration(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        # First get: circuit breaker (returns 0 = OK), second get: idempotency (None = cache miss)
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            202,
+            {
+                "id": "gandi-dom-123",
+                "expires_at": "2027-04-06T00:00:00Z",
+                "auth_info": "EPP-SECRET",
+            },
+        )
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_ok())
+        reg = result.unwrap()
+        self.assertEqual(reg.registrar_domain_id, "gandi-dom-123")
+        self.assertEqual(reg.epp_code, "EPP-SECRET")
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_auth_failure_returns_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(401, {"message": "Invalid token"})
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarAuthError)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_conflict_returns_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(409, {"message": "Domain already registered"})
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarConflictError)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_rate_limit_returns_retriable_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        resp = _mock_response(429, {"message": "Too many requests"})
+        resp.headers = {"Retry-After": "30"}
+        mock_request.return_value = resp
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarRateLimitError)
+
+
+class GandiGatewayAvailabilityTests(TestCase):
+    """Gandi domain availability check."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_available_domain(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0  # circuit breaker OK
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "products": [
+                    {
+                        "status": "available",
+                        "premium": False,
+                        "prices": [{"price_after_taxes": 12.50}],
+                    }
+                ],
+            },
+        )
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_ok())
+        avail = result.unwrap()
+        self.assertTrue(avail.available)
+        self.assertFalse(avail.premium)
+        self.assertEqual(avail.price_cents, 1250)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_unavailable_domain(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "products": [{"status": "unavailable", "premium": False, "prices": []}],
+            },
+        )
+
+        result = self.gateway.check_availability("taken.com")
+
+        self.assertTrue(result.is_ok())
+        self.assertFalse(result.unwrap().available)
+
+
+# ===============================================================================
+# ROTLD GATEWAY
+# ===============================================================================
+
+
+class ROTLDGatewayRegisterTests(TestCase):
+    """ROTLD domain registration."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "email": "ion@example.com",
+            "phone": "+40721000000",
+            "address": "Str. Exemplu 1",
+            "city": "Bucuresti",
+            "postal_code": "010101",
+            "country_code": "RO",
+            "entity_type": "company",
+            "company_name": "SC Exemplu SRL",
+            "cui": "RO12345678",
+        }
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_registration(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            201,
+            {
+                "domain": {
+                    "id": "rotld-12345",
+                    "expire_at": "2027-04-06T00:00:00Z",
+                    "authcode": "RO-EPP-SECRET",
+                },
+            },
+        )
+
+        result = self.gateway.register_domain("exemplu.ro", 1, self.registrant)
+
+        self.assertTrue(result.is_ok())
+        reg = result.unwrap()
+        self.assertEqual(reg.registrar_domain_id, "rotld-12345")
+        self.assertEqual(reg.epp_code, "RO-EPP-SECRET")
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_server_error_returns_transient(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(503, {"error": "Service unavailable"})
+
+        result = self.gateway.register_domain("exemplu.ro", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarTransientError)
+
+
+class ROTLDGatewayRegistrantMappingTests(TestCase):
+    """ROTLD registrant data mapping includes Romanian-specific fields."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+
+    def test_company_registrant_includes_cui(self) -> None:
+        data = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "entity_type": "company",
+            "company_name": "SC Exemplu SRL",
+            "cui": "RO12345678",
+            "email": "ion@example.com",
+        }
+        mapped = self.gateway._map_registrant_to_rotld(data)
+
+        self.assertEqual(mapped["org"], "SC Exemplu SRL")
+        self.assertEqual(mapped["fiscal_code"], "RO12345678")
+        self.assertNotIn("cnp", mapped)
+
+    def test_individual_registrant_includes_cnp(self) -> None:
+        data = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "entity_type": "individual",
+            "cnp": "1234567890123",
+            "email": "ion@example.com",
+        }
+        mapped = self.gateway._map_registrant_to_rotld(data)
+
+        self.assertEqual(mapped["cnp"], "1234567890123")
+        self.assertNotIn("org", mapped)
+        self.assertNotIn("fiscal_code", mapped)
+
+
+# ===============================================================================
+# CIRCUIT BREAKER
+# ===============================================================================
+
+
+class CircuitBreakerTests(TestCase):
+    """Circuit breaker prevents calls to failing registrars."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_open_circuit_blocks_calls(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = CIRCUIT_BREAKER_THRESHOLD
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_err())
+        err = result.unwrap_err()
+        self.assertIsInstance(err, RegistrarTransientError)
+        self.assertIn("Circuit breaker", str(err))
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_below_threshold_allows_calls(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = CIRCUIT_BREAKER_THRESHOLD - 1
+        with patch.object(self.gateway, "_do_check_availability") as mock_do:
+            mock_do.return_value = Ok(DomainAvailabilityResult("example.com", True))
+            result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_ok())
+
+
+# ===============================================================================
+# IDEMPOTENCY
+# ===============================================================================
+
+
+class IdempotencyTests(TestCase):
+    """Idempotency cache prevents duplicate registrations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_cached_registration_returned_immediately(self, mock_cache: MagicMock) -> None:
+        cached_result = DomainRegistrationResult(
+            registrar_domain_id="cached-123",
+            expires_at=datetime(2027, 1, 1, tzinfo=UTC),
+            nameservers=["ns1.example.com"],
+            epp_code="CACHED-EPP",
+        )
+        # First call returns None (circuit breaker), second returns cached result
+        mock_cache.get.side_effect = [0, cached_result]
+
+        result = self.gateway.register_domain("example.com", 1, {})
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap().registrar_domain_id, "cached-123")
+
+
+# ===============================================================================
+# BACKWARD-COMPATIBLE FACADE (services.py DomainRegistrarGateway)
+# ===============================================================================
+
+
+class DomainRegistrarGatewayFacadeTests(TestCase):
+    """The facade in services.py delegates to the gateway layer."""
+
+    def test_register_delegates_to_factory(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("gandi")
+
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway") as mock_factory:
+            mock_gw = MagicMock()
+            mock_gw.register_domain.return_value = Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id="test-123",
+                    expires_at=datetime(2027, 1, 1, tzinfo=UTC),
+                    nameservers=["ns1.gandi.net"],
+                    epp_code="EPP123",
+                )
+            )
+            mock_factory.return_value = mock_gw
+
+            success, data = DomainRegistrarGateway.register_domain(registrar, "test.com", 1, {})
+
+        self.assertTrue(success)
+        self.assertEqual(data["registrar_domain_id"], "test-123")
+
+    def test_unknown_registrar_returns_failure(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("nonexistent")
+
+        success, data = DomainRegistrarGateway.register_domain(registrar, "test.com", 1, {})
+
+        self.assertFalse(success)
+        self.assertIn("error", data)
+
+    def test_verify_webhook_delegates(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("gandi")
+
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway") as mock_factory:
+            mock_gw = MagicMock()
+            mock_gw.verify_webhook_signature.return_value = True
+            mock_factory.return_value = mock_gw
+
+            result = DomainRegistrarGateway.verify_webhook_signature(registrar, "payload", "sig")
+
+        self.assertTrue(result)


### PR DESCRIPTION
## Summary

Phase 2 (Best tier) of the domain registrar gateway implementation from #93. Builds on PR #169 (Phase 1).

### DomainOperation model
- Async operation tracking mirroring `ProvisioningTask` pattern
- Types: `transfer_in`, `transfer_out`, `nameserver_update`, `lock_update`, `whois_update`, `domain_info`
- State lifecycle: `pending` → `submitted` → `completed` / `failed` / `retrying`
- Retry logic with `max_retries` and `next_retry_at`
- Transition methods: `mark_submitted()`, `mark_completed()`, `mark_failed()`
- Field named `state` (not `status`) to comply with FSM guardrail (ADR-0034)

### Gateway extensions (`BaseRegistrarGateway`)
- `initiate_transfer()` — domain transfer with idempotency
- `get_domain_info()` — pull current state from registrar
- `update_nameservers()` — with audit logging
- `set_lock()` — lock/unlock domain at registrar
- `check_availability_bulk()` — batch check with sequential fallback (overridable for native batch APIs)
- All Phase 2 methods are non-abstract with `NotImplementedError` defaults — existing gateways work without changes until they opt in

### Concrete implementations
Both `GandiGateway` and `ROTLDGateway` implement all Phase 2 operations:
- Transfer initiation (Gandi `/transferin`, ROTLD `/domain/transfer`)
- Domain info retrieval
- Nameserver updates
- Lock/unlock

### DomainLifecycleService Phase 2
- `initiate_transfer()` — two-phase: create `Domain` + `DomainOperation` records, then submit to registrar
- `update_nameservers()` — update at registrar, sync local record
- `set_domain_lock()` — with `DomainOperation` tracking
- `sync_domain_info()` — pull registrar state, update all local domain fields

### Management command
- `domain_sync` — pull domain status from registrar APIs, detect drift
- Usage: `manage.py domain_sync [--domain example.com] [--registrar gandi] [--dry-run]`

## Depends on
- PR #169 (Phase 1 — must merge first)

## Test plan
- [x] 15 new Phase 2 tests in `test_gateway_phase2.py` — all passing
  - DomainOperation model: `can_retry`, `duration_seconds`, state transitions
  - Gandi: transfer (success + auth failure), domain info, nameserver update, lock
  - ROTLD: transfer, domain info
  - Bulk availability: sequential fallback, graceful failure handling
  - Lifecycle service: `sync_domain_info` updates local record from registrar
- [x] 25 Phase 1 tests still pass (40 total)
- [x] Ruff lint + format clean
- [x] All pre-commit hooks pass (including FSM guardrail)
- [x] DCO signed

## Diff stats
- **3 new files**: `DomainOperation` model + migration, `domain_sync` command, Phase 2 tests
- **5 modified files**: `base.py`, `gandi.py`, `rotld.py`, `services.py`, `models.py`, `__init__.py`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)