### PR TITLE
fix(billing): address codex/copilot review of #202 — submission edge cases (#123)

### DIFF
--- a/services/platform/apps/billing/efactura/client.py
+++ b/services/platform/apps/billing/efactura/client.py
@@ -567,7 +567,7 @@ class EFacturaClient:
         self,
         xml_content: str,
         *,
-        standard: str = "UBL",
+        standard: str | None = None,
         cif: str | None = None,
         extern: bool = False,
         autofactura: bool = False,
@@ -593,7 +593,7 @@ class EFacturaClient:
             return UploadResponse.error("Invalid e-Factura configuration")
 
         params: dict[str, str] = {
-            "standard": standard,
+            "standard": standard or self.config.default_standard,
             "cif": cif or self.config.company_cui,
         }
         if extern:
@@ -607,7 +607,7 @@ class EFacturaClient:
         self,
         xml_content: str,
         *,
-        standard: str = "UBL",
+        standard: str | None = None,
         cif: str | None = None,
     ) -> UploadResponse:
         """Upload a B2C (consumer) invoice via ANAF's ``/uploadb2c`` endpoint.
@@ -621,7 +621,7 @@ class EFacturaClient:
             return UploadResponse.error("Invalid e-Factura configuration")
 
         params: dict[str, str] = {
-            "standard": standard,
+            "standard": standard or self.config.default_standard,
             "cif": cif or self.config.company_cui,
         }
         return self._post_upload("/uploadb2c", params, xml_content)

--- a/services/platform/apps/billing/efactura/service.py
+++ b/services/platform/apps/billing/efactura/service.py
@@ -121,17 +121,31 @@ class EFacturaService:
         if not self._requires_efactura(invoice):
             return SubmissionResult.error("Invoice does not require e-Factura submission")
 
-        # Idempotency: a document already in flight at ANAF (or accepted) must NOT be
-        # re-uploaded — re-POSTing the same fiscal invoice is a compliance hazard. Treat
-        # SUBMITTED / PROCESSING / ACCEPTED as a no-op returning the existing document.
+        # Idempotency / lifecycle decisions BEFORE any work.
         existing = self._get_existing_document(invoice)
         if existing and existing.status in {
             EFacturaStatus.SUBMITTED.value,
             EFacturaStatus.PROCESSING.value,
             EFacturaStatus.ACCEPTED.value,
         }:
+            # Already in flight at ANAF (or accepted) — never re-POST the same fiscal invoice.
             return SubmissionResult.ok(existing)
+        if existing and existing.status == EFacturaStatus.REJECTED.value:
+            # ANAF rejected it; the same document must not be re-uploaded (duplicate POST). The
+            # invoice must be corrected and a NEW e-Factura document created.
+            return SubmissionResult.error(
+                "Invoice was rejected by ANAF; correct it and submit a new e-Factura document"
+            )
 
+        # B2C (consumer) invoices need a CNP-buyer XML the B2B UBLInvoiceBuilder cannot produce
+        # (it rejects RO invoices without a CUI). Reject cleanly BEFORE generating XML instead of
+        # failing confusingly in the builder; upload_b2c() stays ready for the B2C builder (#123).
+        if self._is_b2c(invoice):
+            return SubmissionResult.error(
+                "B2C e-Factura submission is not yet supported (requires the B2C XML builder + live ANAF verification)"
+            )
+
+        document = existing  # so the except blocks can mark the just-created document as error
         try:
             # Create or update document
             document = self._get_or_create_document(invoice)
@@ -162,11 +176,8 @@ class EFacturaService:
                         errors=error_dicts,
                     )
 
-            # Submit to ANAF. Route consumer (B2C) invoices to /uploadb2c; everything else is B2B.
-            if self._is_b2c(invoice):
-                response = self._client.upload_b2c(xml_content)
-            else:
-                response = self._client.upload_invoice(xml_content)
+            # Submit to ANAF (B2B /upload; B2C is rejected earlier until the B2C XML builder exists).
+            response = self._client.upload_invoice(xml_content)
 
             if response.success:
                 document.mark_submitted(response.upload_index)
@@ -182,30 +193,30 @@ class EFacturaService:
 
         except XMLBuilderError as e:
             logger.error(f"XML generation failed for invoice {invoice.number}: {e}")
-            if existing:
-                existing.mark_error(str(e))
-                existing.save()
+            if document:
+                document.mark_error(str(e))
+                document.save()
             return SubmissionResult.error(f"XML generation failed: {e}")
 
         except AuthenticationError as e:
             logger.error(f"Authentication failed for invoice {invoice.number}: {e}")
-            if existing:
-                existing.mark_error(str(e))
-                existing.save()
+            if document:
+                document.mark_error(str(e))
+                document.save()
             return SubmissionResult.error(f"Authentication failed: {e}")
 
         except NetworkError as e:
             logger.error(f"Network error for invoice {invoice.number}: {e}")
-            if existing:
-                existing.mark_error(str(e))
-                existing.save()
+            if document:
+                document.mark_error(str(e))
+                document.save()
             return SubmissionResult.error(f"Network error: {e}")
 
         except Exception as e:
             logger.exception(f"Unexpected error submitting invoice {invoice.number}")
-            if existing:
-                existing.mark_error(str(e))
-                existing.save()
+            if document:
+                document.mark_error(str(e))
+                document.save()
             return SubmissionResult.error(f"Unexpected error: {e}")
 
     def check_status(self, document: EFacturaDocument) -> StatusCheckResult:

--- a/services/platform/tests/billing/efactura/test_client.py
+++ b/services/platform/tests/billing/efactura/test_client.py
@@ -498,6 +498,23 @@ class EFacturaClientTestCase(TestCase):
         self.assertEqual(headers["Content-Type"], "text/plain")
 
     @patch("apps.billing.efactura.client.EFacturaClient._get_access_token")
+    @patch("apps.billing.efactura.client.EFacturaClient._request_with_retry")
+    def test_upload_uses_configured_standard(self, mock_request, mock_token):
+        """#202 review (P2): EFACTURA_UPLOAD_STANDARD must actually be sent, not hardcoded UBL."""
+        mock_token.return_value = "test-token"
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = (_FIXTURES / "anaf_upload_ok.xml").read_text(encoding="utf-8")
+        mock_response.json.side_effect = json.JSONDecodeError("not json", "", 0)
+        mock_request.return_value = mock_response
+
+        self.client.config.default_standard = "FACT1"
+        self.client.upload_invoice("<Invoice/>")
+
+        params = mock_request.call_args.kwargs["params"]
+        self.assertEqual(params["standard"], "FACT1")
+
+    @patch("apps.billing.efactura.client.EFacturaClient._get_access_token")
     def test_upload_no_token(self, mock_token):
         """Test upload when no token available."""
         mock_token.side_effect = AuthenticationError("No token")

