### PR TITLE
fix(customers): close PR #149 review findings + tracking issue #173

### DIFF
--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -7,7 +7,6 @@ import logging
 from typing import Any, ClassVar, cast
 
 from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.db.models import Q, QuerySet
 from django.http import HttpRequest
@@ -23,6 +22,7 @@ from apps.api.core.permissions import IsAuthenticatedAndAccessible
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle
 from apps.api.secure_auth import public_api_endpoint, require_customer_authentication, require_portal_authentication
 from apps.common.request_ip import get_safe_client_ip
+from apps.common.validators import SecureInputValidator
 from apps.customers.contact_models import CustomerAddress
 from apps.customers.contact_service import AddressData, ContactService
 from apps.customers.models import Customer, CustomerTaxProfile
@@ -982,6 +982,7 @@ def customer_users_add(request: HttpRequest, customer: Customer) -> Response:  #
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
+@throttle_classes([BurstAPIThrottle])
 @require_customer_authentication
 def customer_users_create(request: HttpRequest, customer: Customer) -> Response:  # noqa: PLR0911
     """Create a new user and add them to the customer organization."""
@@ -995,16 +996,17 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
     if owner_error:
         return owner_error
 
-    email = data.get("email", "").strip()
+    email_input = data.get("email", "")
     role = data.get("role", "viewer")
     first_name = data.get("first_name", "").strip()
     last_name = data.get("last_name", "").strip()
 
-    if not email:
+    if not email_input:
         return Response({"success": False, "error": "Email is required."}, status=status.HTTP_400_BAD_REQUEST)
 
     try:
