### PR TITLE
refactor(templates): migrate user.is_staff to user.is_staff_user (#176)

### DIFF
--- a/services/platform/templates/base.html
+++ b/services/platform/templates/base.html
@@ -110,7 +110,7 @@
               </a>
 
               <!-- Staff/Admin Navigation with Dropdowns -->
-              {% if user.is_staff or user.staff_role %}
+              {% if user.is_staff_user %}
 
               {% dropdown "Business" business_items icon="building" %}
               {% dropdown "Support" support_items icon="tickets" %}

--- a/services/platform/templates/billing/partials/billing_list.html
+++ b/services/platform/templates/billing/partials/billing_list.html
@@ -125,13 +125,13 @@ This template includes both the table content and header count update.
         <div class="mb-4">{% icon "clipboard" size="2xl" %}</div>
         <h3 class="text-lg font-medium mb-2">{% trans 'No documents found' %}</h3>
         <p class="text-sm">
-          {% if user.is_staff %}
+          {% if user.is_staff_user %}
             {% trans 'Create your first proforma to get started.' %}
           {% else %}
             {% trans 'No billing documents available for your account.' %}
           {% endif %}
         </p>
-        {% if user.is_staff %}
+        {% if user.is_staff_user %}
           <div class="mt-4">
             {% url 'billing:proforma_create' as create_proforma_url %}
             {% trans "Create First Proforma" as bt13 %}{% button bt13 variant="primary" href=create_proforma_url %}

--- a/services/platform/templates/billing/partials/billing_list_component.html
+++ b/services/platform/templates/billing/partials/billing_list_component.html
@@ -38,13 +38,13 @@ This demonstrates how to use our reusable table component across the platform.
         <div class="mb-4">{% icon "clipboard" size="2xl" %}</div>
         <h3 class="text-lg font-medium mb-2">{% trans 'No documents found' %}</h3>
         <p class="text-sm">
-          {% if user.is_staff %}
+          {% if user.is_staff_user %}
             {% trans 'Create your first proforma to get started.' %}
           {% else %}
             {% trans 'No billing documents available for your account.' %}
           {% endif %}
         </p>
-        {% if user.is_staff %}
+        {% if user.is_staff_user %}
           <div class="mt-4">
             {% url 'billing:proforma_create' as create_proforma_url %}
             {% trans "Create First Proforma" as bt1 %}{% button bt1 variant="primary" href=create_proforma_url %}

--- a/services/platform/templates/billing/proforma_detail.html
+++ b/services/platform/templates/billing/proforma_detail.html
@@ -287,7 +287,7 @@
         </div>
         {% endif %}
 
-        {% if proforma.internal_notes and user.is_staff %}
+        {% if proforma.internal_notes and user.is_staff_user %}
         <div>
           <h4 class="text-sm font-medium text-slate-300 mb-2">{% trans 'Internal Notes' %} <span class="text-xs text-slate-500">({% trans 'staff only' %})</span></h4>
           <div class="text-sm text-slate-300 bg-slate-700 rounded-lg p-3">

--- a/services/platform/templates/components/mobile_header.html
+++ b/services/platform/templates/components/mobile_header.html
@@ -53,7 +53,7 @@
                 </div>
 
                 <!-- Business Section (Staff only) -->
-                {% if user.is_staff or user.staff_role %}
+                {% if user.is_staff_user %}
                 <div class="space-y-4 mb-10">
                     <div class="px-4 py-4 text-sm font-bold text-slate-300 uppercase tracking-wider">
                         {% trans 'Business' %}

--- a/services/platform/templates/customers/partials/header_action.html
+++ b/services/platform/templates/customers/partials/header_action.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load ui_components %}
 
-{% if request.user.is_staff or request.user.staff_role %}
+{% if request.user.is_staff_user %}
 <div class="htmx-stable">
   {% url 'customers:create' as create_url %}
   {% trans "New Customer" as bt_new %}{% button bt_new variant="primary" href=create_url responsive_text="New" size="sm" class="min-w-[80px] whitespace-nowrap" %}