--- a/services/platform/tests/billing/efactura/test_service.py
+++ b/services/platform/tests/billing/efactura/test_service.py
@@ -727,11 +727,12 @@ class SubmissionLifecycleTests(TestCase):
         self.assertEqual(doc.status, EFacturaStatus.SUBMITTED.value)
         self.assertEqual(doc.anaf_upload_index, "IDX-4")
 
-    def test_submit_routes_b2c_invoice_to_uploadb2c(self):
-        """Gap 3 (#123): a B2C invoice is submitted via upload_b2c(), not upload_invoice()."""
+    def test_b2c_invoice_returns_clear_not_supported_error(self):
+        """#202 review (codex P1): the B2B UBLInvoiceBuilder rejects a no-CUI RO invoice, so a real
+        B2C submission failed in _generate_xml before ever reaching upload_b2c (the routing was only
+        exercised by mocked tests). B2C must now be rejected cleanly BEFORE XML generation."""
         invoice = self._ro_invoice("INV-B2C-1")
         client = Mock(spec=EFacturaClient)
-        client.upload_b2c.return_value = UploadResponse(success=True, upload_index="B2C-1")
         service = EFacturaService(client=client)
 
         with patch.object(service, "_generate_xml", return_value="<Invoice/>"), patch.object(
@@ -739,11 +740,54 @@ class SubmissionLifecycleTests(TestCase):
         ), patch.object(service, "_is_b2c", return_value=True):
             result = service.submit_invoice(invoice)
 