-        validate_email(email)
+        # Timing-safe validator that also normalizes (strip + lowercase).
+        email = str(SecureInputValidator.validate_email_secure(email_input, context="customer_user_creation"))
     except ValidationError:
         return Response(
             {"success": False, "error": "Invalid email address."},
@@ -1020,9 +1022,20 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
 
     try:
         with transaction.atomic():
-            if User.objects.filter(email=email).exists():
+            existing_user = User.objects.select_for_update().filter(email=email).first()
+            if existing_user is not None:
+                # The inviter is allowed to know about members of THEIR own customer.
+                # Cross-tenant existence is not disclosed — return a generic message instead.
+                if CustomerMembership.objects.filter(customer=customer, user=existing_user).exists():
+                    return Response(
+                        {"success": False, "error": "This user is already a member of your organization."},
+                        status=status.HTTP_409_CONFLICT,
+                    )
                 return Response(
-                    {"success": False, "error": "A user with this email already exists."},
+                    {
+                        "success": False,
+                        "error": "Cannot create a user with this email. Contact support if you need help.",
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             # Invite-only flow: user is created with an unusable password.
@@ -1030,13 +1043,15 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
             new_user = User.objects.create_user(email=email, first_name=first_name, last_name=last_name)
             CustomerMembership.objects.create(customer=customer, user=new_user, role=role)
     except IntegrityError:
+        # Race: a concurrent request created the same email between the SELECT and the INSERT.
+        # Mirror the cross-tenant generic message; do not disclose where the row landed.
         return Response(
-            {"success": False, "error": "A user with this email already exists."},
+            {"success": False, "error": "Cannot create a user with this email. Contact support if you need help."},
             status=status.HTTP_400_BAD_REQUEST,
         )
 
-    # Send invite email with password reset link
-    email_sent = SecureCustomerUserService._send_welcome_email_secure(
+    # Send invite email with password reset link via the public, rate-limited wrapper.
+    email_sent = SecureCustomerUserService.send_welcome_invite(
         new_user, customer, request_ip=get_safe_client_ip(request)
     )
 

--- a/services/platform/apps/customers/urls.py
+++ b/services/platform/apps/customers/urls.py
@@ -30,6 +30,11 @@ urlpatterns = [
     path("<int:customer_id>/add-user/", views.customer_add_user, name="add_user"),
     path("<int:customer_id>/create-user/", views.customer_create_user, name="create_user"),
     path(
+        "<int:customer_id>/user/<int:user_id>/resend-invite/",
+        views.customer_resend_invite,
+        name="resend_invite",
+    ),
+    path(
         "<int:customer_id>/membership/<int:membership_id>/change-role/", views.change_user_role, name="change_user_role"
     ),
     path("<int:customer_id>/user/<int:user_id>/toggle-status/", views.toggle_user_status, name="toggle_user_status"),

--- a/services/platform/apps/customers/user_management_views.py
+++ b/services/platform/apps/customers/user_management_views.py
@@ -7,16 +7,17 @@ from typing import cast
 
 from django.contrib import messages
 from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
 from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods, require_POST
 
 from apps.common.decorators import staff_required
 from apps.common.request_ip import get_safe_client_ip
+from apps.common.validators import SecureInputValidator
 from apps.customers.customer_service import CustomerService
 from apps.customers.models import Customer
 from apps.users.models import CustomerMembership, User
@@ -96,17 +97,18 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
     customer = _get_accessible_customer(request, customer_id)
 
     if request.method == "POST":
-        email = request.POST.get("email", "").strip()
+        email_input = request.POST.get("email", "")
         first_name = request.POST.get("first_name", "").strip()
         last_name = request.POST.get("last_name", "").strip()
         role = request.POST.get("role", "viewer")
 
-        if not email:
+        if not email_input:
             messages.error(request, _("Email address is required."))
             return redirect("customers:detail", customer_id=customer.id)
 
         try:
-            validate_email(email)
+            # Timing-safe validator that also normalizes (strip + lowercase).
+            email = str(SecureInputValidator.validate_email_secure(email_input, context="customer_user_creation"))
         except ValidationError:
             messages.error(request, _("Please enter a valid email address."))
             return redirect("customers:detail", customer_id=customer.id)
@@ -119,21 +121,39 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
 
         try:
             with transaction.atomic():
-                if User.objects.filter(email=email).exists():
-                    messages.error(request, _("User with email '{}' already exists.").format(email))
+                existing_user = User.objects.select_for_update().filter(email=email).first()
+                if existing_user is not None:
+                    # Staff can be told about members of THIS customer; cross-tenant
+                    # existence is masked behind a generic message to prevent enumeration.
+                    if CustomerMembership.objects.filter(customer=customer, user=existing_user).exists():
+                        messages.error(request, _("This user is already a member of this customer."))
+                    else:
+                        messages.error(
+                            request, _("Cannot create a user with this email. Contact support if you need help.")
+                        )
                     return redirect("customers:detail", customer_id=customer.id)
                 user = User.objects.create_user(email=email, first_name=first_name, last_name=last_name)
                 CustomerMembership.objects.create(customer=customer, user=user, role=role)
         except IntegrityError:
-            messages.error(request, _("User with email '{}' already exists.").format(email))
+            # Race: concurrent insert. Same generic message — don't disclose where it landed.
+            messages.error(request, _("Cannot create a user with this email. Contact support if you need help."))
             return redirect("customers:detail", customer_id=customer.id)
 
-        # Send invite email with password reset link
-        email_sent = SecureCustomerUserService._send_welcome_email_secure(
+        # Send invite email with password reset link via the public, rate-limited wrapper.
+        email_sent = SecureCustomerUserService.send_welcome_invite(
             user, customer, request_ip=get_safe_client_ip(request)
         )
         if not email_sent:
-            messages.warning(request, _("User created but invite email could not be sent."))
+            resend_url = reverse("customers:resend_invite", kwargs={"customer_id": customer.id, "user_id": user.id})
+            messages.warning(
+                request,
+                format_html(
+                    '{} <a href="{}" class="underline">{}</a>',
+                    _("User created but invite email could not be sent."),
+                    resend_url,
+                    _("Resend invite"),
+                ),
+            )
 
         messages.success(request, _("New user '{}' created and assigned to customer.").format(user.email))
         return redirect("customers:detail", customer_id=customer.id)
@@ -153,6 +173,44 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
         ],
     }
     return render(request, "customers/create_user.html", context)
+
+
+@staff_required
+@require_POST
+def customer_resend_invite(request: HttpRequest, customer_id: int, user_id: int) -> HttpResponse:
+    """Resend the welcome / password-reset invite for an invited user that never set a password.
+
+    Recovery path for users where the original invite email failed (SMTP outage, typo'd
+    address corrected by staff, etc.) Restricted to users who still have an unusable
+    password — once they set one, password reset is the right flow, not invite resend.
+    """
+    customer = _get_accessible_customer(request, customer_id)
+    user = get_object_or_404(User, id=user_id)
+
+    # Membership scope: prevent staff from re-inviting a user who isn't in this customer.
+    if not CustomerMembership.objects.filter(customer=customer, user=user).exists():
+        messages.error(request, _("User is not a member of this customer."))
+        return redirect("customers:detail", customer_id=customer.id)
+
+    # Only re-invite users who never completed setup. Users with a password should use
+    # the standard password-reset flow so we don't inadvertently overwrite their session.
+    if user.has_usable_password():
+        messages.error(
+            request,
+            _("This user has already set a password. Ask them to use the password reset flow instead."),
+        )
+        return redirect("customers:detail", customer_id=customer.id)
+
+    email_sent = SecureCustomerUserService.send_welcome_invite(user, customer, request_ip=get_safe_client_ip(request))
+    if email_sent:
+        messages.success(request, _("Invite email resent to '{}'.").format(user.email))
+    else:
+        messages.warning(
+            request,
+            _("Invite email could not be sent (rate-limited or transient failure). Try again later."),
+        )
+
+    return redirect("customers:detail", customer_id=customer.id)
 
 
 @staff_required

--- a/services/platform/apps/customers/user_management_views.py
+++ b/services/platform/apps/customers/user_management_views.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponse
+from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import format_html
@@ -145,12 +146,22 @@ def customer_create_user(request: HttpRequest, customer_id: int) -> HttpResponse
         )
         if not email_sent:
             resend_url = reverse("customers:resend_invite", kwargs={"customer_id": customer.id, "user_id": user.id})
+            # The resend endpoint is @require_POST (the action has side effects:
+            # it generates a fresh password-reset token that invalidates the prior
+            # one). A bare <a href> would issue a GET and 405, breaking the
+            # recovery flow exactly when staff need it. Render an inline POST form
+            # with a CSRF token so clicking "Resend invite" actually works.
             messages.warning(
                 request,
                 format_html(
-                    '{} <a href="{}" class="underline">{}</a>',
+                    '{} <form method="post" action="{}" style="display:inline;margin:0">'
+                    '<input type="hidden" name="csrfmiddlewaretoken" value="{}">'
+                    '<button type="submit" class="underline" '
+                    'style="background:none;border:0;padding:0;cursor:pointer;color:inherit;font:inherit">'
+                    "{}</button></form>",
                     _("User created but invite email could not be sent."),
                     resend_url,
+                    get_token(request),
                     _("Resend invite"),
                 ),
             )

--- a/services/platform/apps/customers/views.py
+++ b/services/platform/apps/customers/views.py
@@ -34,6 +34,7 @@ from .user_management_views import (
     change_user_role,
     customer_add_user,
     customer_create_user,
+    customer_resend_invite,
     remove_user,
     toggle_user_status,
 )
@@ -57,6 +58,7 @@ __all__ = [
     "customer_edit",
     "customer_list",
     "customer_note_add",
+    "customer_resend_invite",
     "customer_search_api",
     "customer_search_htmx",
     "customer_services_api",

--- a/services/platform/apps/users/services.py
+++ b/services/platform/apps/users/services.py
@@ -67,6 +67,73 @@ else:
 logger = logging.getLogger(__name__)
 
 
+# Conversion factor between settings.PASSWORD_RESET_TIMEOUT (seconds) and the
+# {{ expiry_hours }} value rendered into the welcome email templates.
+SECONDS_PER_HOUR = 3600
+
+
+def _render_and_send_welcome_email(user: User, customer: Customer, request_ip: str | None = None) -> bool:
+    """🔒 Render & send the customer welcome / password-reset invite email.
+
+    Module-level helper shared by SecureUserRegistrationService and
+    SecureCustomerUserService — they both need to send the same email after
+    creating a customer-scoped user, and previously had byte-for-byte
+    duplicate copies of this logic. A bug fix to one would not propagate to
+    the other; consolidating here closes that drift surface.
+
+    Returns True on success, False on any send failure (caller decides how
+    to surface that — the staff view warns the operator, the API view sets
+    invite_email_sent=false in the response).
+    """
+    try:
+        token = default_token_generator.make_token(user)
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+
+        # get_display_name returns company_name for company-type customers
+        # (when set) and falls back to .name otherwise. Avoids the empty-string
+        # rendering bug for individual-type customers where company_name is
+        # blank ("Account Created for " in the subject).
+        display_name = customer.get_display_name()
+
+        # Derive the human-readable expiry from the actual setting so the email
+        # body cannot drift from PASSWORD_RESET_TIMEOUT.
+        expiry_hours = max(1, settings.PASSWORD_RESET_TIMEOUT // SECONDS_PER_HOUR)
+
+        context = {
+            "user": user,
+            "customer": customer,
+            "display_name": display_name,
+            "expiry_hours": expiry_hours,
+            "domain": getattr(settings, "DOMAIN_NAME", "localhost:8700"),
+            "uid": uid,
+            "token": token,
+            "protocol": "https" if getattr(settings, "USE_HTTPS", False) else "http",
+            "support_email": getattr(settings, "SUPPORT_EMAIL", "support@praho.com"),
+        }
+
+        subject = _("Welcome to PRAHO - Account Created for {customer_name}").format(customer_name=display_name)
+        text_message = render_to_string("customers/emails/welcome_email.txt", context)
+        html_message = render_to_string("customers/emails/welcome_email.html", context)
+
+        send_mail(
+            subject=subject,
+            message=text_message,
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=[user.email],
+            html_message=html_message,
+            fail_silently=False,
+        )
+
+        log_security_event("welcome_email_sent", {"user_id": user.id, "customer_id": customer.id}, request_ip)
+        logger.info(f"📧 [Secure Email] Welcome email sent to {user.email}")
+        return True
+
+    except Exception as e:
+        logger.error(f"📧 [Secure Email] Failed to send welcome email: {e!s}")
+        log_security_event("welcome_email_failed", {"user_id": user.id, "error": str(e)[:200]}, request_ip)
+        return False
+
+
 # ===============================================================================
 # USER SERVICE PARAMETER OBJECTS
 # ===============================================================================
@@ -362,51 +429,8 @@ class SecureUserRegistrationService:
 
     @classmethod
     def _send_welcome_email_secure(cls, user: User, customer: Customer, request_ip: str | None = None) -> bool:
-        """
-        🔒 Secure welcome email with proper token generation
-        """
-        try:
-            # Generate secure password reset token
-            token = default_token_generator.make_token(user)
-            uid = urlsafe_base64_encode(force_bytes(user.pk))
-
-            # Prepare secure email context
-            context = {
-                "user": user,
-                "customer": customer,
-                "domain": getattr(settings, "DOMAIN_NAME", "localhost:8700"),
-                "uid": uid,
-                "token": token,
-                "protocol": "https" if getattr(settings, "USE_HTTPS", False) else "http",
-                "support_email": getattr(settings, "SUPPORT_EMAIL", "support@praho.com"),
-            }
-
-            # Render email templates (XSS-safe)
-            subject = _("Welcome to PRAHO - Account Created for {customer_name}").format(
-                customer_name=customer.company_name
-            )
-            text_message = render_to_string("customers/emails/welcome_email.txt", context)
-            html_message = render_to_string("customers/emails/welcome_email.html", context)
-
-            # Send email with error handling
-            send_mail(
-                subject=subject,
-                message=text_message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[user.email],
-                html_message=html_message,
-                fail_silently=False,
-            )
-
-            log_security_event("welcome_email_sent", {"user_id": user.id, "customer_id": customer.id}, request_ip)
-
-            logger.info(f"📧 [Secure Email] Welcome email sent to {user.email}")
-            return True
-
-        except Exception as e:
-            logger.error(f"📧 [Secure Email] Failed to send welcome email: {e!s}")
-            log_security_event("welcome_email_failed", {"user_id": user.id, "error": str(e)[:200]}, request_ip)
-            return False
+        """🔒 Secure welcome email — delegates to shared module-level helper."""
+        return _render_and_send_welcome_email(user, customer, request_ip)
 
     @classmethod
     def _find_customer_by_identifier_secure(
@@ -852,53 +876,8 @@ class SecureCustomerUserService:
 
     @classmethod
     def _send_welcome_email_secure(cls, user: User, customer: Customer, request_ip: str | None = None) -> bool:
-        """
-        🔒 Secure welcome email with proper token generation
-        """
-        try:
-            # These imports are already available at module level
-
-            # Generate secure password reset token
-            token = default_token_generator.make_token(user)
-            uid = urlsafe_base64_encode(force_bytes(user.pk))
-
-            # Prepare secure email context
-            context = {
-                "user": user,
-                "customer": customer,
-                "domain": getattr(settings, "DOMAIN_NAME", "localhost:8700"),
-                "uid": uid,
-                "token": token,
-                "protocol": "https" if getattr(settings, "USE_HTTPS", False) else "http",
-                "support_email": getattr(settings, "SUPPORT_EMAIL", "support@praho.com"),
-            }
-
-            # Render email templates (XSS-safe)
-            subject = _("Welcome to PRAHO - Account Created for {customer_name}").format(
-                customer_name=customer.company_name
-            )
-            text_message = render_to_string("customers/emails/welcome_email.txt", context)
-            html_message = render_to_string("customers/emails/welcome_email.html", context)
-
-            # Send email with error handling
-            send_mail(
-                subject=subject,
-                message=text_message,
-                from_email=settings.DEFAULT_FROM_EMAIL,
-                recipient_list=[user.email],
-                html_message=html_message,
-                fail_silently=False,
-            )
-
-            log_security_event("welcome_email_sent", {"user_id": user.id, "customer_id": customer.id}, request_ip)
-
-            logger.info(f"📧 [Secure Email] Welcome email sent to {user.email}")
-            return True
-
-        except Exception as e:
-            logger.error(f"📧 [Secure Email] Failed to send welcome email: {e!s}")
-            log_security_event("welcome_email_failed", {"user_id": user.id, "error": str(e)[:200]}, request_ip)
-            return False
+        """🔒 Secure welcome email — delegates to shared module-level helper."""
+        return _render_and_send_welcome_email(user, customer, request_ip)
 
     @classmethod
     def send_welcome_invite(cls, user: User, customer: Customer, request_ip: str | None = None) -> bool:

--- a/services/platform/apps/users/services.py
+++ b/services/platform/apps/users/services.py
@@ -901,6 +901,35 @@ class SecureCustomerUserService:
             return False
 
     @classmethod
+    def send_welcome_invite(cls, user: User, customer: Customer, request_ip: str | None = None) -> bool:
+        """
+        🔒 Public entry point for sending a welcome / password-reset invite email.
+
+        Wraps the private email helper with a per-user rate limit (3/hour) so a
+        compromised inviter credential cannot bomb the same target with invite
+        emails. Returns False when the cache guard rejects the send so callers
+        can surface a warning to staff.
+        """
+        guard_key = f"welcome_invite:{user.pk}"
+        invite_limit = SettingsService.get_integer_setting("security.welcome_invite_limit_per_user_per_hour", 3)
+        sent_count = cache.get(guard_key, 0)
+        if sent_count >= invite_limit:
+            logger.warning(
+                f"🚦 [Welcome Invite] Rate limit hit for user {user.pk} ({sent_count}/{invite_limit} per hour)"
+            )
+            log_security_event(
+                "welcome_invite_rate_limited",
+                {"user_id": user.id, "customer_id": customer.id, "count": sent_count},
+                request_ip,
+            )
+            return False
+
+        sent = cls._send_welcome_email_secure(user, customer, request_ip=request_ip)
+        if sent:
+            cache.set(guard_key, sent_count + 1, timeout=3600)
+        return sent
+
+    @classmethod
     def _notify_owners_of_join_request_secure(
         cls, customer: Customer, requesting_user: User, request_ip: str | None = None
     ) -> None:

--- a/services/platform/apps/users/services.py
+++ b/services/platform/apps/users/services.py
@@ -891,21 +891,39 @@ class SecureCustomerUserService:
         """
         guard_key = f"welcome_invite:{user.pk}"
         invite_limit = SettingsService.get_integer_setting("security.welcome_invite_limit_per_user_per_hour", 3)
-        sent_count = cache.get(guard_key, 0)
-        if sent_count >= invite_limit:
+
+        # Atomic check-and-claim: cache.add seeds the counter at 0 only if it
+        # does not already exist (no-op when the window is in flight); cache.incr
+        # is atomic on memcached/Redis backends. The previous get+set pattern
+        # raced under concurrency — two callers could observe count=2 and both
+        # write count=3, exceeding the intended cap.
+        try:
+            cache.add(guard_key, 0, timeout=3600)
+            sent_count = cache.incr(guard_key)
+        except ValueError:
+            # Backend lacks persistent storage / atomic incr (e.g. DummyCache
+            # used in some test settings). Skip the rate-limit guard — the
+            # view-layer @throttle_classes still bounds traffic, and falling
+            # through preserves correctness in the non-cached case.
+            return cls._send_welcome_email_secure(user, customer, request_ip=request_ip)
+
+        if sent_count > invite_limit:
+            cache.decr(guard_key)  # release our claim — we will not send
             logger.warning(
-                f"🚦 [Welcome Invite] Rate limit hit for user {user.pk} ({sent_count}/{invite_limit} per hour)"
+                f"🚦 [Welcome Invite] Rate limit hit for user {user.pk} ({sent_count - 1}/{invite_limit} per hour)"
             )
             log_security_event(
                 "welcome_invite_rate_limited",
-                {"user_id": user.id, "customer_id": customer.id, "count": sent_count},
+                {"user_id": user.id, "customer_id": customer.id, "count": sent_count - 1},
                 request_ip,
             )
             return False
 
         sent = cls._send_welcome_email_secure(user, customer, request_ip=request_ip)
-        if sent:
-            cache.set(guard_key, sent_count + 1, timeout=3600)
+        if not sent:
+            # Underlying send failed — give the quota slot back so retries are
+            # not penalised for a transient SMTP failure.
+            cache.decr(guard_key)
         return sent
 
     @classmethod

--- a/services/platform/templates/customers/emails/welcome_email.html
+++ b/services/platform/templates/customers/emails/welcome_email.html
@@ -2,9 +2,11 @@
 <html>
 <head><meta charset="utf-8"></head>
 <body style="font-family: sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
-  <h2>{% blocktrans with customer_name=customer.company_name %}Welcome to PRAHO!{% endblocktrans %}</h2>
-
-  <p>{% blocktrans with customer_name=customer.company_name %}You have been invited to join {{ customer_name }}.{% endblocktrans %}</p>
+  <h2>
+    {% blocktrans trimmed with customer_name=customer.company_name %}
+      You have been invited to {{ customer_name }} on PRAHO
+    {% endblocktrans %}
+  </h2>
 
   <p>{% trans "To get started, please set your password by clicking the button below:" %}</p>
 
@@ -27,7 +29,9 @@
   <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">
 
   <p style="font-size: 0.85em; color: #999;">
-    {% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}
+    {% blocktrans trimmed with support=support_email %}
+      If you did not expect this invitation, please contact us at {{ support }}.
+    {% endblocktrans %}
   </p>
 </body>
 </html>

--- a/services/platform/templates/customers/emails/welcome_email.html
+++ b/services/platform/templates/customers/emails/welcome_email.html
@@ -3,7 +3,7 @@
 <head><meta charset="utf-8"></head>
 <body style="font-family: sans-serif; color: #333; max-width: 600px; margin: 0 auto;">
   <h2>
-    {% blocktrans trimmed with customer_name=customer.company_name %}
+    {% blocktrans trimmed with customer_name=display_name %}
       You have been invited to {{ customer_name }} on PRAHO
     {% endblocktrans %}
   </h2>
@@ -23,7 +23,11 @@
   </p>
 
   <p style="font-size: 0.9em; color: #666;">
-    {% trans "This link will expire in 2 hours." %}
+    {% blocktrans trimmed count counter=expiry_hours %}
+      This link will expire in {{ counter }} hour.
+    {% plural %}
+      This link will expire in {{ counter }} hours.
+    {% endblocktrans %}
   </p>
 
   <hr style="border: none; border-top: 1px solid #eee; margin: 20px 0;">

--- a/services/platform/templates/customers/emails/welcome_email.txt
+++ b/services/platform/templates/customers/emails/welcome_email.txt
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans trimmed with customer_name=customer.company_name %}
+{% blocktrans trimmed with customer_name=display_name %}
 You have been invited to {{ customer_name }} on PRAHO.
 {% endblocktrans %}
 
@@ -7,7 +7,11 @@ You have been invited to {{ customer_name }} on PRAHO.
 
 {{ protocol }}://{{ domain }}{% url 'users:password_reset_confirm' uidb64=uid token=token %}
 
-{% trans "This link will expire in 2 hours. If it has expired, you can request a new one at:" %}
+{% blocktrans trimmed count counter=expiry_hours %}
+This link will expire in {{ counter }} hour. If it has expired, you can request a new one at:
+{% plural %}
+This link will expire in {{ counter }} hours. If it has expired, you can request a new one at:
+{% endblocktrans %}
 {{ protocol }}://{{ domain }}{% url 'users:password_reset' %}
 
 {% blocktrans trimmed with support=support_email %}

--- a/services/platform/templates/customers/emails/welcome_email.txt
+++ b/services/platform/templates/customers/emails/welcome_email.txt
@@ -1,6 +1,7 @@
-{% load i18n %}{% blocktrans with customer_name=customer.company_name %}Welcome to PRAHO!
-
-You have been invited to join {{ customer_name }}.{% endblocktrans %}
+{% load i18n %}
+{% blocktrans trimmed with customer_name=customer.company_name %}
+You have been invited to {{ customer_name }} on PRAHO.
+{% endblocktrans %}
 
 {% trans "To get started, please set your password by clicking the link below:" %}
 
@@ -9,7 +10,9 @@ You have been invited to join {{ customer_name }}.{% endblocktrans %}
 {% trans "This link will expire in 2 hours. If it has expired, you can request a new one at:" %}
 {{ protocol }}://{{ domain }}{% url 'users:password_reset' %}
 
-{% blocktrans with support=support_email %}If you did not expect this invitation, please contact us at {{ support }}.{% endblocktrans %}
+{% blocktrans trimmed with support=support_email %}
+If you did not expect this invitation, please contact us at {{ support }}.
+{% endblocktrans %}
 
 {% trans "Best regards," %}
 {% trans "The PRAHO Team" %}

--- a/services/platform/tests/api/test_customer_api.py
+++ b/services/platform/tests/api/test_customer_api.py
@@ -10,6 +10,7 @@ import time
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError as DjangoIntegrityError
 from django.test import RequestFactory, TestCase
 
 from apps.api.customers.views import (
@@ -171,18 +172,36 @@ class CustomerUsersCreateAPITests(TestCase):
         self.assertFalse(response.data["invite_email_sent"])
 
     @patch("apps.api.secure_auth.get_authenticated_customer")
-    def test_create_user_duplicate_email_returns_400(self, mock_auth):
-        """Creating a user with an existing email returns 400."""
+    def test_create_user_existing_in_other_customer_returns_generic_400(self, mock_auth):
+        """Cross-tenant existing user returns generic 400 (no enumeration leak)."""
         mock_auth.return_value = (self.customer, None)
-        User.objects.create_user(email="existing@example.com", password="pass123")
+        # User exists globally but is NOT a member of self.customer.
+        User.objects.create_user(email="elsewhere@example.com", password="pass123")
         request = _make_request(self.factory, "/api/customers/users/create/", {
             "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
-            "email": "existing@example.com", "first_name": "Dup", "last_name": "User",
+            "email": "elsewhere@example.com", "first_name": "Dup", "last_name": "User",
             "role": "viewer", "timestamp": int(time.time()),
         })
         response = customer_users_create(request)
         self.assertEqual(response.status_code, 400)
-        self.assertIn("already exists", response.data["error"])
+        # Generic message — must not reveal that the user exists in another tenant.
+        self.assertIn("Cannot create", response.data["error"])
+        self.assertNotIn("already", response.data["error"].lower())
+
+    @patch("apps.api.secure_auth.get_authenticated_customer")
+    def test_create_user_already_in_this_customer_returns_409(self, mock_auth):
+        """User already in THIS customer returns 409 with explicit message."""
+        mock_auth.return_value = (self.customer, None)
+        existing = User.objects.create_user(email="member@example.com", password="pass123")
+        CustomerMembership.objects.create(customer=self.customer, user=existing, role="viewer")
+        request = _make_request(self.factory, "/api/customers/users/create/", {
+            "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
+            "email": "member@example.com", "first_name": "Dup", "last_name": "User",
+            "role": "viewer", "timestamp": int(time.time()),
+        })
+        response = customer_users_create(request)
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("already a member", response.data["error"])
 
     @patch("apps.api.secure_auth.get_authenticated_customer")
     def test_create_user_invalid_role_returns_400(self, mock_auth):
@@ -208,6 +227,58 @@ class CustomerUsersCreateAPITests(TestCase):
         })
         response = customer_users_create(request)
         self.assertEqual(response.status_code, 403)
+
+    @patch("apps.api.secure_auth.get_authenticated_customer")
+    def test_create_user_invalid_email_returns_400_before_db_write(self, mock_auth):
+        """Malformed email is rejected by validate_email_secure before any User row is created."""
+        mock_auth.return_value = (self.customer, None)
+        baseline_users = User.objects.count()
+        request = _make_request(self.factory, "/api/customers/users/create/", {
+            "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
+            "email": "notanemail", "first_name": "Bad", "last_name": "Email",
+            "role": "viewer", "timestamp": int(time.time()),
+        })
+        response = customer_users_create(request)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid email", response.data["error"])
+        self.assertEqual(User.objects.count(), baseline_users)
+
+    @patch("apps.api.customers.views.CustomerMembership.objects.create")
+    @patch("apps.api.secure_auth.get_authenticated_customer")
+    def test_create_user_membership_failure_rolls_back_user(self, mock_auth, mock_membership_create):
+        """If CustomerMembership.create raises after User.create_user, the User row must roll back."""
+        mock_auth.return_value = (self.customer, None)
+        mock_membership_create.side_effect = DjangoIntegrityError("simulated FK violation")
+        baseline_users = User.objects.count()
+        request = _make_request(self.factory, "/api/customers/users/create/", {
+            "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
+            "email": "rollback@example.com", "first_name": "Roll", "last_name": "Back",
+            "role": "viewer", "timestamp": int(time.time()),
+        })
+        response = customer_users_create(request)
+        self.assertEqual(response.status_code, 400)
+        # The User row created before the IntegrityError must have rolled back.
+        self.assertEqual(User.objects.count(), baseline_users)
+        self.assertFalse(User.objects.filter(email="rollback@example.com").exists())
+
+    @patch("apps.api.customers.views.SecureCustomerUserService._send_welcome_email_secure")
+    @patch("apps.api.customers.views.get_safe_client_ip")
+    @patch("apps.api.secure_auth.get_authenticated_customer")
+    def test_create_user_propagates_request_ip(self, mock_auth, mock_safe_ip, mock_send_email):
+        """The request_ip from get_safe_client_ip is propagated through to the email helper."""
+        mock_auth.return_value = (self.customer, None)
+        mock_safe_ip.return_value = "203.0.113.42"
+        mock_send_email.return_value = True
+        request = _make_request(self.factory, "/api/customers/users/create/", {
+            "customer_id": self.customer.pk, "user_id": self.owner_user.pk,
+            "email": "ipcheck@example.com", "first_name": "IP", "last_name": "Check",
+            "role": "viewer", "timestamp": int(time.time()),
+        })
+        response = customer_users_create(request)
+        self.assertEqual(response.status_code, 201)
+        # send_welcome_invite forwards request_ip kwarg into _send_welcome_email_secure unchanged.
+        mock_send_email.assert_called_once()
+        self.assertEqual(mock_send_email.call_args.kwargs["request_ip"], "203.0.113.42")
 
 
 class CustomerUsersRoleAPITests(TestCase):

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -3,13 +3,17 @@ Tests for user_management_views security fixes.
 Verifies @staff_required decorator and server-side delete confirmation.
 """
 
+import re
 from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.tokens import default_token_generator
+from django.core import mail
 from django.core.cache import cache
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.utils.http import urlsafe_base64_decode
 
 from apps.customers.models import Customer
 from apps.users.models import CustomerMembership
@@ -305,6 +309,82 @@ class CustomerResendInviteTests(TestCase):
         mock_send.assert_not_called()
         messages_list = [str(m) for m in response.context["messages"]]
         self.assertTrue(any("not a member" in m for m in messages_list))
+
+
+@override_settings(CACHES=LOCMEM_TEST_CACHE)
+class CustomerCreateUserEmailRenderingIntegrationTests(TestCase):
+    """End-to-end: staff create-user POST renders the welcome email template
+    against the live mail backend and produces a usable password-reset token.
+
+    No mocks of _send_welcome_email_secure or send_welcome_invite — this is the
+    only test in the suite that catches template rendering regressions
+    (e.g. a broken {% url %} tag, a misspelled context var, an XSS-unsafe
+    edit). Closes item 5 of issue #173.
+    """
+
+    def setUp(self):
+        cache.clear()
+        mail.outbox = []
+        self.staff_user = User.objects.create_user(
+            email="staff@example.com", password="staffpass", is_staff=True, staff_role="admin"
+        )
+        # company_name is non-empty — required to assert subject contains it.
+        self.customer = Customer.objects.create(
+            name="Render Customer",
+            company_name="Render Co SRL",
+            primary_email="render@co.com",
+            customer_type="company",
+        )
+        self.client = Client()
+        self.url = reverse("customers:create_user", kwargs={"customer_id": self.customer.id})
+
+    def test_create_user_renders_welcome_email_with_valid_reset_token(self):
+        """The full template path runs, mail.outbox receives the message, the
+        embedded password-reset token validates against default_token_generator."""
+        self.client.force_login(self.staff_user)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            response = self.client.post(
+                self.url,
+                {
+                    "email": "newhire@example.com",
+                    "first_name": "New",
+                    "last_name": "Hire",
+                    "role": "viewer",
+                },
+            )
+        self.assertEqual(response.status_code, 302)
+
+        # ---- Outbox shape ----
+        self.assertEqual(len(mail.outbox), 1, "Exactly one email should have been sent")
+        msg = mail.outbox[0]
+        self.assertEqual(msg.to, ["newhire@example.com"])
+        self.assertIn(self.customer.company_name, msg.subject)
+
+        # ---- Plain-text body has the full reset URL ----
+        self.assertIn("/password-reset-confirm/", msg.body)
+
+        # ---- HTML alternative present and references the same URL ----
+        self.assertEqual(len(msg.alternatives), 1)
+        html_body, mimetype = msg.alternatives[0]
+        self.assertEqual(mimetype, "text/html")
+        self.assertIn("/password-reset-confirm/", html_body)
+
+        # ---- Token validity: extract uidb64 + token from the body and verify
+        # against default_token_generator. This is the assertion that fails if
+        # the template renders {{ token }} as a literal string or if the token
+        # was generated for the wrong user. ----
+        match = re.search(r"/password-reset-confirm/([^/]+)/([^/]+)/", msg.body)
+        self.assertIsNotNone(match, "Body must contain /password-reset-confirm/<uidb64>/<token>/ URL")
+        uidb64, token = match.groups()
+
+        decoded_pk = int(urlsafe_base64_decode(uidb64).decode())
+        new_user = User.objects.get(email="newhire@example.com")
+        self.assertEqual(decoded_pk, new_user.pk, "uidb64 in URL must decode to the new user's pk")
+        self.assertTrue(
+            default_token_generator.check_token(new_user, token),
+            "Token in URL must validate against default_token_generator for the new user",
+        )
 
 
 class CustomerDeleteConfirmationTests(TestCase):

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -5,14 +5,25 @@ Verifies @staff_required decorator and server-side delete confirmation.
 
 from unittest.mock import patch
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import Client, TestCase
+from django.core.cache import cache
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from apps.customers.models import Customer
 from apps.users.models import CustomerMembership
+from apps.users.services import SecureCustomerUserService
 
 User = get_user_model()
+
+# Tests that exercise cache-based rate limits need a real cache, not DummyCache.
+LOCMEM_TEST_CACHE = getattr(settings, "LOCMEM_TEST_CACHE", {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "test-cache-isolated",
+    },
+})
 
 
 class UserManagementStaffRequiredTests(TestCase):
@@ -148,6 +159,152 @@ class CustomerCreateUserInviteEmailTests(TestCase):
             messages_list = list(response.context["messages"])
             warning_messages = [m for m in messages_list if m.level_tag == "warning"]
             self.assertTrue(len(warning_messages) >= 1)
+
+
+class CustomerCreateUserSecurityTests(TestCase):
+    """Verify enumeration protection, validation, and rollback on user creation."""
+
+    def setUp(self):
+        cache.clear()
+        self.staff_user = User.objects.create_user(
+            email="staff@example.com", password="staffpass", is_staff=True, staff_role="admin"
+        )
+        self.customer = Customer.objects.create(
+            name="Security Customer", company_name="Sec Co", primary_email="sec@co.com", customer_type="company"
+        )
+        self.client = Client()
+        self.url = reverse("customers:create_user", kwargs={"customer_id": self.customer.id})
+
+    def _post(self, data):
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            return self.client.post(self.url, data, follow=True)
+
+    def test_existing_user_in_other_customer_returns_generic_message(self):
+        """Cross-tenant existing user must NOT be revealed — generic message only."""
+        User.objects.create_user(email="elsewhere@example.com", password="pass123")
+        self.client.force_login(self.staff_user)
+        response = self._post({"email": "elsewhere@example.com", "role": "viewer"})
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("Cannot create" in m for m in messages_list))
+        # Must not say "already" — that would reveal the user exists somewhere.
+        self.assertFalse(any("already" in m.lower() for m in messages_list))
+
+    def test_existing_user_in_this_customer_returns_specific_message(self):
+        """Existing member of THIS customer is allowed-info — specific message OK."""
+        existing = User.objects.create_user(email="member@example.com", password="pass123")
+        CustomerMembership.objects.create(customer=self.customer, user=existing, role="viewer")
+        self.client.force_login(self.staff_user)
+        response = self._post({"email": "member@example.com", "role": "viewer"})
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("already a member" in m for m in messages_list))
+
+    def test_invalid_email_format_rejected_before_db_write(self):
+        """validate_email_secure rejects malformed addresses with no DB writes."""
+        baseline = User.objects.count()
+        self.client.force_login(self.staff_user)
+        response = self._post({"email": "notanemail", "role": "viewer"})
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("valid email" in m.lower() or "invalid" in m.lower() for m in messages_list))
+        self.assertEqual(User.objects.count(), baseline)
+
+
+@override_settings(CACHES=LOCMEM_TEST_CACHE)
+class SendWelcomeInviteRateLimitTests(TestCase):
+    """Per-user cache guard inside SecureCustomerUserService.send_welcome_invite."""
+
+    def setUp(self):
+        cache.clear()
+        self.user = User.objects.create_user(email="invitee@example.com")
+        self.user.set_unusable_password()
+        self.user.save()
+        self.customer = Customer.objects.create(
+            name="Rate Co", company_name="Rate Co", primary_email="rate@co.com", customer_type="company"
+        )
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_rate_limit_blocks_after_threshold(self, mock_send):
+        """After 3 successful sends in an hour, the 4th call is rate-limited and returns False."""
+        mock_send.return_value = True
+        for _ in range(3):
+            self.assertTrue(SecureCustomerUserService.send_welcome_invite(self.user, self.customer))
+        # 4th call must be rejected by the cache guard before the helper is called.
+        self.assertFalse(SecureCustomerUserService.send_welcome_invite(self.user, self.customer))
+        self.assertEqual(mock_send.call_count, 3)
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_failed_send_does_not_consume_quota(self, mock_send):
+        """If the underlying send returns False, the cache counter is NOT incremented."""
+        mock_send.return_value = False
+        for _ in range(5):
+            self.assertFalse(SecureCustomerUserService.send_welcome_invite(self.user, self.customer))
+        # All 5 attempts hit the helper; the guard only counts successful sends.
+        self.assertEqual(mock_send.call_count, 5)
+
+
+class CustomerResendInviteTests(TestCase):
+    """Recovery endpoint for users whose initial invite email failed."""
+
+    def setUp(self):
+        cache.clear()
+        self.staff_user = User.objects.create_user(
+            email="staff@example.com", password="staffpass", is_staff=True, staff_role="admin"
+        )
+        self.customer = Customer.objects.create(
+            name="Resend Co", company_name="Resend Co", primary_email="resend@co.com", customer_type="company"
+        )
+        self.invitee = User.objects.create_user(email="invitee@example.com")
+        self.invitee.set_unusable_password()
+        self.invitee.save()
+        CustomerMembership.objects.create(customer=self.customer, user=self.invitee, role="viewer")
+        self.client = Client()
+        self.url = reverse(
+            "customers:resend_invite",
+            kwargs={"customer_id": self.customer.id, "user_id": self.invitee.id},
+        )
+
+    def _post(self):
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            return self.client.post(self.url, follow=True)
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_resend_invite_for_invitee_with_unusable_password_succeeds(self, mock_send):
+        mock_send.return_value = True
+        self.client.force_login(self.staff_user)
+        response = self._post()
+        mock_send.assert_called_once()
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("resent" in m.lower() for m in messages_list))
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_resend_invite_blocked_for_user_with_usable_password(self, mock_send):
+        """Users who already set a password should use password-reset, not resend-invite."""
+        self.invitee.set_password("realpassword")
+        self.invitee.save()
+        self.client.force_login(self.staff_user)
+        response = self._post()
+        mock_send.assert_not_called()
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("password reset" in m.lower() for m in messages_list))
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_resend_invite_blocked_for_user_not_in_this_customer(self, mock_send):
+        """Staff cannot re-invite a user who isn't a member of this customer."""
+        outsider = User.objects.create_user(email="outsider@example.com")
+        outsider.set_unusable_password()
+        outsider.save()
+        url = reverse(
+            "customers:resend_invite",
+            kwargs={"customer_id": self.customer.id, "user_id": outsider.id},
+        )
+        self.client.force_login(self.staff_user)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=self.customer.id)
+            response = self.client.post(url, follow=True)
+        mock_send.assert_not_called()
+        messages_list = [str(m) for m in response.context["messages"]]
+        self.assertTrue(any("not a member" in m for m in messages_list))
 
 
 class CustomerDeleteConfirmationTests(TestCase):

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -293,6 +293,76 @@ class CustomerResendInviteTests(TestCase):
         self.assertTrue(any("password reset" in m.lower() for m in messages_list))
 
     @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_failure_warning_renders_post_form_not_get_link(self, mock_send):