--- a/services/platform/templates/dashboard.html
+++ b/services/platform/templates/dashboard.html
@@ -10,7 +10,7 @@
   <!-- Header -->
   <div class="mb-8">
     <h1 class="text-3xl font-bold text-white">
-      {% if user.is_staff %}
+      {% if user.is_staff_user %}
       {% icon "dashboard" size="lg" css_class="text-blue-400 mr-1" %} {% trans 'Dashboard PragmaticHost' %}
       {% else %}
       {% if user.first_name %}
@@ -21,7 +21,7 @@
       {% endif %}
     </h1>
     <p class="mt-2 text-slate-400">
-      {% if user.is_staff %}
+      {% if user.is_staff_user %}
       {% filter force_escape %}{% blocktrans with first_name=user.first_name|default:user.username %}Hello, {{ first_name }}! Here is an overview of your business activity.{% endblocktrans %}{% endfilter %}
       {% else %}
       {% trans 'Here is an overview of your hosting services and account.' %}
@@ -31,7 +31,7 @@
 
   <!-- Stats Cards -->
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-    {% if user.is_staff %}
+    {% if user.is_staff_user %}
     <!-- Staff View: Business Metrics -->
     <!-- Total Customers -->
     <div class="bg-slate-800 rounded-lg p-6 border border-slate-700">
@@ -146,7 +146,7 @@
     <div class="bg-slate-800 rounded-lg border border-slate-700">
       <div class="p-6">
         <h3 class="text-lg font-medium text-white mb-4">
-          {% if user.is_staff %}
+          {% if user.is_staff_user %}
           {% icon "receipt" size="md" css_class="text-slate-400 mr-1" %} {% trans 'Recent Invoices & Proformas' %}
           {% else %}
           {% icon "receipt" size="md" css_class="text-slate-400 mr-1" %} {% trans 'My Recent Invoices & Proformas' %}
@@ -163,7 +163,7 @@
             <div class="p-3 bg-slate-700 rounded-md hover:bg-slate-600 transition-colors border border-transparent hover:border-slate-500">
               <div class="flex items-center justify-between">
                 <div class="flex-1 min-w-0">
-                  {% if user.is_staff %}
+                  {% if user.is_staff_user %}
                   <p class="text-white font-medium group-hover:text-blue-400 transition-colors leading-5">{{ document.customer.company_name }}</p>
                   {% else %}
                   <p class="text-white font-medium group-hover:text-blue-400 transition-colors leading-5">
@@ -189,7 +189,7 @@
               </div>
               <div class="flex items-center justify-between mt-1">
                 <div class="text-slate-400 text-sm leading-4">
-                  {% if user.is_staff %}
+                  {% if user.is_staff_user %}
                     {% if document.document_type == 'invoice' %}
                     {% trans 'Invoice' %} #{{ document.number }} - {{ document.created_at|date:"d.m.Y" }}
                     {% else %}
@@ -207,7 +207,7 @@
           </a>
           {% empty %}
           <p class="text-slate-400 text-center py-4">
-            {% if user.is_staff %}
+            {% if user.is_staff_user %}
             {% trans 'No recent documents' %}
             {% else %}
             {% trans 'No recent documents found' %}
@@ -228,7 +228,7 @@
     <div class="bg-slate-800 rounded-lg border border-slate-700">
       <div class="p-6">
         <h3 class="text-lg font-medium text-white mb-4">
-          {% if user.is_staff %}
+          {% if user.is_staff_user %}
           {% icon "tickets" size="md" css_class="text-slate-400 mr-1" %} {% trans 'Recent Tickets' %}
           {% else %}
           {% icon "tickets" size="md" css_class="text-slate-400 mr-1" %} {% trans 'My Recent Tickets' %}
@@ -241,7 +241,7 @@
             <div class="p-3 bg-slate-700 rounded-md hover:bg-slate-600 transition-colors border border-transparent hover:border-slate-500">
               <div class="flex items-center justify-between">
                 <div class="flex-1 min-w-0">
