### PR TITLE
fix(billing): e-Factura submission deadline → working days (OUG 89/2025)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "lxml>=6.0.2",
     "bleach>=6.3.0",
     "python-stdnum>=2.2",
+    "holidays>=0.40",  # Romanian public-holiday calendar for working-day e-Factura deadlines
 ]
 
 # ===============================================================================

--- a/services/platform/apps/billing/efactura/models.py
+++ b/services/platform/apps/billing/efactura/models.py
@@ -409,10 +409,16 @@ class EFacturaDocument(models.Model):
 
     @property
     def submission_deadline(self) -> datetime.datetime | None:
-        """Calculate the submission deadline from invoice issue date."""
+        """Calculate the submission deadline from the invoice issue date.
+
+        OUG 89/2025 (in force since Jan 2026): 5 WORKING days, not calendar days — skipping weekends
+        and Romanian public holidays.
+        """
+        from apps.billing.efactura.working_days import submission_deadline_datetime  # noqa: PLC0415
+
         if self.invoice.issued_at:
             deadline_days = SettingsService.get_integer_setting("billing.efactura_submission_deadline_days", 5)
-            return self.invoice.issued_at + timedelta(days=deadline_days)
+            return submission_deadline_datetime(self.invoice.issued_at, deadline_days)
         return None
 
     @property

--- a/services/platform/apps/billing/efactura/service.py
+++ b/services/platform/apps/billing/efactura/service.py
@@ -365,13 +365,19 @@ class EFacturaService:
 
         deadline_days = SettingsService.get_integer_setting("billing.efactura_submission_deadline_days", 5)
 
-        cutoff = timezone.now() + timedelta(hours=hours)
-        deadline_start = cutoff - timedelta(days=deadline_days)
+        # Coarse pre-filter on issue date: a WORKING-day deadline spans MORE calendar days than the
+        # raw count (weekends + holidays are skipped), so look back generously and let the precise,
+        # working-day-aware is_deadline_approaching check below do the real filtering.
+        # NOTE: `+7` buffer assumes deadline_days <= 5. The worst calendar span for 5 working days
+        # is the Easter cluster (Good Friday + 2 weekends + Easter Monday) = 5 + 4 skipped = 9 days,
+        # plus a 24h warning window comfortably fits in 12 (5+7). If deadline_days is ever raised,
+        # widen this buffer proportionally (rule-of-thumb: deadline_days + max(holiday_cluster_span)).
+        now = timezone.now()
+        lookback = timedelta(days=deadline_days + 7)
 
-        # Find invoices issued within deadline window that don't have accepted e-Factura
         invoices = Invoice.objects.filter(
-            issued_at__gte=deadline_start,
-            issued_at__lte=cutoff - timedelta(days=deadline_days) + timedelta(hours=hours),
+            issued_at__gte=now - lookback,
+            issued_at__lte=now,
             bill_to_country="RO",
             bill_to_tax_id__isnull=False,
             status="issued",

--- a/services/platform/apps/billing/efactura/settings.py
+++ b/services/platform/apps/billing/efactura/settings.py
@@ -231,7 +231,7 @@ EFACTURA_DEFAULTS: dict[str, Any] = {
     EFacturaSettingKeys.B2C_ENABLED: False,  # Mandatory from Jan 2025
     EFacturaSettingKeys.B2C_MINIMUM_AMOUNT: 0,
     EFacturaSettingKeys.B2B_MINIMUM_AMOUNT: 0,
-    # Submission (5 calendar days per Romanian law)
+    # Submission (5 WORKING days per OUG 89/2025; was 5 calendar days pre-2026)
     EFacturaSettingKeys.SUBMISSION_DEADLINE_DAYS: 5,
     EFacturaSettingKeys.DEADLINE_WARNING_HOURS: 24,
     EFacturaSettingKeys.AUTO_SUBMIT_ENABLED: True,
@@ -605,7 +605,7 @@ class EFacturaSettings:
 
     @property
     def submission_deadline_days(self) -> int:
-        """Get submission deadline in calendar days (default: 5)."""
+        """Get submission deadline in WORKING days (OUG 89/2025; default: 5)."""
         return self._get_int(EFacturaSettingKeys.SUBMISSION_DEADLINE_DAYS, 5)
 
     @property
@@ -743,8 +743,10 @@ class EFacturaSettings:
         return dt.astimezone(ROMANIA_TIMEZONE)
 
     def calculate_deadline(self, issued_at: datetime) -> datetime:
-        """Calculate submission deadline from issue date."""
-        return issued_at + timedelta(days=self.submission_deadline_days)
+        """Calculate the WORKING-day submission deadline (OUG 89/2025) from the issue date."""
+        from apps.billing.efactura.working_days import submission_deadline_datetime  # noqa: PLC0415
+
+        return submission_deadline_datetime(issued_at, self.submission_deadline_days)
 
     def is_deadline_approaching(self, issued_at: datetime) -> bool:
         """Check if submission deadline is approaching."""

--- a/services/platform/apps/billing/efactura/working_days.py
+++ b/services/platform/apps/billing/efactura/working_days.py
@@ -1,0 +1,50 @@
+"""Romanian working-day arithmetic for RO e-Factura submission deadlines.
+
+OUG 89/2025 (effective 1 Jan 2026) changed the e-Factura submission deadline from 5 calendar days
+to 5 WORKING days from the invoice issue date (Art. 10 para. 7), with the term computed per
+Regulation (EEC, Euratom) No. 1182/71. Working days skip Saturdays, Sundays, and Romanian public
+holidays — including the moveable Orthodox Easter and Pentecost — via the `holidays` library.
+"""
+
+from __future__ import annotations
+
+import datetime
+from zoneinfo import ZoneInfo
+
+import holidays
+
+ROMANIA_TZ = ZoneInfo("Europe/Bucharest")
+
+# date.weekday() returns 0=Monday..6=Sunday; values < this are working weekdays (Mon-Fri).
+_SATURDAY = 5
+
+
+def add_working_days(start: datetime.date, working_days: int) -> datetime.date:
+    """Return the date `working_days` Romanian working days after `start` (start exclusive).
+
+    Skips Saturdays, Sundays and Romanian public holidays. A non-positive `working_days` returns
+    `start` unchanged. The holiday calendar spans `start`'s year and the next so a year-end deadline
+    that rolls into January still sees January's holidays.
+    """
+    if working_days <= 0:
+        return start
+    cal = holidays.Romania(years=range(start.year, start.year + 2))  # type: ignore[attr-defined]  # no stubs
+    result = start
+    remaining = working_days
+    while remaining > 0:
+        result += datetime.timedelta(days=1)
+        if result.weekday() < _SATURDAY and result not in cal:  # Mon-Fri and not a public holiday
+            remaining -= 1
+    return result
+
+
+def submission_deadline_datetime(issued_at: datetime.datetime, working_days: int) -> datetime.datetime:
+    """Romanian working-day submission deadline as an aware datetime (end of the deadline day in
+    Romania time).
+
+    `issued_at` is first converted to the Romanian LOCAL calendar date so the day boundary is RO
+    time, not UTC — an invoice issued at 23:30 UTC counts from the next Romanian day.
+    """
+    issue_date = issued_at.astimezone(ROMANIA_TZ).date()
+    deadline_date = add_working_days(issue_date, working_days)
+    return datetime.datetime.combine(deadline_date, datetime.time.max, tzinfo=ROMANIA_TZ)

--- a/services/platform/tests/billing/efactura/test_models.py
+++ b/services/platform/tests/billing/efactura/test_models.py
@@ -3,11 +3,13 @@ Tests for EFacturaDocument model.
 """
 
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
 
 from apps.billing.efactura.models import EFacturaDocument, EFacturaDocumentType, EFacturaStatus
+from apps.billing.efactura.working_days import submission_deadline_datetime
 from tests.helpers.fsm_helpers import force_status
 
 
@@ -190,20 +192,36 @@ class EFacturaDocumentModelTestCase(TestCase):
 
         deadline = document.submission_deadline
         self.assertIsNotNone(deadline)
-        expected = self.invoice.issued_at + timedelta(days=5)
-        self.assertEqual(deadline, expected)
+        # OUG 89/2025: 5 WORKING days, not 5 calendar days. The model delegates to the working-day
+        # calculator; the result always lands on a Romanian working day (Mon-Fri, non-holiday) at or
+        # after the old 5-calendar-day mark.
+        self.assertEqual(deadline, submission_deadline_datetime(self.invoice.issued_at, 5))
+        self.assertLess(deadline.weekday(), 5)
+        self.assertGreaterEqual(deadline.date(), (self.invoice.issued_at + timedelta(days=5)).date())
 
     def test_is_deadline_approaching(self):
-        """Test deadline approaching detection."""
-        self.invoice.issued_at = timezone.now() - timedelta(days=4, hours=12)
-        self.invoice.save()
+        """Test deadline approaching detection within the warning window.
 
+        Working-day deadlines (OUG 89/2025) make a calendar-day offset like `days=4, hours=12`
+        unreliable — the 5-working-day deadline can land 5-9 calendar days out depending on
+        which weekends and Romanian holidays the window spans. Pin model-module `timezone.now`
+        to one minute inside the warning window of the actual computed deadline.
+        """
+        self.invoice.issued_at = timezone.now()
+        self.invoice.save()
         document = EFacturaDocument.objects.create(invoice=self.invoice)
-        self.assertTrue(document.is_deadline_approaching)
+
+        deadline = submission_deadline_datetime(self.invoice.issued_at, 5)
+        # Default warning is 24 h (SettingsService default in is_deadline_approaching).
+        now_inside_window = deadline - timedelta(hours=24) + timedelta(minutes=1)
+        with patch("apps.billing.efactura.models.timezone.now", return_value=now_inside_window):
+            self.assertTrue(document.is_deadline_approaching)
 
     def test_is_deadline_passed(self):
         """Test deadline passed detection."""
-        self.invoice.issued_at = timezone.now() - timedelta(days=6)
+        # 21 calendar days back guarantees 5 working days have elapsed regardless of which
+        # weekends/holidays intervened (working-day deadline, OUG 89/2025).
+        self.invoice.issued_at = timezone.now() - timedelta(days=21)
         self.invoice.save()
 
         document = EFacturaDocument.objects.create(invoice=self.invoice)

--- a/services/platform/tests/billing/efactura/test_security.py
+++ b/services/platform/tests/billing/efactura/test_security.py
@@ -303,10 +303,16 @@ class BoundaryConditionTestCase(TestCase):
         self.assertIsNotNone(result)
 
     def test_deadline_exactly_at_boundary(self):
-        """Test deadline calculation exactly at 5 day mark."""
+        """Test deadline-passed crossing at the actual boundary (OUG 89/2025 working days).
+
+        Pin `now` to one second past the deadline the system itself computes, so the test
+        exercises the boundary regardless of how many weekends/holidays the 5-working-day
+        window spans for today's `now`."""
         settings = EFacturaSettings()
-        issued_at = timezone.now() - timedelta(days=5)
-        self.assertTrue(settings.is_deadline_passed(issued_at))
+        issued_at = timezone.now()
+        deadline = settings.calculate_deadline(issued_at)
+        with patch.object(settings, "get_romania_now", return_value=deadline + timedelta(seconds=1)):
+            self.assertTrue(settings.is_deadline_passed(issued_at))
 
     def test_deadline_one_second_before(self):
         """Test deadline calculation one second before."""

--- a/services/platform/tests/billing/efactura/test_settings.py
+++ b/services/platform/tests/billing/efactura/test_settings.py
@@ -305,11 +305,15 @@ class EFacturaSettingsTimezoneTestCase(TestCase):
         self.assertEqual(ro_time.tzinfo, ROMANIA_TIMEZONE)
 
     def test_calculate_deadline(self):
-        """Test deadline calculation."""
+        """Test deadline calculation delegates to the working-day helper (OUG 89/2025)."""
+        from apps.billing.efactura.working_days import submission_deadline_datetime  # noqa: PLC0415
+
         issued_at = timezone.now()
         deadline = self.settings.calculate_deadline(issued_at)
-        expected = issued_at + timedelta(days=5)
-        self.assertEqual(deadline, expected)
+        # Delegation + working-day property: always Mon-Fri, at or after the 5-calendar-day mark.
+        self.assertEqual(deadline, submission_deadline_datetime(issued_at, 5))
+        self.assertLess(deadline.weekday(), 5)
+        self.assertGreaterEqual(deadline.date(), (issued_at + timedelta(days=5)).date())
 
     def test_is_deadline_approaching_false(self):
         """Test deadline not approaching for fresh invoice."""
@@ -317,9 +321,18 @@ class EFacturaSettingsTimezoneTestCase(TestCase):
         self.assertFalse(self.settings.is_deadline_approaching(issued_at))
 
     def test_is_deadline_approaching_true(self):
-        """Test deadline approaching within 24 hours."""
-        issued_at = timezone.now() - timedelta(days=4, hours=1)
-        self.assertTrue(self.settings.is_deadline_approaching(issued_at))
+        """Test deadline approaching within the warning window (24h by default).
+
+        Working-day deadlines (OUG 89/2025) make `issued_at - timedelta(days=4)` unreliable —
+        the actual deadline may be 5-9 calendar days out depending on which weekends/holidays
+        fall in the window. We pin `get_romania_now()` to one minute inside the warning window.
+        """
+        issued_at = timezone.now()
+        deadline = self.settings.calculate_deadline(issued_at)
+        warning_window = timedelta(hours=self.settings.deadline_warning_hours)
+        now_inside_window = deadline - warning_window + timedelta(minutes=1)
+        with patch.object(self.settings, "get_romania_now", return_value=now_inside_window):
+            self.assertTrue(self.settings.is_deadline_approaching(issued_at))
 
     def test_is_deadline_passed_false(self):
         """Test deadline not passed for fresh invoice."""
@@ -327,9 +340,13 @@ class EFacturaSettingsTimezoneTestCase(TestCase):
         self.assertFalse(self.settings.is_deadline_passed(issued_at))
 
     def test_is_deadline_passed_true(self):
-        """Test deadline passed after 5 days."""
-        issued_at = timezone.now() - timedelta(days=6)
-        self.assertTrue(self.settings.is_deadline_passed(issued_at))
+        """Test deadline passed: pin `now` to one second past the actual computed (working-day)
+        deadline so the assertion is independent of how many weekends/holidays the window spans."""
+        issued_at = timezone.now()
+        deadline = self.settings.calculate_deadline(issued_at)
+        now_past_deadline = deadline + timedelta(seconds=1)
+        with patch.object(self.settings, "get_romania_now", return_value=now_past_deadline):
+            self.assertTrue(self.settings.is_deadline_passed(issued_at))
 
 
 class EFacturaSettingsValidationTestCase(TestCase):

--- a/services/platform/tests/billing/efactura/test_working_days.py
+++ b/services/platform/tests/billing/efactura/test_working_days.py
@@ -1,0 +1,90 @@
+"""Tests for Romanian working-day e-Factura deadline arithmetic (OUG 89/2025)."""
+
+from __future__ import annotations
+
+import datetime
+
+import holidays
+from django.test import TestCase
+
+from apps.billing.efactura.working_days import add_working_days, submission_deadline_datetime
+
+
+class WorkingDaysTests(TestCase):
+    def setUp(self):
+        self.cal = holidays.Romania(years=range(2026, 2028))
+
+    def test_result_is_always_a_working_day(self):
+        """Whatever the start date, the deadline lands on a Mon-Fri that is not a RO holiday."""
+        start = datetime.date(2026, 1, 1)
+        for offset in range(0, 366, 5):
+            d = start + datetime.timedelta(days=offset)
+            result = add_working_days(d, 5)
+            self.assertGreater(result, d)
+            self.assertLess(result.weekday(), 5, f"{result} is a weekend")
+            self.assertNotIn(result, self.cal, f"{result} is a Romanian public holiday")
+
+    def test_counts_exactly_n_working_days(self):
+        """Exactly N working days are counted between start (exclusive) and the result (inclusive),
+        including across the Easter / National-Day / Christmas holiday clusters."""
+        for start, n in [
+            (datetime.date(2026, 6, 1), 5),
+            (datetime.date(2026, 4, 9), 3),    # spans Orthodox Good Friday + Easter Monday
+            (datetime.date(2026, 11, 26), 5),  # spans St Andrew (Nov 30) + National Day (Dec 1)
+            (datetime.date(2026, 12, 23), 5),  # spans Christmas
+        ]:
+            result = add_working_days(start, n)
+            counted = 0
+            d = start + datetime.timedelta(days=1)
+            while d <= result:
+                if d.weekday() < 5 and d not in self.cal:
+                    counted += 1
+                d += datetime.timedelta(days=1)
+            self.assertEqual(counted, n, f"{start}+{n}wd -> {result} counted {counted} working days")
+
+    def test_easter_cluster_2026_hand_computed_golden(self):
+        """Hand-computed golden for the Easter 2026 cluster — anchors the algorithm to an
+        independently verified expected value, not to its own output.
+
+        Start: Thursday 2026-04-09. Counting 5 working days, day-by-day:
+          Fri 2026-04-10  Good Friday (HOLIDAY) — skip
+          Sat 2026-04-11  weekend — skip
+          Sun 2026-04-12  weekend — skip
+          Mon 2026-04-13  Easter Monday (HOLIDAY) — skip
+          Tue 2026-04-14  working day  #1
+          Wed 2026-04-15  working day  #2
+          Thu 2026-04-16  working day  #3
+          Fri 2026-04-17  working day  #4
+          Sat 2026-04-18  weekend — skip
+          Sun 2026-04-19  weekend — skip
+          Mon 2026-04-20  working day  #5  ← deadline lands here
+        """
+        self.assertEqual(add_working_days(datetime.date(2026, 4, 9), 5), datetime.date(2026, 4, 20))
+
+    def test_deadline_datetime_is_end_of_day(self):
+        """The submission window ends at the last instant of the deadline day in RO local time
+        (consistent with Reg 1182/71 Art. 3: period ends with the last hour of the last day)."""
+        issued = datetime.datetime(2026, 6, 1, 9, 0, tzinfo=datetime.UTC)
+        deadline = submission_deadline_datetime(issued, 5)
+        self.assertEqual(deadline.time(), datetime.time.max)
+
+    def test_skips_orthodox_easter_monday_2026(self):
+        """The moveable Orthodox Easter Monday (2026-04-13) is a RO public holiday a working-day
+        deadline must never land on."""
+        self.assertIn(datetime.date(2026, 4, 13), self.cal)
+        result = add_working_days(datetime.date(2026, 4, 9), 2)
+        self.assertNotEqual(result, datetime.date(2026, 4, 13))
+        self.assertLess(result.weekday(), 5)
+        self.assertNotIn(result, self.cal)
+
+    def test_zero_or_negative_returns_start(self):
+        d = datetime.date(2026, 6, 15)
+        self.assertEqual(add_working_days(d, 0), d)
+        self.assertEqual(add_working_days(d, -3), d)
+
+    def test_deadline_datetime_uses_romania_local_date(self):
+        """An invoice issued late UTC counts from the next ROMANIAN day, not the UTC day."""
+        # 22:30 UTC on 2026-06-15 is 01:30 on 2026-06-16 in Romania (EEST, UTC+3).
+        issued = datetime.datetime(2026, 6, 15, 22, 30, tzinfo=datetime.UTC)
+        deadline = submission_deadline_datetime(issued, 5)
+        self.assertEqual(deadline.date(), add_working_days(datetime.date(2026, 6, 16), 5))

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,18 @@ wheels = [
 ]
 
 [[package]]
+name = "holidays"
+version = "0.99"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/69/7626f743128513c919ed058530d62a86902099532a86222260b0cfc70d7c/holidays-0.99.tar.gz", hash = "sha256:9ef8278cdfb67dbd93309ec9b30c30609ab35fd57cb207ce4593f80dc91196f5", size = 931630, upload-time = "2026-06-15T20:39:42.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/263e875ca954c44dbd29000a840b43bf875fbf4fdacf9430cd8fc92ad45e/holidays-0.99-py3-none-any.whl", hash = "sha256:bc47cefa781dbc6415e782767dea013794146cc629845354b393c53cdee90c64", size = 1503023, upload-time = "2026-06-15T20:39:40.575Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1784,6 +1796,7 @@ dependencies = [
     { name = "django-ipware" },
     { name = "django-q2" },
     { name = "djangorestframework" },
+    { name = "holidays" },
     { name = "lxml" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
@@ -1891,6 +1904,7 @@ requires-dist = [
     { name = "django-ipware", specifier = ">=7.0.1" },
     { name = "django-q2", specifier = ">=1.9.0" },
     { name = "djangorestframework", specifier = ">=3.16.0" },
+    { name = "holidays", specifier = ">=0.40" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },


### PR DESCRIPTION
## What

OUG 89/2025 amends OUG 120/2021 Art. 10 alin. (7), effective January 2026: the RO e-Factura transmission deadline changes from **5 calendar days** (*5 zile calendaristice*) to **5 working days** (*5 zile lucrătoare*) from the invoice issue date, with the term computed per Regulation (EEC, Euratom) No. 1182/71. Working days skip Saturdays, Sundays and Romanian public holidays — including the moveable Orthodox Easter cluster and Pentecost, which can stretch a 5-working-day window to ~9–12 calendar days.

This swaps every deadline-computation site in the billing app onto a single working-day helper backed by the `holidays` library.

## Changes

- **`apps/billing/efactura/working_days.py`** (new): `add_working_days(start, n)` + `submission_deadline_datetime(issued_at, n)`. The datetime helper normalises `issued_at` to the Romanian local date first (an invoice issued 23:30 UTC counts from the next Romanian day) and returns end-of-day in RO time per Reg 1182/71 Art. 3.
- **`models.py`** `EFacturaDocument.submission_deadline` and **`settings.py`** `EFacturaSettings.calculate_deadline` delegate to the helper instead of `issued_at + timedelta(days=N)`. Setting label + default comment relabelled "working days".
- **`service.py`** `check_approaching_deadlines` widens the coarse SQL pre-filter to `deadline_days + 7` calendar days (precise filtering still runs per-document through the working-day-aware `is_deadline_approaching`); the `+7` buffer assumption is documented inline.
- **Dependency**: `holidays>=0.40` (RO calendar incl. moveable Orthodox Easter/Pentecost).

## Tests

- **`tests/billing/efactura/test_working_days.py`** (new, 7 tests): result-is-always-a-working-day invariant; exact-N-counted across Easter / National-Day / Christmas clusters; **Easter-2026 hand-computed golden** (Thu Apr 9 + 5 wd = Mon Apr 20); end-of-day time anchor; Easter-Monday skip; zero/negative no-op; RO-local-date conversion for late-UTC invoices.
- Existing calendar-day deadline tests in `test_models` / `test_settings` / `test_security` rewritten to be working-day-correct (TDD Inversion Check): boundary `_true` tests now pin `now` relative to the **actual computed deadline** so they pass on every weekday, not just non-Easter ones.

## Verification

- Authoritative source: OUG 89/2025 PDF on static.anaf.ro — Art. X amending Art. 10 alin. (7): *"Termenul-limită [...] este de 5 zile lucrătoare de la data emiterii facturii"*.
- Full billing suite: **2489 tests, 0 failures**. `make check-types` clean on all four source files.

Refs #123 (ANAF compliance — closes the working-days-deadline gap; submission-layer gaps remain, gated on an ANAF SPV account).