### PR TITLE
feat(common): tri-state Retriability signal on Result, with review hardening (#121)

### DIFF
--- a/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
+++ b/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
@@ -60,8 +60,16 @@ class Ok(Generic[T]):
 @dataclass(frozen=True)
 class Err(Generic[E]):
     error: E
+    retriability: Retriability = Retriability.UNKNOWN  # see below
 
 Result = Union[Ok[T], Err[E]]
+
+
+# Tri-state retriability signal (issue #121)
+class Retriability(StrEnum):
+    RETRIABLE = "retriable"          # caller knows transient (DB timeout, 5xx)
+    NOT_RETRIABLE = "not_retriable"  # caller knows permanent (validation, 4xx)
+    UNKNOWN = "unknown"              # caller did not classify (default)
 
 # Romanian Business Domain Types
 CUIString = str  # Romanian CUI format: "RO12345678"

--- a/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
+++ b/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
@@ -57,19 +57,19 @@ We implemented a **3-Phase Comprehensive Type Safety Strategy** using MyPy stric
 class Ok(Generic[T]):
     value: T
 
-@dataclass(frozen=True)
-class Err(Generic[E]):
-    error: E
-    retriability: Retriability = Retriability.UNKNOWN  # see below
-
-Result = Union[Ok[T], Err[E]]
-
-
 # Tri-state retriability signal (issue #121)
 class Retriability(StrEnum):
     RETRIABLE = "retriable"          # caller knows transient (DB timeout, 5xx)
     NOT_RETRIABLE = "not_retriable"  # caller knows permanent (validation, 4xx)
     UNKNOWN = "unknown"              # caller did not classify (default)
+
+
+@dataclass(frozen=True)
+class Err(Generic[E]):
+    error: E
+    retriability: Retriability = Retriability.UNKNOWN
+
+Result = Union[Ok[T], Err[E]]
 
 # Romanian Business Domain Types
 CUIString = str  # Romanian CUI format: "RO12345678"

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -11,7 +11,7 @@ import uuid
 from decimal import Decimal
 from typing import Any, TypedDict
 
-from django.db import DatabaseError, IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, InterfaceError, OperationalError, transaction
 from django.db.models import Count, Q, Sum
 from django_fsm import ConcurrentTransition, TransitionNotAllowed
 
@@ -161,9 +161,15 @@ class RefundService:
             return Ok(order)
         except Order.DoesNotExist:
             return Err("Failed to process refund: Order not found")
-        except Exception:
-            logger.exception("Order lookup for refund failed for order_id=%s", order_id)
+        except (OperationalError, InterfaceError):
+            # Connection drops and deadlocks are the genuinely transient DB failures.
+            logger.exception("Order lookup for refund hit a transient DB error for order_id=%s", order_id)
             return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
+        except Exception:
+            # Unclassified failures (e.g. a malformed id) repeat on every attempt —
+            # stay at the UNKNOWN default rather than asserting retriability.
+            logger.exception("Order lookup for refund failed for order_id=%s", order_id)
+            return Err("Failed to process refund: database error")
 
     @staticmethod
     def _validate_order_refund(order: Any, refund_data: RefundData) -> Result[None, str]:
@@ -318,9 +324,14 @@ class RefundService:
             return Ok(invoice)
         except Invoice.DoesNotExist:
             return Err("Failed to process refund: Invoice not found")
-        except Exception:
-            logger.exception("Invoice lookup for refund failed for invoice_id=%s", invoice_id)
+        except (OperationalError, InterfaceError):
+            # Connection drops and deadlocks are the genuinely transient DB failures.
+            logger.exception("Invoice lookup for refund hit a transient DB error for invoice_id=%s", invoice_id)
             return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
+        except Exception:
+            # Unclassified failures repeat on every attempt — stay at the UNKNOWN default.
+            logger.exception("Invoice lookup for refund failed for invoice_id=%s", invoice_id)
+            return Err("Failed to process refund: database error")
 
     @staticmethod
     def _validate_invoice_refund(invoice: Any, refund_data: RefundData) -> Result[None, str]:

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -17,7 +17,7 @@ from django_fsm import ConcurrentTransition, TransitionNotAllowed
 
 from apps.billing.gateways.base import GATEWAY_PAYMENT_METHODS, PaymentGatewayFactory
 from apps.billing.models import Currency, Invoice, Refund, RefundStatusHistory, log_security_event
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability
 from apps.orders.models import Order
 
 logger = logging.getLogger(__name__)
@@ -163,7 +163,7 @@ class RefundService:
             return Err("Failed to process refund: Order not found")
         except Exception:
             logger.exception("Order lookup for refund failed for order_id=%s", order_id)
-            return Err("Failed to process refund: database error")
+            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
 
     @staticmethod
     def _validate_order_refund(order: Any, refund_data: RefundData) -> Result[None, str]:
@@ -320,7 +320,7 @@ class RefundService:
             return Err("Failed to process refund: Invoice not found")
         except Exception:
             logger.exception("Invoice lookup for refund failed for invoice_id=%s", invoice_id)
-            return Err("Failed to process refund: database error")
+            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
 
     @staticmethod
     def _validate_invoice_refund(invoice: Any, refund_data: RefundData) -> Result[None, str]:

--- a/services/platform/apps/billing/stripe_metering.py
+++ b/services/platform/apps/billing/stripe_metering.py
@@ -32,16 +32,23 @@ from .subscription_models import Subscription
 logger = logging.getLogger(__name__)
 
 
-# Stripe error class names that indicate a transient failure.
-# Names rather than imports because the stripe module is loaded lazily.
-_RETRIABLE_STRIPE_ERROR_NAMES = frozenset({"RateLimitError", "APIConnectionError", "Timeout", "TryAgain", "APIError"})
-# Stripe error class names that indicate a permanent failure (4xx semantics).
+# Stripe error class names whose failure is provably safe to replay. Only the two
+# cases where Stripe did NOT process the request qualify: RateLimitError (rejected
+# before processing) and APIConnectionError (the request never reached Stripe).
+# Names rather than imports because the stripe module is loaded lazily; every name
+# here must exist in stripe._error (guarded by
+# tests/billing/test_stripe_error_classification.py).
+# Deliberately UNKNOWN, not RETRIABLE: APIError (generic 5xx — the mutation may have
+# committed server-side; blind replay of a non-idempotent POST could double-create).
+_RETRIABLE_STRIPE_ERROR_NAMES = frozenset({"RateLimitError", "APIConnectionError"})
+# Stripe error class names that indicate an unambiguously permanent failure (4xx).
+# Deliberately UNKNOWN, not NOT_RETRIABLE: CardError (Stripe's advice is per-decline —
+# either try_again_later or do_not_try_again — so it can't be classified blind).
 _NOT_RETRIABLE_STRIPE_ERROR_NAMES = frozenset(
     {
         "InvalidRequestError",
         "AuthenticationError",
         "PermissionError",
-        "CardError",
         "IdempotencyError",
         "SignatureVerificationError",
     }

--- a/services/platform/apps/billing/stripe_metering.py
+++ b/services/platform/apps/billing/stripe_metering.py
@@ -24,12 +24,44 @@ from django.db import transaction
 from django.utils import timezone
 from django_fsm import TransitionNotAllowed
 
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability
 
 from .metering_models import BillingCycle, UsageAggregation, UsageMeter
 from .subscription_models import Subscription
 
 logger = logging.getLogger(__name__)
+
+
+# Stripe error class names that indicate a transient failure.
+# Names rather than imports because the stripe module is loaded lazily.
+_RETRIABLE_STRIPE_ERROR_NAMES = frozenset({"RateLimitError", "APIConnectionError", "Timeout", "TryAgain", "APIError"})
+# Stripe error class names that indicate a permanent failure (4xx semantics).
+_NOT_RETRIABLE_STRIPE_ERROR_NAMES = frozenset(
+    {
+        "InvalidRequestError",
+        "AuthenticationError",
+        "PermissionError",
+        "CardError",
+        "IdempotencyError",
+        "SignatureVerificationError",
+    }
+)
+
+
+def _classify_stripe_error(exc: BaseException) -> Retriability:
+    """Map a stripe exception to its retriability via class-name lookup.
+
+    Class names are used (not isinstance) because importing ``stripe.error.*``
+    at module load would defeat the lazy ``get_stripe()`` pattern. Unknown
+    StripeError subclasses fall back to UNKNOWN — the caller can still log
+    them but consumers will not auto-retry.
+    """
+    name = type(exc).__name__
+    if name in _RETRIABLE_STRIPE_ERROR_NAMES:
+        return Retriability.RETRIABLE
+    if name in _NOT_RETRIABLE_STRIPE_ERROR_NAMES:
+        return Retriability.NOT_RETRIABLE
+    return Retriability.UNKNOWN
 
 
 def get_stripe() -> Any:
@@ -91,7 +123,7 @@ class StripeMeterService:
 
         except self.stripe.error.StripeError as e:
             logger.error(f"Stripe error creating meter: {e}")
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
         except Exception as e:
             logger.exception(f"Error creating Stripe Meter: {e}")
             return Err(str(e))
@@ -105,7 +137,7 @@ class StripeMeterService:
             meter = self.stripe.billing.Meter.retrieve(meter_id)
             return Ok(meter)
         except self.stripe.error.StripeError as e:
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
     def list_meters(self, limit: int = 100) -> Result[Any, str]:
         """List all Stripe Meters"""
@@ -116,7 +148,7 @@ class StripeMeterService:
             meters = self.stripe.billing.Meter.list(limit=limit)
             return Ok(list(meters.data))
         except self.stripe.error.StripeError as e:
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
     def deactivate_meter(self, meter_id: str) -> Result[Any, str]:
         """Deactivate a Stripe Meter"""
@@ -128,7 +160,7 @@ class StripeMeterService:
             logger.info(f"Deactivated Stripe Meter: {meter_id}")
             return Ok(meter)
         except self.stripe.error.StripeError as e:
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
 
 class StripeMeterEventService:
@@ -202,7 +234,7 @@ class StripeMeterEventService:
 
         except self.stripe.error.StripeError as e:
             logger.error(f"Stripe error reporting usage: {e}")
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
         except Exception as e:
             logger.exception(f"Error reporting usage to Stripe: {e}")
             return Err(str(e))
@@ -294,7 +326,7 @@ class StripeSubscriptionMeterService:
 
         except self.stripe.error.StripeError as e:
             logger.error(f"Stripe error creating subscription: {e}")
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
     def add_metered_item(self, subscription_id: str, price_id: str) -> Result[Any, str]:
         """Add a metered item to an existing subscription"""
@@ -317,7 +349,7 @@ class StripeSubscriptionMeterService:
             )
 
         except self.stripe.error.StripeError as e:
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
     def get_usage_summary(
         self, subscription_item_id: str, start_time: datetime | None = None, end_time: datetime | None = None
@@ -356,7 +388,7 @@ class StripeSubscriptionMeterService:
             )
 
         except self.stripe.error.StripeError as e:
-            return Err(str(e))
+            return Err(str(e), retriability=_classify_stripe_error(e))
 
 
 class StripeUsageSyncService:

--- a/services/platform/apps/common/types.py
+++ b/services/platform/apps/common/types.py
@@ -95,6 +95,14 @@ class Retriability(StrEnum):
     "caller did not assert" as "definitely not retriable" — the most dangerous
     wrong answer for transient infrastructure errors.
 
+    ``RETRIABLE`` asserts more than "the failure was transient": it asserts the
+    request was **provably not applied** and is therefore safe to replay (e.g. a
+    rate-limit rejection before processing, a connection that never reached the
+    server, a read-only lookup). A transient failure of a *non-idempotent
+    mutating* operation — a timed-out reboot, a POST whose response was lost — is
+    ``UNKNOWN``, not ``RETRIABLE``, because the operation may already have taken
+    effect; only registrar/provider idempotency or reconciliation upgrades it.
+
     Consumers choose policy per-workflow:
       - Non-idempotent paths (payments, provisioning) treat ``UNKNOWN`` as
         "do not retry" — fail closed.

--- a/services/platform/apps/common/types.py
+++ b/services/platform/apps/common/types.py
@@ -84,11 +84,54 @@ class Ok[T]:
         raise ValueError(f"Called unwrap_err on Ok: {self.value}")
 
 
+class Retriability(StrEnum):
+    """Tri-state signal for whether an Err might succeed on retry.
+
+    Three states are needed because most ``Err(...)`` producers in the codebase
+    are bare ``except Exception as e: return Err(str(e))`` patterns that cannot
+    distinguish transient from permanent failures at construction time. A
+    ``bool`` collapses ``NOT_RETRIABLE`` and ``UNKNOWN`` into the same value,
+    which causes consumers reading ``retriable == False`` to silently treat
+    "caller did not assert" as "definitely not retriable" — the most dangerous
+    wrong answer for transient infrastructure errors.
+
+    Consumers choose policy per-workflow:
+      - Non-idempotent paths (payments, provisioning) treat ``UNKNOWN`` as
+        "do not retry" — fail closed.
+      - Idempotent reads can treat ``UNKNOWN`` as "retry once with backoff".
+      - ``RETRIABLE`` is always safe to retry; ``NOT_RETRIABLE`` is never.
+    """
+
+    RETRIABLE = "retriable"
+    NOT_RETRIABLE = "not_retriable"
+    UNKNOWN = "unknown"
+
+
 @dataclass(frozen=True)
 class Err[E]:
-    """Error result containing an error value"""
+    """Error result containing an error value.
+
+    ``retriability`` signals whether the operation that produced this error
+    might succeed on retry. Default is ``Retriability.UNKNOWN`` so legacy
+    ``Err("...")`` call sites do not falsely assert permanence — see
+    ``Retriability`` for the three states and consumer policy.
+
+    Use ``is_retriable`` for the conservative "should I retry?" check (only
+    ``RETRIABLE`` returns True; ``UNKNOWN`` and ``NOT_RETRIABLE`` return False).
+    """
 
     error: E
+    retriability: Retriability = Retriability.UNKNOWN
+
+    @property
+    def is_retriable(self) -> bool:
+        """True only when the producer explicitly asserted ``RETRIABLE``.
+
+        ``UNKNOWN`` returns False so non-idempotent consumers (payments,
+        provisioning) fail closed by default. Idempotent consumers that want
+        to retry on UNKNOWN should check ``retriability`` directly.
+        """
+        return self.retriability == Retriability.RETRIABLE
 
     def is_ok(self) -> bool:
         return False
@@ -119,6 +162,20 @@ class Err[E]:
 
 # Result type alias
 Result = Ok[T] | Err[E]
+
+
+def retriability_of(result: Result[Any, Any]) -> Retriability:
+    """Return the retriability of an ``Err`` result, or ``UNKNOWN`` for ``Ok``.
+
+    Convenience for sites that re-wrap an inner ``Err`` into an outer ``Err``
+    and want to propagate the retriability signal without manually narrowing
+    the union type. ``Ok`` returns ``UNKNOWN`` because there is no error to
+    classify; callers in the ``Ok`` branch should not be using this.
+    """
+    if isinstance(result, Err):
+        return result.retriability
+    return Retriability.UNKNOWN
+
 
 # ===============================================================================
 # TYPE VARIABLES

--- a/services/platform/apps/infrastructure/provider_config.py
+++ b/services/platform/apps/infrastructure/provider_config.py
@@ -29,7 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from apps.common.types import Err, Ok, Result, Retriability
+from apps.common.types import Err, Ok, Result
 
 if TYPE_CHECKING:
     from apps.infrastructure.models import CloudProvider
@@ -332,8 +332,11 @@ def run_provider_command(  # Complexity: multi-step workflow  # noqa: PLR0911  #
         return Ok(cmd_result)
 
     except subprocess.TimeoutExpired:
+        # This runner executes state-changing ops (reboot, resize, power_off); a
+        # timed-out command may have already executed server-side, so replay is not
+        # provably safe — UNKNOWN, not RETRIABLE.
         logger.error(f"[Provider:{provider_type}] {operation} timed out after {timeout}s")
-        return Err(f"Command timed out after {timeout} seconds", retriability=Retriability.RETRIABLE)
+        return Err(f"Command timed out after {timeout} seconds")
 
     except Exception as e:
         logger.exception(f"[Provider:{provider_type}] {operation} failed: {e}")

--- a/services/platform/apps/infrastructure/provider_config.py
+++ b/services/platform/apps/infrastructure/provider_config.py
@@ -29,7 +29,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability
 
 if TYPE_CHECKING:
     from apps.infrastructure.models import CloudProvider
@@ -333,7 +333,7 @@ def run_provider_command(  # Complexity: multi-step workflow  # noqa: PLR0911  #
 
     except subprocess.TimeoutExpired:
         logger.error(f"[Provider:{provider_type}] {operation} timed out after {timeout}s")
-        return Err(f"Command timed out after {timeout} seconds")
+        return Err(f"Command timed out after {timeout} seconds", retriability=Retriability.RETRIABLE)
 
     except Exception as e:
         logger.exception(f"[Provider:{provider_type}] {operation} failed: {e}")

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 
 from apps.common.encryption import DecryptionError
 from apps.common.outbound_http import OutboundPolicy, safe_request
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability
 from apps.settings.services import SettingsService
 
 from .virtualmin_models import VirtualminServer
@@ -748,7 +748,10 @@ class VirtualminGateway:
 
         # Rate limiting check
         if not self._check_rate_limit(program):
-            return Err(VirtualminRateLimitedError(f"Rate limit exceeded for {program}", self.server.hostname, program))
+            return Err(
+                VirtualminRateLimitedError(f"Rate limit exceeded for {program}", self.server.hostname, program),
+                retriability=Retriability.RETRIABLE,
+            )
 
         # Prepare request parameters
         api_params = {"program": program, **params}
@@ -809,7 +812,10 @@ class VirtualminGateway:
 
         logger.error(f"❌ [Virtualmin] {program} failed after {execution_time:.2f}s: {error_msg}")
 
-        return Err(VirtualminTransientError(error_msg, self.server.hostname, program))
+        return Err(
+            VirtualminTransientError(error_msg, self.server.hostname, program),
+            retriability=Retriability.RETRIABLE,
+        )
 
     def _make_request(self, params: dict[str, Any], attempt: int) -> requests.Response:
         """
@@ -931,10 +937,10 @@ class VirtualminGateway:
                 )
             else:
                 error = result.unwrap_err()
-                return Err(f"Connection test failed: {error}")
+                return Err(f"Connection test failed: {error}", retriability=Retriability.RETRIABLE)
 
         except Exception as e:
-            return Err(f"Connection test error: {e}")
+            return Err(f"Connection test error: {e}", retriability=Retriability.RETRIABLE)
 
     def get_server_info(self) -> Result[dict[str, Any], str]:
         """Get server information and statistics"""

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -28,7 +28,7 @@ from django.utils import timezone
 
 from apps.common.encryption import DecryptionError
 from apps.common.outbound_http import OutboundPolicy, safe_request
-from apps.common.types import Err, Ok, Result, Retriability
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 from apps.settings.services import SettingsService
 
 from .virtualmin_models import VirtualminServer
@@ -937,10 +937,13 @@ class VirtualminGateway:
                 )
             else:
                 error = result.unwrap_err()
-                return Err(f"Connection test failed: {error}", retriability=Retriability.RETRIABLE)
+                # Propagate the inner call's signal — a validation error is permanent,
+                # blanket RETRIABLE here would invite a retry loop on it.
+                return Err(f"Connection test failed: {error}", retriability=retriability_of(result))
 
         except Exception as e:
-            return Err(f"Connection test error: {e}", retriability=Retriability.RETRIABLE)
+            # No signal available for unexpected exceptions — stay at the UNKNOWN default.
+            return Err(f"Connection test error: {e}")
 
     def get_server_info(self) -> Result[dict[str, Any], str]:
         """Get server information and statistics"""

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -21,7 +21,7 @@ from django.db import models, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.types import Err, Ok, Result, Retriability, retriability_of
+from apps.common.types import Err, Ok, Result, retriability_of
 
 from .security_utils import IdempotencyManager
 from .virtualmin_backup_service import BackupConfig, RestoreConfig
@@ -1025,7 +1025,9 @@ class VirtualminProvisioningService:
             gateway = self._get_gateway(server)
             return gateway.test_connection()
         except Exception as e:
-            return Err(f"Connection test failed: {e}", retriability=Retriability.RETRIABLE)
+            # Gateway setup failures (no server configured, credential decryption)
+            # are not transient — stay at the UNKNOWN default.
+            return Err(f"Connection test failed: {e}")
 
     def sync_account_from_virtualmin(self, account: VirtualminAccount) -> Result[dict[str, Any], str]:
         """

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -21,7 +21,7 @@ from django.db import models, transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 
 from .security_utils import IdempotencyManager
 from .virtualmin_backup_service import BackupConfig, RestoreConfig
@@ -313,7 +313,7 @@ class VirtualminProvisioningService:
                 error = result.unwrap_err()
                 error_msg = str(error)
                 job.mark_failed(error_msg)
-                return Err(error_msg)
+                return Err(error_msg, retriability=retriability_of(result))
 
         except Exception as e:
             logger.exception(f"Error executing domain creation: {e}")
@@ -629,7 +629,7 @@ class VirtualminProvisioningService:
                     error_msg = str(error)
                     job.mark_failed(error_msg)
                     IdempotencyManager.clear(idempotency_key)
-                    return Err(error_msg)
+                    return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
                 IdempotencyManager.clear(idempotency_key)
@@ -752,7 +752,7 @@ class VirtualminProvisioningService:
                     error_msg = str(error)
                     job.mark_failed(error_msg)
                     IdempotencyManager.clear(idempotency_key)
-                    return Err(error_msg)
+                    return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
                 IdempotencyManager.clear(idempotency_key)
@@ -910,7 +910,7 @@ class VirtualminProvisioningService:
                     error_msg = str(error)
                     job.mark_failed(error_msg)
                     IdempotencyManager.clear(idempotency_key)
-                    return Err(error_msg)
+                    return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
                 IdempotencyManager.clear(idempotency_key)
@@ -1025,7 +1025,7 @@ class VirtualminProvisioningService:
             gateway = self._get_gateway(server)
             return gateway.test_connection()
         except Exception as e:
-            return Err(f"Connection test failed: {e}")
+            return Err(f"Connection test failed: {e}", retriability=Retriability.RETRIABLE)
 
     def sync_account_from_virtualmin(self, account: VirtualminAccount) -> Result[dict[str, Any], str]:
         """
@@ -1195,7 +1195,7 @@ class VirtualminServerManagementService:
                 server.save(update_fields=["last_health_check", "health_check_error", "status", "updated_at"])
 
                 logger.warning(f"⚠️ [ServerManagement] Health check failed for {server.hostname}: {error_msg}")
-                return Err(error_msg)
+                return Err(error_msg, retriability=retriability_of(result))
 
         except Exception as e:
             logger.exception(f"Error in health check for {server.hostname}: {e}")

--- a/services/platform/tests/billing/test_refund_retriability.py
+++ b/services/platform/tests/billing/test_refund_retriability.py
@@ -1,0 +1,57 @@
+"""
+Retriability annotations on RefundService lookup failures.
+
+Only genuinely transient database failures (connection drops, deadlocks —
+OperationalError/InterfaceError) may assert RETRIABLE. The broad
+except-Exception catch-all must stay UNKNOWN: a malformed id raises the
+same exception on every attempt, and labeling it RETRIABLE is exactly the
+"most dangerous wrong answer" the tri-state design exists to prevent.
+"""
+
+from unittest.mock import patch
+
+from django.db import InterfaceError, OperationalError
+from django.test import SimpleTestCase
+
+from apps.billing.refund_service import RefundService
+from apps.common.types import Err, Retriability
+
+
+def _patched_order_manager(side_effect: Exception):
+    return patch(
+        "apps.billing.refund_service.Order.objects.select_for_update",
+        side_effect=side_effect,
+    )
+
+
+class RefundLookupRetriabilityTests(SimpleTestCase):
+    def test_unexpected_exception_is_unknown(self) -> None:
+        with _patched_order_manager(RuntimeError("malformed id")):
+            result = RefundService._get_order("not-a-real-id")
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+    def test_operational_error_is_retriable(self) -> None:
+        with _patched_order_manager(OperationalError("deadlock detected")):
+            result = RefundService._get_order("some-id")
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_interface_error_is_retriable(self) -> None:
+        with _patched_order_manager(InterfaceError("connection already closed")):
+            result = RefundService._get_order("some-id")
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_invoice_lookup_mirrors_order_semantics(self) -> None:
+        with patch(
+            "apps.billing.refund_service.Invoice.objects.select_for_update",
+            side_effect=RuntimeError("malformed id"),
+        ):
+            result = RefundService._get_invoice("not-a-real-id")
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)

--- a/services/platform/tests/billing/test_stripe_error_classification.py
+++ b/services/platform/tests/billing/test_stripe_error_classification.py
@@ -1,0 +1,63 @@
+"""
+_classify_stripe_error maps real Stripe SDK exception classes to Retriability.
+
+The classifier matches by class NAME (the stripe module is imported lazily),
+which silently rots if a name doesn't exist in the installed SDK — so the
+first test pins every configured name against the real module.
+"""
+
+import stripe
+from django.test import SimpleTestCase
+
+from apps.billing.stripe_metering import (
+    _NOT_RETRIABLE_STRIPE_ERROR_NAMES,
+    _RETRIABLE_STRIPE_ERROR_NAMES,
+    _classify_stripe_error,
+)
+from apps.common.types import Retriability
+
+
+def _real_stripe_error_names() -> set[str]:
+    return {
+        name
+        for name in dir(stripe._error)
+        if isinstance(getattr(stripe._error, name), type)
+        and issubclass(getattr(stripe._error, name), BaseException)
+    }
+
+
+class StripeErrorClassificationTests(SimpleTestCase):
+    def test_configured_names_reference_real_stripe_classes(self) -> None:
+        """A name that no Stripe class carries is dead configuration."""
+        real = _real_stripe_error_names()
+        self.assertLessEqual(_RETRIABLE_STRIPE_ERROR_NAMES, real)
+        self.assertLessEqual(_NOT_RETRIABLE_STRIPE_ERROR_NAMES, real)
+
+    def test_provably_unapplied_errors_classify_retriable(self) -> None:
+        """Only failures where Stripe never processed the request are RETRIABLE."""
+        for exc in (
+            stripe.RateLimitError("rate limited"),
+            stripe.APIConnectionError("connection dropped"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertEqual(_classify_stripe_error(exc), Retriability.RETRIABLE)
+
+    def test_permanent_errors_classify_not_retriable(self) -> None:
+        for exc in (
+            stripe.InvalidRequestError("bad param", param=None),
+            stripe.AuthenticationError("bad key"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertEqual(_classify_stripe_error(exc), Retriability.NOT_RETRIABLE)
+
+    def test_ambiguous_errors_fall_back_to_unknown(self) -> None:
+        """APIError (indeterminate 5xx) and CardError (per-decline advice) must not
+        assert a retry policy blind — a mutating POST behind an APIError may have
+        committed server-side."""
+        for exc in (
+            stripe.APIError("server error"),
+            stripe.CardError("declined", param=None, code="card_declined"),
+            stripe.StripeError("mystery"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertEqual(_classify_stripe_error(exc), Retriability.UNKNOWN)

--- a/services/platform/tests/common/test_result_types.py
+++ b/services/platform/tests/common/test_result_types.py
@@ -1,0 +1,185 @@
+"""
+Tests for the Result pattern (Ok/Err) in apps.common.types.
+
+Covers the retriable signal on Err (issue #121) and core Result behavior.
+"""
+
+from django.test import TestCase
+
+from apps.common.types import Err, Ok, Retriability
+
+
+class OkTests(TestCase):
+    """Tests for the Ok result type."""
+
+    def test_ok_is_ok(self) -> None:
+        self.assertTrue(Ok(42).is_ok())
+
+    def test_ok_is_not_err(self) -> None:
+        self.assertFalse(Ok(42).is_err())
+
+    def test_ok_unwrap(self) -> None:
+        self.assertEqual(Ok("hello").unwrap(), "hello")
+
+    def test_ok_unwrap_or_returns_value(self) -> None:
+        self.assertEqual(Ok(42).unwrap_or(0), 42)
+
+    def test_ok_map_transforms_value(self) -> None:
+        result = Ok(5).map(lambda x: x * 2)
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), 10)
+
+    def test_ok_map_exception_returns_err(self) -> None:
+        result = Ok(5).map(lambda x: 1 / 0)
+        self.assertTrue(result.is_err())
+
+    def test_ok_and_then_chains(self) -> None:
+        result = Ok(5).and_then(lambda x: Ok(x + 1))
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), 6)
+
+    def test_ok_and_then_to_err(self) -> None:
+        result = Ok(5).and_then(lambda _x: Err("fail"))
+        self.assertTrue(result.is_err())
+
+    def test_ok_unwrap_err_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            Ok(42).unwrap_err()
+
+
+class ErrTests(TestCase):
+    """Tests for the Err result type."""
+
+    def test_err_is_err(self) -> None:
+        self.assertTrue(Err("oops").is_err())
+
+    def test_err_is_not_ok(self) -> None:
+        self.assertFalse(Err("oops").is_ok())
+
+    def test_err_unwrap_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            Err("oops").unwrap()
+
+    def test_err_unwrap_or_returns_default(self) -> None:
+        self.assertEqual(Err("oops").unwrap_or(99), 99)
+
+    def test_err_unwrap_err(self) -> None:
+        self.assertEqual(Err("oops").unwrap_err(), "oops")
+
+    def test_err_map_is_noop(self) -> None:
+        err = Err("fail")
+        result = err.map(lambda x: x * 2)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err(), "fail")
+
+    def test_err_and_then_is_noop(self) -> None:
+        err = Err("fail")
+        result = err.and_then(Ok)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err(), "fail")
+
+
+class ErrRetriabilityTests(TestCase):
+    """Tests for the retriability signal on Err (issue #121).
+
+    The signal is tri-state (RETRIABLE / NOT_RETRIABLE / UNKNOWN) so that
+    legacy ``Err(str(e))`` sites that cannot classify the underlying error
+    do not silently assert permanence. ``is_retriable`` is the conservative
+    "should I retry?" check used by non-idempotent consumers.
+    """
+
+    def test_err_defaults_to_unknown(self) -> None:
+        """Legacy Err('msg') calls default to UNKNOWN, not NOT_RETRIABLE."""
+        err = Err("database timeout")
+        self.assertEqual(err.retriability, Retriability.UNKNOWN)
+        self.assertFalse(err.is_retriable)
+
+    def test_err_explicit_retriable(self) -> None:
+        err = Err("lock contention", retriability=Retriability.RETRIABLE)
+        self.assertEqual(err.retriability, Retriability.RETRIABLE)
+        self.assertTrue(err.is_retriable)
+
+    def test_err_explicit_not_retriable(self) -> None:
+        err = Err("validation failed", retriability=Retriability.NOT_RETRIABLE)
+        self.assertEqual(err.retriability, Retriability.NOT_RETRIABLE)
+        self.assertFalse(err.is_retriable)
+
+    def test_is_retriable_only_true_for_retriable_state(self) -> None:
+        """is_retriable returns False for UNKNOWN — non-idempotent consumers fail closed."""
+        self.assertFalse(Err("x", retriability=Retriability.UNKNOWN).is_retriable)
+        self.assertFalse(Err("x", retriability=Retriability.NOT_RETRIABLE).is_retriable)
+        self.assertTrue(Err("x", retriability=Retriability.RETRIABLE).is_retriable)
+
+    def test_retriability_preserved_through_map(self) -> None:
+        """Err.map() returns self, so retriability must survive."""
+        err = Err("timeout", retriability=Retriability.RETRIABLE)
+        result = err.map(lambda x: x)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_retriability_preserved_through_and_then(self) -> None:
+        err = Err("timeout", retriability=Retriability.RETRIABLE)
+        result = err.and_then(Ok)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_frozen_dataclass_prevents_mutation(self) -> None:
+        err = Err("fail", retriability=Retriability.RETRIABLE)
+        with self.assertRaises(AttributeError):
+            err.retriability = Retriability.NOT_RETRIABLE  # type: ignore[misc]  # intentional: testing frozen dataclass rejects mutation
+
+    def test_ok_map_exception_creates_unknown_err(self) -> None:
+        """When Ok.map() catches an exception, retriability is UNKNOWN — caller did not classify."""
+        result = Ok(1).map(lambda x: 1 / 0)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+
+class ErrEqualityContractTests(TestCase):
+    """Tests documenting the equality/hash contract change introduced by retriability.
+
+    Two ``Err`` instances are equal iff both ``error`` AND ``retriability`` match.
+    This is intentional: if a caller cares whether a failure is retriable, two
+    errs with different retriability should compare unequal.
+    """
+
+    def test_err_equal_when_default_retriability_matches(self) -> None:
+        self.assertEqual(Err("x"), Err("x"))
+        self.assertEqual(Err("x"), Err("x", retriability=Retriability.UNKNOWN))
+
+    def test_err_not_equal_when_retriability_differs(self) -> None:
+        self.assertNotEqual(Err("x"), Err("x", retriability=Retriability.RETRIABLE))
+        self.assertNotEqual(
+            Err("x", retriability=Retriability.NOT_RETRIABLE),
+            Err("x", retriability=Retriability.RETRIABLE),
+        )
+
+    def test_err_hash_matches_equality(self) -> None:
+        self.assertEqual(hash(Err("x")), hash(Err("x", retriability=Retriability.UNKNOWN)))
+        self.assertNotEqual(hash(Err("x")), hash(Err("x", retriability=Retriability.RETRIABLE)))
+
+
+class ErrPatternMatchTests(TestCase):
+    """``case Err(x)`` should still bind ``x`` to ``.error`` after the new field.
+
+    Dataclass ``__match_args__`` is positional, so ``case Err(msg)`` continues
+    to match the first field (``error``); ``retriability`` is reachable via
+    ``case Err(msg, r)`` if needed.
+    """
+
+    def test_single_positional_match_binds_error(self) -> None:
+        err: Err[str] = Err("boom", retriability=Retriability.RETRIABLE)
+        match err:
+            case Err(msg):
+                self.assertEqual(msg, "boom")
+            case _:  # pragma: no cover
+                self.fail("Err did not match")
+
+    def test_two_positional_match_binds_error_and_retriability(self) -> None:
+        err: Err[str] = Err("boom", retriability=Retriability.RETRIABLE)
+        match err:
+            case Err(msg, r):
+                self.assertEqual(msg, "boom")
+                self.assertEqual(r, Retriability.RETRIABLE)
+            case _:  # pragma: no cover
+                self.fail("Err did not match")

--- a/services/platform/tests/common/test_result_types.py
+++ b/services/platform/tests/common/test_result_types.py
@@ -6,7 +6,7 @@ Covers the retriable signal on Err (issue #121) and core Result behavior.
 
 from django.test import TestCase
 
-from apps.common.types import Err, Ok, Retriability
+from apps.common.types import Err, Ok, Retriability, retriability_of
 
 
 class OkTests(TestCase):
@@ -183,3 +183,25 @@ class ErrPatternMatchTests(TestCase):
                 self.assertEqual(r, Retriability.RETRIABLE)
             case _:  # pragma: no cover
                 self.fail("Err did not match")
+
+
+class RetriabilityOfHelperTests(TestCase):
+    """retriability_of propagates an Err's signal and is inert for Ok."""
+
+    def test_ok_returns_unknown(self) -> None:
+        self.assertEqual(retriability_of(Ok("fine")), Retriability.UNKNOWN)
+
+    def test_err_default_returns_unknown(self) -> None:
+        self.assertEqual(retriability_of(Err("no signal")), Retriability.UNKNOWN)
+
+    def test_err_retriable_propagates(self) -> None:
+        self.assertEqual(
+            retriability_of(Err("transient", retriability=Retriability.RETRIABLE)),
+            Retriability.RETRIABLE,
+        )
+
+    def test_err_not_retriable_propagates(self) -> None:
+        self.assertEqual(
+            retriability_of(Err("permanent", retriability=Retriability.NOT_RETRIABLE)),
+            Retriability.NOT_RETRIABLE,
+        )

--- a/services/platform/tests/provisioning/test_virtualmin_retriability.py
+++ b/services/platform/tests/provisioning/test_virtualmin_retriability.py
@@ -1,0 +1,71 @@
+"""
+Retriability annotations on the Virtualmin connection-test paths.
+
+test_connection wraps an inner call() Result — its Err must PROPAGATE the
+inner retriability, not blanket-assert RETRIABLE (a validation error is
+permanent; forcing RETRIABLE invites a retry loop the moment a consumer
+wires up retries). Unexpected exceptions carry no signal, so they must
+stay UNKNOWN — the fail-closed default the tri-state design mandates.
+"""
+
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from apps.common.types import Err, Retriability
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminAPIError,
+    VirtualminConfig,
+    VirtualminGateway,
+)
+from apps.provisioning.virtualmin_models import VirtualminServer
+from apps.provisioning.virtualmin_service import VirtualminProvisioningService
+
+
+def _gateway() -> VirtualminGateway:
+    server = VirtualminServer(hostname="test.example.com")
+    return VirtualminGateway(VirtualminConfig(server=server))
+
+
+class GatewayTestConnectionRetriabilityTests(SimpleTestCase):
+    def test_failed_call_propagates_inner_retriability(self) -> None:
+        """An inner Err with UNKNOWN retriability must not be upgraded to RETRIABLE."""
+        gateway = _gateway()
+        inner = Err(VirtualminAPIError("Validation error: bad program"))
+
+        with patch.object(gateway, "call", return_value=inner):
+            result = gateway.test_connection()
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+    def test_failed_call_keeps_explicit_retriable_signal(self) -> None:
+        gateway = _gateway()
+        inner = Err(VirtualminAPIError("Server unreachable"), retriability=Retriability.RETRIABLE)
+
+        with patch.object(gateway, "call", return_value=inner):
+            result = gateway.test_connection()
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_unexpected_exception_is_unknown(self) -> None:
+        gateway = _gateway()
+
+        with patch.object(gateway, "call", side_effect=RuntimeError("boom")):
+            result = gateway.test_connection()
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+
+class ServiceTestServerConnectionRetriabilityTests(SimpleTestCase):
+    def test_gateway_setup_failure_is_unknown(self) -> None:
+        """_get_gateway failures (no server, credential errors) are not transient."""
+        service = VirtualminProvisioningService()
+
+        with patch.object(service, "_get_gateway", side_effect=RuntimeError("No server specified")):
+            result = service.test_server_connection(VirtualminServer(hostname="x.example.com"))
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)


### PR DESCRIPTION
## Summary

Lands PR #168 (thanks @b3lz3but) — a tri-state Retriability signal on the shared Result Err type — with the corrections from its review round.

### From #168
- Retriability StrEnum (RETRIABLE / NOT_RETRIABLE / UNKNOWN), Err.retriability field (default UNKNOWN, frozen), conservative is_retriable, retriability_of propagation helper
- Backfilled producers in refund_service, stripe_metering, provider_config, virtualmin gateway/service; ADR-0003 updated

### Review hardening on top
RETRIABLE is now defined as *provably not applied / safe to replay*, not merely *transient* — and the backfilled classifications were tightened to match, so the shared retry contract doesn't bake in unsafe precedent before any consumer reads it:
- **refund_service**: broad except → UNKNOWN; only OperationalError/InterfaceError are RETRIABLE
- **virtualmin test_connection / test_server_connection**: propagate the inner signal / stay UNKNOWN instead of forcing RETRIABLE
- **provider_config**: a timed-out state-changing command (reboot/resize) → UNKNOWN (may have executed server-side)
- **stripe_metering**: only RateLimitError + APIConnectionError stay RETRIABLE; APIError + CardError → UNKNOWN; removed two non-existent SDK class names
- Added the tests the backfill lacked: retriability_of propagation, Stripe classifier pinned to the real SDK, refund DB-error buckets, virtualmin connection paths

### Deferred (own review needed)
- #253 — pre-existing Virtualmin retry-loop exception-type mismatch (control-flow change)
- #254 — propagate the signal through public service boundaries + define operation-aware policy, to land with the first retry consumer

### Test plan
- Full suite green: platform (failfast, parallel), portal, integration, cache, security phases; mypy + ruff clean on all changed files

Closes #121