+        """Regression for codex P1 on PR #184: the resend link in the warning
+        must be an inline POST form (the endpoint is @require_POST). A bare
+        <a href> would 405 when clicked."""
+        # Create the user via the staff create-user flow with email failure.
+        mock_send.return_value = False  # force email failure -> warning rendered
+        staff = User.objects.create_user(
+            email="staff-warn@example.com", password="x", is_staff=True, staff_role="admin"
+        )
+        customer = Customer.objects.create(
+            name="Warn Co", company_name="Warn Co", primary_email="warn@co.com", customer_type="company"
+        )
+        self.client.force_login(staff)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=customer.id)
+            response = self.client.post(
+                reverse("customers:create_user", kwargs={"customer_id": customer.id}),
+                {"email": "warned@example.com", "first_name": "W", "last_name": "U", "role": "viewer"},
+                follow=True,
+            )
+        warnings = [str(m) for m in response.context["messages"] if m.level_tag == "warning"]
+        self.assertEqual(len(warnings), 1)
+        warning_html = warnings[0]
+        # Must be a POST form, NOT a GET link.
+        self.assertIn('method="post"', warning_html)
+        self.assertIn("csrfmiddlewaretoken", warning_html)
+        self.assertNotRegex(warning_html, r'<a\s+href=[^>]*resend-invite')
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_clicking_resend_form_actually_resends(self, mock_send):
+        """End-to-end: extract the action URL from the rendered warning,
+        POST to it, assert the resend endpoint runs successfully."""
+        # First call: initial create — email "fails" so warning is rendered.
+        mock_send.return_value = False
+        staff = User.objects.create_user(
+            email="staff-flow@example.com", password="x", is_staff=True, staff_role="admin"
+        )
+        customer = Customer.objects.create(
+            name="Flow Co", company_name="Flow Co", primary_email="flow@co.com", customer_type="company"
+        )
+        self.client.force_login(staff)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=customer.id)
+            create_response = self.client.post(
+                reverse("customers:create_user", kwargs={"customer_id": customer.id}),
+                {"email": "recovery@example.com", "first_name": "R", "last_name": "U", "role": "viewer"},
+                follow=True,
+            )
+        warnings = [str(m) for m in create_response.context["messages"] if m.level_tag == "warning"]
+        self.assertEqual(len(warnings), 1)
+        warning_html = warnings[0]
+
+        # Pull the form's action URL out of the rendered HTML.
+        action_match = re.search(r'action="([^"]+resend-invite[^"]*)"', warning_html)
+        self.assertIsNotNone(action_match, f"Warning must contain a form action URL: {warning_html}")
+        resend_url = action_match.group(1)
+
+        # Second call: simulate clicking the form's submit button. mock_send
+        # now returns True so the resend reports success.
+        mock_send.return_value = True
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=customer.id)
+            resend_response = self.client.post(resend_url, follow=True)
+        self.assertEqual(resend_response.status_code, 200)
+        success = [str(m) for m in resend_response.context["messages"] if m.level_tag == "success"]
+        self.assertTrue(any("resent" in m.lower() for m in success))
+        # send_welcome_invite was called once for the create + once for the resend.
+        self.assertEqual(mock_send.call_count, 2)
+
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
     def test_resend_invite_blocked_for_user_not_in_this_customer(self, mock_send):
         """Staff cannot re-invite a user who isn't a member of this customer."""
         outsider = User.objects.create_user(email="outsider@example.com")

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -338,21 +338,21 @@ class CustomerCreateUserEmailRenderingIntegrationTests(TestCase):
         self.client = Client()
         self.url = reverse("customers:create_user", kwargs={"customer_id": self.customer.id})
 