-                  {% if user.is_staff %}
+                  {% if user.is_staff_user %}
                   <p class="text-white font-medium group-hover:text-blue-400 transition-colors leading-5">{{ ticket.customer.company_name }}</p>
                   {% else %}
                   <p class="text-white font-medium group-hover:text-blue-400 transition-colors leading-5 truncate">{{ ticket.title }}</p>
@@ -263,14 +263,14 @@
               </div>
               <div class="flex items-center justify-between mt-1">
                 <div class="text-slate-400 text-sm leading-4">
-                  {% if user.is_staff %}
+                  {% if user.is_staff_user %}
                   {{ ticket.title|truncatechars:40 }}
                   {% else %}
                   {{ ticket.created_at|date:"d.m.Y" }}
                   {% endif %}
                 </div>
                 <div class="text-slate-400 text-sm leading-4">
-                  {% if user.is_staff %}
+                  {% if user.is_staff_user %}
                   {{ ticket.created_at|date:"d.m.Y" }}
                   {% else %}
                   #{{ ticket.ticket_number }}
@@ -281,7 +281,7 @@
           </a>
           {% empty %}
           <p class="text-slate-400 text-center py-4">
-            {% if user.is_staff %}
+            {% if user.is_staff_user %}
             {% trans 'No recent tickets' %}
             {% else %}
             {% trans 'No recent support tickets' %}
@@ -305,7 +305,7 @@
           {% icon "lightning" size="md" css_class="text-slate-400 mr-1" %} {% trans 'Quick Actions' %}
         </h3>
 
-        {% if user.is_staff %}
+        {% if user.is_staff_user %}
         <!-- Staff Actions: Business Management -->
         <div class="grid grid-cols-2 gap-3">
           {% url 'customers:create' as create_customer_url %}
@@ -355,14 +355,14 @@
     <div class="bg-slate-800 rounded-lg border border-slate-700">
       <div class="p-6">
         <h3 class="text-lg font-medium text-white mb-4">
-          {% if user.is_staff %}
+          {% if user.is_staff_user %}
           {% icon "chart" size="md" css_class="text-slate-400 mr-1" %} {% trans 'System Status' %}
           {% else %}
           {% icon "building" size="md" css_class="text-slate-400 mr-1" %} {% trans 'Account Information' %}
           {% endif %}
         </h3>
 
-        {% if user.is_staff %}
+        {% if user.is_staff_user %}
         <!-- Staff: System Status (dynamic, cached, refreshable via HTMX) -->
         {% include "dashboard_partials/system_status.html" %}
         {% else %}

--- a/services/platform/templates/users/profile.html
+++ b/services/platform/templates/users/profile.html
@@ -135,7 +135,7 @@
             <dd class="mt-1 text-sm text-white">
               {% if user.is_superuser %}
                 {% trans "Superuser" as bt1 %}{% badge bt1 variant="primary" icon="user" %}
-              {% elif user.is_staff %}
+              {% elif user.is_staff_user %}
                 {% trans "Staff" as bt2 %}{% badge bt2 variant="info" icon="settings" %}
               {% else %}
                 {% trans "User" as bt3 %}{% badge bt3 variant="success" icon="user" %}


### PR DESCRIPTION
## Summary

Migrates ~24 instances of `user.is_staff` and `user.is_staff or user.staff_role` to `user.is_staff_user` across 8 non-ticket template files.

- **dashboard.html** (15 instances) — highest-traffic page, staff-by-role users now see the correct staff UI
- **billing_list.html**, **billing_list_component.html** (4 total) — customer column and header controls
- **proforma_detail.html** — internal notes guard
- **base.html** — compound `user.is_staff or user.staff_role` simplified to `user.is_staff_user`
- **mobile_header.html** — same compound pattern
- **header_action.html** — `request.user.is_staff or request.user.staff_role` simplified
- **users/profile.html** — staff badge display

## Not included

Ticket templates (`detail.html`, `list.html`, `comments_list.html`, `status_and_comments.html`, `tickets_table.html`) are covered by PR #159 and excluded to avoid merge conflicts.

## Test plan

- [x] All pre-commit hooks pass (template lint, i18n, security checks)
- [x] Changes are template-only — no Python logic affected

Addresses #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #176