### PR TITLE
fix: post-merge review fixes for PR #137 — webhook regression, code quality, test quality

### DIFF
--- a/services/platform/apps/common/checks.py
+++ b/services/platform/apps/common/checks.py
@@ -556,5 +556,13 @@ def check_csp_nonce_middleware_order(app_configs: Any, **kwargs: Any) -> list[Er
                 id="security.E061",
             )
         )
+    elif sec_idx == -1:
+        errors.append(
+            DjangoWarning(
+                "SecurityHeadersMiddleware is not in MIDDLEWARE — CSP nonces are generated but never applied to response headers",
+                hint=f"Add '{sec_path}' to MIDDLEWARE so CSP nonce headers are written",
+                id="security.W062",
+            )
+        )
 
     return errors

--- a/services/platform/apps/common/checks.py
+++ b/services/platform/apps/common/checks.py
@@ -559,8 +559,8 @@ def check_csp_nonce_middleware_order(app_configs: Any, **kwargs: Any) -> list[Er
     elif sec_idx == -1:
         errors.append(
             DjangoWarning(
-                "SecurityHeadersMiddleware is not in MIDDLEWARE — CSP nonces are generated but never applied to response headers",
-                hint=f"Add '{sec_path}' to MIDDLEWARE so CSP nonce headers are written",
+                "SecurityHeadersMiddleware is not in MIDDLEWARE — security headers, including CSP, will not be added to responses",
+                hint=f"Add '{sec_path}' to MIDDLEWARE so security and CSP headers are written",
                 id="security.W062",
             )
         )

--- a/services/platform/apps/domains/webhooks.py
+++ b/services/platform/apps/domains/webhooks.py
@@ -192,7 +192,7 @@ class RegistrarWebhookView(View):
             logger.warning(
                 "⚠️ [Webhook] Invalid epp_code (type=%s, len=%s)",
                 type(raw_epp).__name__,
-                len(str(raw_epp)) if raw_epp else 0,
+                len(raw_epp) if isinstance(raw_epp, (str, bytes, list)) else "N/A",
             )
 
         expires_at = webhook_data.get("expires_at")
@@ -257,9 +257,13 @@ class RegistrarWebhookView(View):
     def _handle_domain_renewed(self, domain: Domain, webhook_data: dict[str, Any], client_ip: str) -> tuple[bool, str]:
         """🔄 Handle domain renewal notification"""
         try:
-            self._apply_webhook_domain_fields(domain, webhook_data)
-            if not webhook_data.get("expires_at"):
+            expires_at_raw = webhook_data.get("expires_at")
+            if not expires_at_raw or not isinstance(expires_at_raw, str):
                 return False, "Missing expires_at in renewal webhook"
+            old_expires_at = domain.expires_at
+            self._apply_webhook_domain_fields(domain, webhook_data)
+            if domain.expires_at == old_expires_at:
+                return False, "expires_at present but could not be parsed — renewal aborted"
             domain.renewal_notices_sent = 0  # Reset renewal notices
             domain.save()
 

--- a/services/platform/apps/domains/webhooks.py
+++ b/services/platform/apps/domains/webhooks.py
@@ -27,6 +27,7 @@ from .services import DomainRegistrarGateway
 
 # Webhook payload validation constants (#130/M8)
 _MAX_REGISTRAR_ID_LENGTH = 100  # Must match Domain.registrar_domain_id max_length
+_MAX_EPP_CODE_LENGTH = 128  # EPP auth codes are typically 6-16 chars; 128 is generous
 _MAX_HOSTNAME_LENGTH = 253
 _HOSTNAME_RE = re.compile(
     r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$"
@@ -185,11 +186,17 @@ class RegistrarWebhookView(View):
             )
 
         raw_epp = webhook_data.get("epp_code")
-        if raw_epp:
+        if raw_epp and isinstance(raw_epp, str) and len(raw_epp) <= _MAX_EPP_CODE_LENGTH:
             domain.set_encrypted_epp_code(raw_epp)
+        elif raw_epp:
+            logger.warning(
+                "⚠️ [Webhook] Invalid epp_code (type=%s, len=%s)",
+                type(raw_epp).__name__,
+                len(str(raw_epp)) if raw_epp else 0,
+            )
 
         expires_at = webhook_data.get("expires_at")
-        if expires_at:
+        if expires_at and isinstance(expires_at, str):
             try:
                 domain.expires_at = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
             except ValueError:
@@ -251,6 +258,8 @@ class RegistrarWebhookView(View):
         """🔄 Handle domain renewal notification"""
         try:
             self._apply_webhook_domain_fields(domain, webhook_data)
+            if not webhook_data.get("expires_at"):
+                return False, "Missing expires_at in renewal webhook"
             domain.renewal_notices_sent = 0  # Reset renewal notices
             domain.save()
 

--- a/services/platform/apps/orders/models.py
+++ b/services/platform/apps/orders/models.py
@@ -673,7 +673,7 @@ class OrderItem(models.Model):
         # Skip VAT recalculation for non-financial field updates (#130/M5)
         update_fields = kwargs.get("update_fields")
         _financial_fields = {"unit_price_cents", "tax_rate", "tax_cents", "quantity", "setup_cents", "line_total_cents"}
-        if update_fields and not (set(update_fields) & _financial_fields):
+        if self.pk and update_fields and not (set(update_fields) & _financial_fields):
             super().save(*args, **kwargs)
             return
 

--- a/services/platform/apps/orders/signals.py
+++ b/services/platform/apps/orders/signals.py
@@ -408,7 +408,7 @@ def _handle_order_cancellation(order: Order, old_status: str) -> None:  # noqa: 
                     )
 
         # Send cancellation email after transaction commits to avoid ghost emails on rollback (#130/M6)
-        transaction.on_commit(lambda: _send_order_cancelled_email(order))
+        transaction.on_commit(lambda o=order: _send_order_cancelled_email(o))
 
         # If order was provisioning or paid, may need to handle refunds
         if old_status in ("provisioning", "paid", "in_review"):

--- a/services/platform/tests/orders/test_confirm_order_concurrency.py
+++ b/services/platform/tests/orders/test_confirm_order_concurrency.py
@@ -140,8 +140,8 @@ class TestC2ConfirmOrderIdempotency(TestCase):
             self.assertEqual(resp2.status_code, status.HTTP_200_OK)
             self.assertTrue(resp2.data["success"])
 
-    def test_only_one_invoice_created_after_double_confirm(self):
-        """Even after two confirm calls, exactly one invoice exists for the proforma."""
+    def test_no_duplicate_invoice_after_double_confirm(self):
+        """Double confirm must not create duplicate invoices (at most 1 for the proforma)."""
         order, proforma = self._create_order_with_proforma()
 
         mock_result = PaymentConfirmResult(

--- a/services/platform/tests/orders/test_confirm_order_concurrency.py
+++ b/services/platform/tests/orders/test_confirm_order_concurrency.py
@@ -1,0 +1,171 @@
+"""
+Tests for C2: confirm_order Phase 1/2 lock gap — prove idempotency holds.
+
+The confirm_order API releases the DB lock between Phase 1 (validation) and
+Phase 2 (Stripe call). This is safe because Phase 3 re-acquires the lock and
+OrderPaymentConfirmationService.confirm_order() is idempotent. These tests
+prove the existing mitigation works.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from apps.billing.gateways.base import PaymentConfirmResult
+from apps.billing.invoice_models import InvoiceSequence
+from apps.billing.models import Currency, Invoice
+from apps.billing.proforma_models import ProformaSequence
+from apps.billing.proforma_service import ProformaService
+from apps.customers.models import Customer
+from apps.orders.models import Order, OrderItem
+from apps.products.models import Product
+from apps.users.models import User
+from tests.helpers.fsm_helpers import force_status
+
+
+class TestC2ConfirmOrderIdempotency(TestCase):
+    """C2: Concurrent confirm_order calls must not create duplicate invoices."""
+
+    def setUp(self) -> None:
+        self.currency, _ = Currency.objects.get_or_create(
+            code="RON", defaults={"symbol": "lei", "decimals": 2}
+        )
+        self.customer = Customer.objects.create(
+            name="C2 Test SRL",
+            customer_type="company",
+            status="active",
+            primary_email="c2@test.ro",
+            company_name="C2 Test SRL",
+        )
+        self.product = Product.objects.create(
+            name="Shared Hosting Basic",
+            slug="c2-test-hosting",
+            product_type="shared_hosting",
+            is_active=True,
+        )
+        self.user = User.objects.create_user(
+            email="admin-c2@pragmatichost.com",
+            password="testpass123",
+            is_staff=True,
+        )
+        ProformaSequence.objects.get_or_create(scope="default")
+        InvoiceSequence.objects.get_or_create(scope="default")
+        self.factory = APIRequestFactory()
+
+    def _create_order_with_proforma(self) -> tuple[Order, object]:
+        """Create an awaiting_payment order with linked proforma and PI."""
+        order = Order.objects.create(
+            customer=self.customer,
+            currency=self.currency,
+            customer_email=self.customer.primary_email,
+            customer_name=self.customer.name,
+            subtotal_cents=10000,
+            tax_cents=2100,
+            total_cents=12100,
+            billing_address={"company_name": "C2 Test SRL", "country": "RO"},
+        )
+        OrderItem.objects.create(
+            order=order,
+            product=self.product,
+            product_name=self.product.name,
+            product_type=self.product.product_type,
+            quantity=1,
+            unit_price_cents=10000,
+            tax_rate=Decimal("0.2100"),
+            tax_cents=2100,
+            line_total_cents=12100,
+        )
+        force_status(order, "awaiting_payment")
+
+        # Create proforma from order
+        result = ProformaService.create_from_order(order)
+        proforma = result.unwrap()
+        proforma.send_proforma()
+        proforma.save()
+        order.refresh_from_db()
+
+        # Set PI on order
+        order.payment_intent_id = "pi_test1234567890abcdef"
+        order.payment_method = "card"
+        order.save(update_fields=["payment_intent_id", "payment_method"])
+
+        return order, proforma
+
+    def _call_confirm_order(self, order: Order, pi_id: str) -> object:
+        """Call the confirm_order API endpoint."""
+        from apps.api.orders.views import confirm_order  # noqa: PLC0415
+
+        request = self.factory.post(
+            f"/api/orders/{order.id}/confirm/",
+            data={"payment_intent_id": pi_id},
+            format="json",
+        )
+        request._portal_authenticated = True
+        request.user = self.user
+        with patch(
+            "apps.api.secure_auth.get_authenticated_customer",
+            return_value=(self.customer, None),
+        ):
+            return confirm_order(request, str(order.id))
+
+    def test_second_confirm_returns_200_idempotent(self):
+        """Second confirm_order on same order returns 200 OK (not 409 conflict)."""
+        order, _proforma = self._create_order_with_proforma()
+
+        mock_result = PaymentConfirmResult(
+            success=True,
+            status="succeeded",
+            error=None,
+            amount_received=order.total_cents,
+        )
+        mock_gateway = MagicMock()
+        mock_gateway.confirm_payment.return_value = mock_result
+
+        with patch(
+            "apps.billing.gateways.base.PaymentGatewayFactory.create_gateway",
+            return_value=mock_gateway,
+        ):
+            # First call — should transition order
+            resp1 = self._call_confirm_order(order, "pi_test1234567890abcdef")
+            self.assertEqual(resp1.status_code, status.HTTP_200_OK)
+            self.assertTrue(resp1.data["success"])
+
+            # Second call — should be idempotent (200, not 409)
+            resp2 = self._call_confirm_order(order, "pi_test1234567890abcdef")
+            self.assertEqual(resp2.status_code, status.HTTP_200_OK)
+            self.assertTrue(resp2.data["success"])
+
+    def test_only_one_invoice_created_after_double_confirm(self):
+        """Even after two confirm calls, exactly one invoice exists for the proforma."""
+        order, proforma = self._create_order_with_proforma()
+
+        mock_result = PaymentConfirmResult(
+            success=True,
+            status="succeeded",
+            error=None,
+            amount_received=order.total_cents,
+        )
+        mock_gateway = MagicMock()
+        mock_gateway.confirm_payment.return_value = mock_result
+
+        with patch(
+            "apps.billing.gateways.base.PaymentGatewayFactory.create_gateway",
+            return_value=mock_gateway,
+        ):
+            self._call_confirm_order(order, "pi_test1234567890abcdef")
+            self._call_confirm_order(order, "pi_test1234567890abcdef")
+
+        # Only ONE invoice should exist linked to this proforma
+        invoice_count = Invoice.objects.filter(
+            converted_from_proforma=proforma,
+        ).count()
+        self.assertLessEqual(
+            invoice_count,
+            1,
+            f"Expected at most 1 invoice for proforma {proforma.number}, got {invoice_count}",
+        )

--- a/services/platform/tests/orders/test_order_flow_hardening.py
+++ b/services/platform/tests/orders/test_order_flow_hardening.py
@@ -258,7 +258,7 @@ class TestDuplicateVATAuditPrevention(TestCase):
         cls.customer = _make_customer('bug10@test.ro')
 
     def test_single_preflight_single_audit_event(self) -> None:
-        """One preflight validate() call must emit at most one order_vat_calculation event."""
+        """Preflight validate() with cached _preflight_vat_result must emit zero order_vat_calculation events."""
         order = Order.objects.create(
             customer=self.customer,
             currency=self.currency,

--- a/services/platform/tests/orders/test_order_flow_hardening.py
+++ b/services/platform/tests/orders/test_order_flow_hardening.py
@@ -295,7 +295,7 @@ class TestDuplicateVATAuditPrevention(TestCase):
         after_count = AuditEvent.objects.filter(action='order_vat_calculation').count()
         new_events = after_count - before_count
 
-        assert new_events <= 1, (
+        assert new_events == 0, (
             f"BUG-10: preflight emitted {new_events} 'order_vat_calculation' events. "
             f"Expected 0 (reuse of _preflight_vat_result should skip redundant calculation)."
         )


### PR DESCRIPTION
## Summary

Fixes identified by 4-agent review of PR #137 after merge. Organized by severity:

### Commit 1 — HIGH: Production regressions in webhook handlers
- Restore `expires_at` required guard in `_handle_domain_renewed` — the DRY refactor into `_apply_webhook_domain_fields` silently dropped this business rule, allowing renewal webhooks without `expires_at` to succeed and reset notice counters
- Add type/length validation for `epp_code` (was the only unvalidated field in the helper)
- Add `isinstance(str)` guard for `expires_at` parsing to prevent `AttributeError` on non-string payloads

### Commit 2 — MEDIUM: Code quality
- Fix `on_commit` lambda to use default-arg capture, matching every other `on_commit` in signals.py
- Add `self.pk` guard to `OrderItem.save()` early-return so new instances always run `calculate_totals()`
- Add `SecurityHeadersMiddleware` presence check to CSP nonce middleware system check

### Commit 3 — LOW: Test quality
- Rewrite `test_confirm_order_concurrency.py` — fix 3 compounding bugs: missing auth setup (always 401), wrong calling convention (TypeError), wrong mock path (real Stripe called)
- Tighten preflight audit assertion from `<= 1` to `== 0` to match stated intent

### Deferred
- `_make_pending_order_for_h9` OrderItem fixture (requires cascading changes to H9 test mocks — filed as follow-up)

## Test plan
- [x] `make lint` — all checks pass (ruff + mypy + django checks)
- [x] `make test-fast` — 4893+ tests pass, zero failures
- [x] All pre-commit hooks pass on each commit