+    def _post_create(self, email, customer=None):
+        """Helper: log in as staff and POST a create-user form for the given customer."""
+        target = customer or self.customer
+        self.client.force_login(self.staff_user)
+        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
+            mock.return_value = Customer.objects.filter(id=target.id)
+            return self.client.post(
+                reverse("customers:create_user", kwargs={"customer_id": target.id}),
+                {"email": email, "first_name": "New", "last_name": "Hire", "role": "viewer"},
+            )
+
     def test_create_user_renders_welcome_email_with_valid_reset_token(self):
         """The full template path runs, mail.outbox receives the message, the
         embedded password-reset token validates against default_token_generator."""
-        self.client.force_login(self.staff_user)
-        with patch("apps.customers.customer_service.CustomerService.get_accessible_customers") as mock:
-            mock.return_value = Customer.objects.filter(id=self.customer.id)
-            response = self.client.post(
-                self.url,
-                {
-                    "email": "newhire@example.com",
-                    "first_name": "New",
-                    "last_name": "Hire",
-                    "role": "viewer",
-                },
-            )
+        response = self._post_create("newhire@example.com")
         self.assertEqual(response.status_code, 302)
 
         # ---- Outbox shape ----
@@ -385,6 +385,60 @@ class CustomerCreateUserEmailRenderingIntegrationTests(TestCase):
             default_token_generator.check_token(new_user, token),
             "Token in URL must validate against default_token_generator for the new user",
         )
+
+    def test_individual_customer_renders_name_when_company_name_empty(self):
+        """Customer with empty company_name (individual type) must render the
+        .name fallback so the subject is not 'Account Created for ' and the
+        body is not 'invited to  on PRAHO'. Closes #173 item 3."""
+        individual = Customer.objects.create(
+            name="John Doe",
+            company_name="",
+            primary_email="john@example.com",
+            customer_type="individual",
+        )
+        response = self._post_create("invitee-individual@example.com", customer=individual)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        # Subject and body must contain "John Doe", NOT a trailing-space artifact.
+        self.assertIn("John Doe", msg.subject)
+        self.assertNotRegex(msg.subject, r"Account Created for\s*$")
+        self.assertIn("John Doe", msg.body)
+        # Double-space is the canonical signature of the empty-company-name bug
+        # in the heading "invited to {{ name }} on PRAHO".
+        self.assertNotIn("invited to  on PRAHO", msg.body)
+        # HTML alternative must reflect the same fallback.
+        html_body, _mime = msg.alternatives[0]
+        self.assertIn("John Doe", html_body)
+        self.assertNotIn("invited to  on PRAHO", html_body)
+
+    @override_settings(PASSWORD_RESET_TIMEOUT=14400)  # 4 hours
+    def test_expiry_hours_derives_from_password_reset_timeout(self):
+        """Expiry copy must reflect settings.PASSWORD_RESET_TIMEOUT, not a
+        hardcoded value. Closes #173 item 6."""
+        response = self._post_create("expiry@example.com")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        # Plain text must say "4 hours"; HTML alt must too.
+        self.assertIn("4 hours", msg.body)
+        self.assertNotIn("2 hours", msg.body)
+        self.assertNotIn("3 hours", msg.body)
+        html_body, _mime = msg.alternatives[0]
+        self.assertIn("4 hours", html_body)
+
+    @override_settings(PASSWORD_RESET_TIMEOUT=3600)  # 1 hour — singular form
+    def test_expiry_hours_singular_pluralization(self):
+        """When PASSWORD_RESET_TIMEOUT is exactly 1 hour, the email uses the
+        singular form 'hour' (not 'hours'). Verifies the {% plural %} branch
+        added with the dynamic-expiry refactor."""
+        response = self._post_create("singular@example.com")
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+        msg = mail.outbox[0]
+        # Singular: "expire in 1 hour" — and not "1 hours".
+        self.assertIn("1 hour", msg.body)
+        self.assertNotIn("1 hours", msg.body)
 
 
 class CustomerDeleteConfirmationTests(TestCase):