-        self.assertTrue(result.success, msg=result.error_message)
-        client.upload_b2c.assert_called_once()
+        self.assertFalse(result.success)
+        self.assertIn("b2c", result.error_message.lower())
+        client.upload_b2c.assert_not_called()
         client.upload_invoice.assert_not_called()
+
+    def test_fresh_failure_marks_new_document_as_error_not_queued(self):
+        """#202 review (codex P2): a fresh submission that fails AFTER queue-before-upload must mark
+        the NEW document `error` (with backoff), not leave it `queued` where
+        process_pending_submissions hot-retries it forever without incrementing retry_count."""
+        invoice = self._ro_invoice("INV-FAIL-1")
+        client = Mock(spec=EFacturaClient)
+        client.upload_invoice.side_effect = NetworkError("boom")
+        service = EFacturaService(client=client)
+
+        with patch.object(service, "_generate_xml", return_value="<Invoice/>"), patch.object(
+            service, "_log_audit_event"
+        ), patch.object(service, "_is_b2c", return_value=False):
+            result = service.submit_invoice(invoice)
+
+        self.assertFalse(result.success)
         doc = EFacturaDocument.objects.get(invoice=invoice)
-        self.assertEqual(doc.anaf_upload_index, "B2C-1")
+        self.assertEqual(doc.status, EFacturaStatus.ERROR.value)
+        self.assertGreaterEqual(doc.retry_count, 1)
+
+    def test_rejected_document_is_not_resubmitted(self):
+        """#202 review (copilot): submit_invoice on an ANAF-rejected doc must NOT re-POST (duplicate
+        submission) — it returns a clear error directing a corrected resubmission."""
+        invoice = self._ro_invoice("INV-REJ-1")
+        doc = EFacturaDocument.objects.create(
+            invoice=invoice, document_type=EFacturaDocumentType.INVOICE.value
+        )
+        doc.mark_queued()
+        doc.save()
+        doc.mark_submitted("IDX-R")
+        doc.save()
+        doc.mark_rejected([{"message": "bad"}])
+        doc.save()
+        client = Mock(spec=EFacturaClient)
+        service = EFacturaService(client=client)
+
+        with patch.object(service, "_generate_xml", return_value="<Invoice/>"), patch.object(
+            service, "_log_audit_event"
+        ):
+            result = service.submit_invoice(invoice)
+
+        self.assertFalse(result.success)
+        client.upload_invoice.assert_not_called()
+        client.upload_b2c.assert_not_called()
 
     def test_submit_routes_b2b_invoice_to_upload(self):
         """A B2B invoice (the default) goes to upload_invoice(), not upload_b2c()."""


### PR DESCRIPTION
Follow-up to the merged #202, addressing the codex + copilot review comments. Four **real** issues (verified against code, fixed with TDD):

1. **Hot-retry-loop regression (codex P2, mine).** Phase 0's queue-before-upload left a *fresh* doc in `queued` when a later step raised — the `except` blocks only marked `existing` (None on first submit) — so `process_pending_submissions` re-picked it every cycle without incrementing `retry_count`. Fixed: mark the created `document` as `error` (with backoff) in all four except blocks.
2. **Rejected-doc re-upload (copilot).** A `rejected` doc was neither short-circuited nor queueable → duplicate POST + failed transition. Fixed: clean "correct it and submit a new document" error before any upload.
3. **B2C routing after XML generation (codex P1).** The B2B `UBLInvoiceBuilder` rejects a no-CUI RO invoice, so real B2C failed in `_generate_xml` before reaching `upload_b2c` (only mocked tests exercised it). Fixed: reject B2C cleanly *before* generating XML with an explicit "not yet supported" message; `upload_b2c()` stays ready for the CNP-buyer builder.
4. **`EFACTURA_UPLOAD_STANDARD` was dead (codex P2, mine).** `upload_invoice`/`upload_b2c` now default `standard` from `config.default_standard` instead of hardcoding `"UBL"`.

**Tests:** inverted the now-wrong B2C routing test (Check 6); DB-backed tests for fresh-failure-marks-error and rejected-not-resubmitted; configured-standard assertion. efactura suite **546 OK**; lint + check-types clean.

Refs #123.