### PR TITLE
fix(notifications): dedupe marketing_consent audit (#182)

### DIFF
--- a/services/platform/apps/customers/signals.py
+++ b/services/platform/apps/customers/signals.py
@@ -751,12 +751,31 @@ def _handle_marketing_consent_change(customer: Customer, old_consent: bool, new_
     """
     consent_action = "granted" if new_consent else "withdrawn"
 
+    # Source attribution: callers (EmailPreferenceService.update_preferences,
+    # process_unsubscribe, admin actions) set instance._consent_source before
+    # save() so the signal records WHERE the change originated. Falls back to
+    # "system" for direct Customer.save() callers (data imports, fixtures,
+    # ad-hoc shell commands). GDPR Art. 7 requires this attribution; collapsing
+    # the prior service-layer log_simple_event call into the signal keeps a
+    # single audit record per consent flip.
+    source = getattr(customer, "_consent_source", "system")
+    category = getattr(customer, "_consent_category", None)
+
+    evidence: dict[str, Any] = {
+        "customer_id": str(customer.id),
+        "old_consent": old_consent,
+        "new_consent": new_consent,
+        "source": source,
+    }
+    if category is not None:
+        evidence["category"] = category
+
     compliance_request = ComplianceEventRequest(
         compliance_type="marketing_consent",
         reference_id=f"customer_{customer.id}",
-        description=f"Marketing consent {consent_action}",
+        description=f"Marketing consent {consent_action} via {source}",
         status="success",
-        evidence={"customer_id": str(customer.id), "old_consent": old_consent, "new_consent": new_consent},
+        evidence=evidence,
     )
 
     try:

--- a/services/platform/apps/notifications/services.py
+++ b/services/platform/apps/notifications/services.py
@@ -1384,13 +1384,17 @@ class EmailPreferenceService:
 
     @staticmethod
     def update_preferences(customer: Customer, preferences: dict[str, bool]) -> None:
-        """Update email preferences for a customer with atomic consent tracking."""
-        from apps.audit.services import AuditService  # noqa: PLC0415
+        """Update email preferences for a customer with atomic consent tracking.
+
+        Source attribution is threaded into the post_save signal via
+        ``_consent_source`` on the locked instance so a single compliance audit
+        record (the signal-driven one in apps.customers.signals) carries the
+        origin. Issue #182 — drops a duplicate service-layer audit call.
+        """
         from apps.customers.models import Customer as CustomerModel  # noqa: PLC0415
 
         with transaction.atomic():
             locked = CustomerModel.objects.select_for_update(of=("self",)).get(id=customer.id)
-            old_marketing = locked.marketing_consent
 
             # "marketing" is the canonical key; "newsletters" is accepted as an alias.
             # If both are present, "marketing" wins so an explicit opt-out cannot be
@@ -1400,26 +1404,11 @@ class EmailPreferenceService:
             elif "newsletters" in preferences:
                 locked.marketing_consent = preferences["newsletters"]
 
+            # The signal compares against the pre-save DB value, so we don't
+            # need to gate the attribution here — if no consent change occurs,
+            # the signal won't emit an audit event regardless.
+            locked._consent_source = "preference_center"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
             locked.save(update_fields=["marketing_consent"])
-
-            if old_marketing != locked.marketing_consent:
-                # Audit is best-effort — never block a GDPR consent change (Art. 7(3))
-                # because of an audit-table failure. Savepoint isolates audit DB writes
-                # so a failure here does not mark the outer transaction for rollback.
-                try:
-                    with transaction.atomic():
-                        AuditService.log_simple_event(
-                            "marketing_consent_granted" if locked.marketing_consent else "marketing_consent_withdrawn",
-                            content_object=locked,
-                            description=f"Email preferences updated for customer {locked.id}",
-                            old_values={"marketing_consent": old_marketing},
-                            new_values={"marketing_consent": locked.marketing_consent},
-                            metadata={"source": "preference_center"},
-                        )
-                except Exception:
-                    logger.exception(
-                        "🔥 [Consent] Audit logging failed for marketing_consent change on customer %s", locked.id
-                    )
 
     @staticmethod
     def can_send_category(customer: Customer, category: str) -> bool:
@@ -1451,7 +1440,6 @@ class EmailPreferenceService:
         Returns:
             True if unsubscribe was successful
         """
-        from apps.audit.services import AuditService  # noqa: PLC0415
         from apps.customers.models import (  # noqa: PLC0415  # Deferred: avoids circular import
             Customer,  # Circular: cross-app  # Deferred: avoids circular import
         )
@@ -1482,26 +1470,13 @@ class EmailPreferenceService:
                     EmailSuppressionService.suppress_email(email, "unsubscribe")
                     return True
 
-                old_marketing = customer.marketing_consent
                 if category == "marketing" or category is None:
                     customer.marketing_consent = False
+                # Source + category are threaded into the post_save signal so
+                # the single compliance audit record records origin (issue #182).
+                customer._consent_source = "unsubscribe_link"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
+                customer._consent_category = category or "all_marketing"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
                 customer.save(update_fields=["marketing_consent"])
-
-                if old_marketing != customer.marketing_consent:
-                    # Audit is best-effort — never block a GDPR consent withdrawal
-                    # (Art. 7(3)) because of an audit-table failure.
-                    try:
-                        with transaction.atomic():
-                            AuditService.log_simple_event(
-                                "marketing_consent_withdrawn",
-                                content_object=customer,
-                                description=f"Unsubscribe via token for {email[:3]}***",
-                                old_values={"marketing_consent": old_marketing},
-                                new_values={"marketing_consent": False},
-                                metadata={"source": "unsubscribe_link", "category": category or "all_marketing"},
-                            )
-                    except Exception:
-                        logger.exception("🔥 [Unsubscribe] Audit logging failed for customer %s", customer.id)
 
                 logger.info(f"✅ [Unsubscribe] Processed for {email[:3]}***")
                 return True

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -245,7 +245,7 @@ class ProcessUnsubscribeTests(TestCase):
             template_key="marketing",
         )
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             result = EmailPreferenceService.process_unsubscribe(
                 str(token.id), "marketing"
             )
@@ -254,60 +254,32 @@ class ProcessUnsubscribeTests(TestCase):
         customer.refresh_from_db()
         self.assertFalse(customer.marketing_consent)
 
+        # Issue #182: a single compliance audit record per consent flip,
+        # carrying source attribution in evidence.
         mock_audit.assert_called_once()
-        call_args = mock_audit.call_args
-        self.assertEqual(call_args.args[0], "marketing_consent_withdrawn")
-        self.assertEqual(call_args.kwargs["content_object"], customer)
-        self.assertEqual(call_args.kwargs["old_values"], {"marketing_consent": True})
-        self.assertEqual(call_args.kwargs["new_values"], {"marketing_consent": False})
-        self.assertEqual(call_args.kwargs["metadata"]["source"], "unsubscribe_link")
-        self.assertEqual(call_args.kwargs["metadata"]["category"], "marketing")
-
-    def test_unsubscribe_audit_failure_does_not_block_consent_withdrawal(self) -> None:
-        """GDPR Art. 7(3): service-layer audit errors must never block a consent withdrawal.
-
-        Note: patching log_simple_event raises a Python exception, which the savepoint
-        catches. It does NOT simulate the full PostgreSQL InFailedSqlTransaction recovery
-        path (that would require a real failed SQL statement inside the savepoint, which
-        is not feasible in a unit test). The savepoint pattern is correct by code reading;
-        this test verifies the Python-level exception handling.
-        """
-        customer = Customer.objects.create(
-            name="Resilient Customer",
-            customer_type="individual",
-            primary_email="resilient@example.com",
-            marketing_consent=True,
-        )
-        token = UnsubscribeToken.objects.create(
-            email="resilient@example.com",
-            template_key="marketing",
-        )
-
-        with patch(
-            "apps.audit.services.AuditService.log_simple_event",
-            side_effect=OperationalError("audit table down"),
-        ):
-            result = EmailPreferenceService.process_unsubscribe(str(token.id), "marketing")
-
-        self.assertTrue(result)
-        customer.refresh_from_db()
-        self.assertFalse(customer.marketing_consent)
+        request = mock_audit.call_args.args[0]
+        self.assertEqual(request.compliance_type, "marketing_consent")
+        self.assertEqual(request.evidence["customer_id"], str(customer.id))
+        self.assertTrue(request.evidence["old_consent"])
+        self.assertFalse(request.evidence["new_consent"])
+        self.assertEqual(request.evidence["source"], "unsubscribe_link")
+        self.assertEqual(request.evidence["category"], "marketing")
 
     def test_unsubscribe_signal_audit_failure_does_not_block_consent_withdrawal(self) -> None:
-        """GDPR Art. 7(3): signal-side audit errors must also not block consent.
+        """GDPR Art. 7(3): signal-side audit errors must not block consent.
 
-        Customer.save() fires post_save → _handle_marketing_consent_change → log_compliance_event.
-        On real Postgres, an OperationalError mid-SQL inside log_compliance_event would mark the
-        connection InFailedSqlTransaction and force a rollback of the outer transaction unless
-        wrapped in a savepoint. This test patches log_compliance_event (the signal-side path),
-        distinct from the log_simple_event test above (the service-layer path).
+        Issue #182 collapsed the duplicate service-layer audit call into the
+        signal handler, so this is now the sole audit path. Customer.save()
+        fires post_save → _handle_marketing_consent_change → log_compliance_event.
+        On real Postgres, an OperationalError mid-SQL would mark the connection
+        InFailedSqlTransaction and force a rollback unless wrapped in a
+        savepoint.
 
-        Test limitation: SQLite does not implement InFailedSqlTransaction state, so this test
-        cannot empirically distinguish "savepoint present" from "savepoint absent" — falsified
-        in this session by removing the savepoint and observing the test still pass. The
-        savepoint is required for production Postgres correctness; this test verifies the
-        Python-level exception flow only. Project-wide test-config limitation, also affects
-        select_for_update() coverage.
+        Test limitation: SQLite does not implement InFailedSqlTransaction
+        state, so this test cannot empirically distinguish "savepoint present"
+        from "savepoint absent". The savepoint is required for production
+        Postgres correctness; this test verifies the Python-level exception
+        flow only.
         """
         customer = Customer.objects.create(
             name="Signal Resilient",
@@ -343,24 +315,27 @@ class UpdatePreferencesTests(TestCase):
         )
 
     def test_update_preferences_persists_marketing_consent(self) -> None:
-        """Setting marketing=True persists and emits a granted audit event."""
+        """Setting marketing=True persists and emits a single compliance audit record with source."""
         customer = self._make_customer(marketing=False)
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
         customer.refresh_from_db()
         self.assertTrue(customer.marketing_consent)
+        # Issue #182: one compliance record with source="preference_center".
         mock_audit.assert_called_once()
-        self.assertEqual(mock_audit.call_args.args[0], "marketing_consent_granted")
-        self.assertEqual(mock_audit.call_args.kwargs["old_values"], {"marketing_consent": False})
-        self.assertEqual(mock_audit.call_args.kwargs["new_values"], {"marketing_consent": True})
+        request = mock_audit.call_args.args[0]
+        self.assertEqual(request.compliance_type, "marketing_consent")
+        self.assertFalse(request.evidence["old_consent"])
+        self.assertTrue(request.evidence["new_consent"])
+        self.assertEqual(request.evidence["source"], "preference_center")
 
     def test_update_preferences_no_audit_when_unchanged(self) -> None:
         """If consent value is unchanged, no audit event is emitted."""
         customer = self._make_customer(marketing=True)
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
         mock_audit.assert_not_called()
@@ -385,29 +360,35 @@ class UpdatePreferencesTests(TestCase):
         customer.refresh_from_db()
         self.assertTrue(customer.marketing_consent)
 
-    def test_update_preferences_audit_failure_does_not_block_consent_change(self) -> None:
-        """GDPR Art. 7(3): service-layer audit errors must never block a consent change.
+    def test_single_compliance_record_per_consent_flip(self) -> None:
+        """Issue #182 acceptance: exactly one ComplianceLog row per consent flip.
 
-        See test_unsubscribe_audit_failure_does_not_block_consent_withdrawal for the
-        note on why a Python-level OperationalError mock is the practical limit of
-        unit testing here.
+        Before the fix, both the post_save signal and the service layer wrote
+        an audit record (ComplianceLog + AuditEvent) for a single consent
+        change, forcing downstream consumers to dedupe. After the fix, the
+        signal is the canonical writer and carries source attribution in
+        evidence.
         """
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
         customer = self._make_customer(marketing=False)
+        before = ComplianceLog.objects.filter(compliance_type="marketing_consent").count()
 
-        with patch(
-            "apps.audit.services.AuditService.log_simple_event",
-            side_effect=OperationalError("audit table down"),
-        ):
-            EmailPreferenceService.update_preferences(customer, {"marketing": True})
+        EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
-        customer.refresh_from_db()
-        self.assertTrue(customer.marketing_consent)
+        new_records = ComplianceLog.objects.filter(compliance_type="marketing_consent").order_by("-id")
+        self.assertEqual(new_records.count() - before, 1)
+        latest = new_records.first()
+        self.assertEqual(latest.evidence["source"], "preference_center")
+        self.assertEqual(latest.evidence["customer_id"], str(customer.id))
+        self.assertTrue(latest.evidence["new_consent"])
 
     def test_update_preferences_signal_audit_failure_does_not_block_consent_change(self) -> None:
-        """GDPR Art. 7(3): signal-side audit errors must also not block consent.
+        """GDPR Art. 7(3): signal-side audit errors must not block consent.
 
-        Counterpart to test_update_preferences_audit_failure: patches log_compliance_event
-        (the customers.signals path) instead of log_simple_event (the service-layer path).
+        Issue #182 made the signal handler the sole audit path for marketing
+        consent on Customer; an OperationalError inside log_compliance_event
+        must not propagate out of update_preferences.
         """
         customer = self._make_customer(marketing=False)
 


### PR DESCRIPTION
Closes #182

## Summary
- Issue #182: marketing-consent change on Customer produced two audit records (signal `log_compliance_event` + service-layer `log_simple_event` from PR #162).
- Thread source attribution through the signal (`instance._consent_source` / `_consent_category`); drop the service-layer audit call.
- Single canonical audit writer is now `apps/customers/signals.py::_handle_marketing_consent_change`, so every consent mutation path (admin, fixtures, imports, direct `Customer.save()`) is captured. Source falls back to `"system"` when not set.
- Quorum decision: option (c) — Gemini 9/10, Codex 9/10, Claude 8/10. Codex specifically flagged option (b) as creating "silent audit gaps" for non-service-layer mutations.

## Test plan
- [x] `pytest tests/notifications/test_unsubscribe_tokens.py` — 26 passed (includes new `test_single_compliance_record_per_consent_flip` acceptance test).
- [x] `mypy apps/customers/signals.py apps/notifications/services.py` — clean.
- [x] `ruff check` — clean.
- [x] Verified pre-existing failures in `tests/customers/` are unrelated (django_fsm `Direct status modification`, Romanian IBAN) — same failures on master.
- [ ] Reviewer: confirm reporting tools that count consent changes still work after dropping `AuditEvent` rows for `marketing_consent_*` actions on Customer (User.accepts_marketing path is unaffected — separate signal in `apps/audit/signals.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)