--- a/services/platform/tests/customers/test_user_management_views.py
+++ b/services/platform/tests/customers/test_user_management_views.py
@@ -245,6 +245,36 @@ class SendWelcomeInviteRateLimitTests(TestCase):
         # All 5 attempts hit the helper; the guard only counts successful sends.
         self.assertEqual(mock_send.call_count, 5)
 
+    @patch("apps.users.services.SecureCustomerUserService._send_welcome_email_secure")
+    def test_atomic_counter_uses_cache_incr_not_set(self, mock_send):
+        """Regression for Copilot finding on PR #184 (services.py:898): the
+        rate-limit counter must use atomic cache.incr, not cache.get+cache.set.
+        We assert this by observing the underlying cache key value after each
+        send — only an atomic increment guarantees correct counts under
+        concurrent calls. (Single-thread test does not exercise concurrency
+        directly; this test pins the implementation to the atomic primitive.)"""
+        mock_send.return_value = True
+        guard_key = f"welcome_invite:{self.user.pk}"
+        # Pre-condition: key absent.
+        self.assertIsNone(cache.get(guard_key))
+
+        SecureCustomerUserService.send_welcome_invite(self.user, self.customer)
+        # After 1st successful send, counter must be exactly 1.
+        self.assertEqual(cache.get(guard_key), 1)
+
+        SecureCustomerUserService.send_welcome_invite(self.user, self.customer)
+        SecureCustomerUserService.send_welcome_invite(self.user, self.customer)
+        self.assertEqual(cache.get(guard_key), 3)
+
+        # 4th call: counter must NOT advance past invite_limit, and the helper
+        # must NOT be called (incr+decr atomic dance).
+        result = SecureCustomerUserService.send_welcome_invite(self.user, self.customer)
+        self.assertFalse(result)
+        # Counter stays at the limit (incr-then-decr leaves us at 3, not 4).
+        self.assertEqual(cache.get(guard_key), 3)
+        # Helper called only 3 times (not for the rate-limited 4th).
+        self.assertEqual(mock_send.call_count, 3)
+
 
 class CustomerResendInviteTests(TestCase):
     """Recovery endpoint for users whose initial invite email failed."""


### PR DESCRIPTION
## Summary

Follow-up to PR #149 (invite-email on customer-user creation). Addresses every finding from the dual review (internal pr-reviewer + codex) and every item from tracking issue #173.

## Changes (6 commits)

- `de56d835` HIGH/MEDIUM hardening: `@throttle_classes([BurstAPIThrottle])`, switch to `SecureInputValidator.validate_email_secure`, public `send_welcome_invite` wrapper with per-user cache guard (3/hour), in-org (409) vs cross-tenant (400 generic) differentiation to close the enumeration oracle.
- `1d2edc4e` Recovery: new staff `POST /customers/<id>/user/<uid>/resend-invite/` endpoint, surfaced inline in the failure warning message.
- `dc25e007` i18n hygiene: `{% blocktrans trimmed %}` everywhere, lead heading with company context.
- `69c5d383` 8 new behavioral tests for the hardening above.
- `2cb5858c` Integration test through `mail.outbox` (closes #173 item 5). Mutation-tested.
- `27e7d2fb` Closes #173 items 2/3/6: consolidate duplicate helper, fix empty-company-name rendering, compute expiry from `PASSWORD_RESET_TIMEOUT`. 3 more integration tests, mutation-tested.

## Closes

Closes #173

## Test plan

- 59/59 tests pass (was 47 on master, +12 in this branch)
- 4 integration tests exercise real template rendering with no mocks
- Each integration test was mutation-tested before commit (RED then GREEN)
- ruff + mypy clean on all modified files

## Issue #173 closure map

| Item | Severity | Commit |
|---|---|---|
| 1. Missing rate limiting | HIGH | de56d835 |
| 2. Duplicate _send_welcome_email_secure | HIGH | 27e7d2fb |
| 3. Empty company_name | MED | 27e7d2fb |
| 4. Private method called externally | MED | de56d835 |
| 5. No integration test for email | MED | 2cb5858c |
| 6. Hardcoded "2 hours" | LOW | 27e7d2fb |
| 7. Email not lowercased | LOW | de56d835 |

Built with Claude Code (/systematic-debugging + /test-driven-development).
