### PR TITLE
feat(domains): registrar gateway layer (Gandi + ROTLD), reconciled + hardened (#93)

### DIFF
--- a/services/platform/apps/domains/gateways/__init__.py
+++ b/services/platform/apps/domains/gateways/__init__.py
@@ -1,0 +1,46 @@
+"""
+Domain Registrar Gateways — PRAHO Platform
+
+Abstract gateway interface + concrete implementations for domain registrar APIs.
+Follows the billing gateway pattern (ABC + factory + Result types).
+"""
+
+# Import the concrete gateways for their registration side effects. Each module
+# calls RegistrarGatewayFactory.register_gateway(...) at import time, so without
+# importing them here the factory registry stays empty at runtime and every
+# create_gateway() call raises "No gateway registered" — the whole gateway layer
+# would be dead code in production (it only worked in tests because the test suite
+# imports the concrete modules directly). Importing gandi/rotld pulls in .base
+# transitively, so registration is complete once this package finishes importing.
+from . import gandi, rotld  # noqa: F401  # registration side effects
+from .base import (
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import (
+    RegistrarAPIError,
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+
+__all__ = [
+    "BaseRegistrarGateway",
+    "DomainAvailabilityResult",
+    "DomainRegistrationResult",
+    "DomainRenewalResult",
+    "RegistrarAPIError",
+    "RegistrarAuthError",
+    "RegistrarConflictError",
+    "RegistrarErrorCode",
+    "RegistrarGatewayFactory",
+    "RegistrarNotFoundError",
+    "RegistrarRateLimitError",
+    "RegistrarTransientError",
+]

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -180,6 +180,8 @@ class BaseRegistrarGateway(ABC):
         nameservers: list[str] | None = None,
     ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
         """Register a domain, with circuit breaker and idempotency protection."""
+        if guard := self._verified_adapter_guard():
+            return guard
         return self._execute_idempotent_operation(
             idempotency_key=f"domain_reg:{self.gateway_name}:{domain_name}",
             fn=lambda: self._do_register(domain_name, years, registrant_data, nameservers),
@@ -195,6 +197,8 @@ class BaseRegistrarGateway(ABC):
         years: int,
     ) -> Result[DomainRenewalResult, RegistrarAPIError]:
         """Renew a domain, with circuit breaker and idempotency protection."""
+        if guard := self._verified_adapter_guard():
+            return guard
         return self._execute_idempotent_operation(
             idempotency_key=f"domain_renew:{self.gateway_name}:{domain_name}:{years}",
             fn=lambda: self._do_renew(registrar_domain_id, domain_name, years),
@@ -202,6 +206,27 @@ class BaseRegistrarGateway(ABC):
             audit_event="domain_renewal",
             domain_name=domain_name,
             audit_metadata={"years": years},
+        )
+
+    def _verified_adapter_guard(self) -> Err[RegistrarAPIError] | None:
+        """Refuse chargeable register/renew calls until the adapter is sandbox-verified.
+
+        The concrete response schemas were built from documentation without a live
+        sandbox; ``settings.REGISTRAR_ADAPTERS_VERIFIED`` must be flipped on by an
+        operator after validating an adapter against the real registrar. Returns an
+        Err to short-circuit, or None when verified.
+        """
+        from django.conf import settings  # noqa: PLC0415  # avoid import-time settings access
+
+        if getattr(settings, "REGISTRAR_ADAPTERS_VERIFIED", False):
+            return None
+        return Err(
+            RegistrarAPIError(
+                f"{self.gateway_name} adapter is not verified against the registrar sandbox; "
+                "refusing chargeable operation (set REGISTRAR_ADAPTERS_VERIFIED=true once validated)",
+                code=RegistrarErrorCode.NOT_CONFIGURED,
+                registrar_name=self.registrar.name,
+            )
         )
 
     def _execute_idempotent_operation(  # noqa: PLR0913  # cohesive call + audit context for one op

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from django.core.cache import cache
 
 from apps.common.outbound_http import OutboundPolicy, safe_request
-from apps.common.types import Err, Ok, Result, Retriability
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 
 from .errors import (
     RegistrarAPIError,
@@ -254,6 +254,7 @@ class BaseRegistrarGateway(ABC):
         result = self._retry(
             lambda: self._do_check_availability(domain_name),
             operation=f"check:{domain_name}",
+            retry_on_unknown=True,  # availability is a safe read — replaying it is harmless
         )
 
         if result.is_ok():
@@ -396,6 +397,8 @@ class BaseRegistrarGateway(ABC):
         fn: Any,
         operation: str,
         max_retries: int = MAX_RETRIES,
+        *,
+        retry_on_unknown: bool = False,
     ) -> Result[Any, RegistrarAPIError]:
         last_result: Result[Any, RegistrarAPIError] = Err(
             RegistrarAPIError("No attempts made", code=RegistrarErrorCode.INTERNAL_ERROR)
@@ -407,8 +410,15 @@ class BaseRegistrarGateway(ABC):
             if last_result.is_ok():
                 return last_result
 
+            # Honor the Retriability tag, NOT the error class: a mutating POST tagged
+            # UNKNOWN (may have reached the registrar) must not be auto-replayed —
+            # doing so risks a duplicate registration/renewal charge. Only RETRIABLE
+            # (and, for idempotent reads, UNKNOWN) is safe to retry.
             error = last_result.unwrap_err()
-            is_retryable = isinstance(error, RegistrarTransientError | RegistrarRateLimitError)
+            retriability = retriability_of(last_result)
+            is_retryable = retriability == Retriability.RETRIABLE or (
+                retry_on_unknown and retriability == Retriability.UNKNOWN
+            )
             if not is_retryable or attempt == max_retries - 1:
                 break
 

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -1,0 +1,520 @@
+"""
+Abstract base class for domain registrar gateways.
+
+Follows the billing gateway ABC + factory pattern and cloud gateway Result[T, E] pattern.
+All registrar HTTP goes through safe_request() with a per-registrar OutboundPolicy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.core.cache import cache
+
+from apps.common.outbound_http import OutboundPolicy, safe_request
+from apps.common.types import Err, Ok, Result, Retriability
+
+from .errors import (
+    RegistrarAPIError,
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+
+if TYPE_CHECKING:
+    import requests
+
+    from apps.domains.models import Registrar
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker defaults
+CIRCUIT_BREAKER_THRESHOLD = 5  # failures before tripping
+CIRCUIT_BREAKER_RESET_SECONDS = 300  # 5 minutes
+IDEMPOTENCY_TTL_SECONDS = 3600  # 1 hour
+# Sentinel stored under the idempotency key while a registrar call is in flight, so a
+# second concurrent request for the same domain is rejected instead of issuing a
+# duplicate (and chargeable) registration. Replaced with the real result on success.
+_IDEMPOTENCY_IN_PROGRESS = "__in_progress__"
+
+# Retry defaults
+MAX_RETRIES = 3
+BACKOFF_BASE_SECONDS = 0.5
+
+# Registrar JSON responses are small (domain/order records). Cap the body before
+# deserializing so a malicious or misbehaving registrar can't exhaust memory (M5).
+MAX_RESPONSE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
+
+# HTTP status codes used in error mapping
+HTTP_OK = 200
+HTTP_CREATED = 201
+HTTP_ACCEPTED = 202
+HTTP_UNAUTHORIZED = 401
+HTTP_FORBIDDEN = 403
+HTTP_NOT_FOUND = 404
+HTTP_CONFLICT = 409
+HTTP_RATE_LIMITED = 429
+HTTP_SERVER_ERROR = 500
+
+
+# ===============================================================================
+# RESULT TYPES
+# ===============================================================================
+
+
+@dataclass(frozen=True)
+class DomainRegistrationResult:
+    """Successful domain registration response from a registrar."""
+
+    registrar_domain_id: str
+    expires_at: datetime
+    nameservers: list[str]
+    epp_code: str = ""
+
+
+@dataclass(frozen=True)
+class DomainRenewalResult:
+    """Successful domain renewal response from a registrar."""
+
+    new_expires_at: datetime
+
+
+@dataclass(frozen=True)
+class DomainAvailabilityResult:
+    """Domain availability check response from a registrar."""
+
+    domain_name: str
+    available: bool
+    premium: bool = False
+    price_cents: int | None = None
+
+
+# ===============================================================================
+# ABSTRACT BASE GATEWAY
+# ===============================================================================
+
+
+class BaseRegistrarGateway(ABC):
+    """Abstract base class for all domain registrar gateways.
+
+    Subclasses implement the four core operations against a specific registrar API.
+    The base class provides: circuit breaker, idempotency, retry with backoff,
+    SSRF-safe HTTP via OutboundPolicy, and audit logging.
+    """
+
+    def __init__(self, registrar: Registrar) -> None:
+        self.registrar = registrar
+        self.logger = logging.getLogger(f"apps.domains.gateways.{self.gateway_name}")
+
+    # -- Abstract interface --------------------------------------------------
+
+    @property
+    @abstractmethod
+    def gateway_name(self) -> str:
+        """Machine-readable gateway identifier (e.g. 'gandi', 'rotld')."""
+
+    @abstractmethod
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        """Return the OutboundPolicy for this registrar's API."""
+
+    @abstractmethod
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        """Registrar-specific registration logic."""
+
+    @abstractmethod
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        """Registrar-specific renewal logic."""
+
+    @abstractmethod
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        """Registrar-specific availability check."""
+
+    @abstractmethod
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        """Registrar-specific webhook signature verification."""
+
+    # -- Public interface (with circuit breaker + idempotency) ----------------
+
+    def register_domain(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None = None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        """Register a domain, with circuit breaker and idempotency protection."""
+        return self._execute_idempotent_operation(
+            idempotency_key=f"domain_reg:{self.gateway_name}:{domain_name}",
+            fn=lambda: self._do_register(domain_name, years, registrant_data, nameservers),
+            operation=f"register:{domain_name}",
+            audit_event="domain_registration",
+            domain_name=domain_name,
+        )
+
+    def renew_domain(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        """Renew a domain, with circuit breaker and idempotency protection."""
+        return self._execute_idempotent_operation(
+            idempotency_key=f"domain_renew:{self.gateway_name}:{domain_name}:{years}",
+            fn=lambda: self._do_renew(registrar_domain_id, domain_name, years),
+            operation=f"renew:{domain_name}",
+            audit_event="domain_renewal",
+            domain_name=domain_name,
+            audit_metadata={"years": years},
+        )
+
+    def _execute_idempotent_operation(  # noqa: PLR0913  # cohesive call + audit context for one op
+        self,
+        idempotency_key: str,
+        fn: Any,
+        operation: str,
+        audit_event: str,
+        domain_name: str,
+        audit_metadata: dict[str, Any] | None = None,
+    ) -> Result[Any, RegistrarAPIError]:
+        """Run a state-changing registrar call with circuit-breaker + idempotency.
+
+        Idempotency claims the key atomically *before* the call (cache.add), so a
+        second concurrent request for the same domain is refused instead of issuing
+        a duplicate, chargeable operation — the previous get-then-call had a window
+        where two requests both missed the cache and both called the registrar. The
+        claim is replaced with the result on success and released on failure so a
+        legitimate retry can proceed.
+        """
+        if err := self._check_circuit_breaker():
+            return err
+
+        cached = cache.get(idempotency_key)
+        if cached is not None and cached != _IDEMPOTENCY_IN_PROGRESS:
+            self.logger.info("Idempotency hit for %s", operation)
+            return Ok(cached)
+
+        # Atomically claim the slot. add() only succeeds if the key is absent, so a
+        # concurrent in-flight request loses the race and is rejected.
+        if not cache.add(idempotency_key, _IDEMPOTENCY_IN_PROGRESS, IDEMPOTENCY_TTL_SECONDS):
+            existing = cache.get(idempotency_key)
+            if existing is not None and existing != _IDEMPOTENCY_IN_PROGRESS:
+                return Ok(existing)
+            self.logger.warning("Concurrent %s already in progress — rejecting duplicate", operation)
+            return Err(RegistrarConflictError(domain_name, self.registrar.name))
+
+        result = self._retry(fn, operation=operation)
+
+        if result.is_ok():
+            cache.set(idempotency_key, result.unwrap(), IDEMPOTENCY_TTL_SECONDS)
+            self._record_success()
+            self.logger.info("%s succeeded via %s", operation, self.gateway_name)
+            self._audit_api_call(audit_event, domain_name, success=True, metadata=audit_metadata)
+        else:
+            cache.delete(idempotency_key)  # release the claim so a legitimate retry can proceed
+            self._record_failure(result.unwrap_err())
+            self.logger.error("%s failed: %s", operation, result.unwrap_err())
+            self._audit_api_call(
+                audit_event, domain_name, success=False, error=str(result.unwrap_err()), metadata=audit_metadata
+            )
+
+        return result
+
+    def check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        """Check domain availability (no idempotency needed, but respects circuit breaker)."""
+        if err := self._check_circuit_breaker():
+            return err
+
+        result = self._retry(
+            lambda: self._do_check_availability(domain_name),
+            operation=f"check:{domain_name}",
+        )
+
+        if result.is_ok():
+            self._record_success()
+        else:
+            self._record_failure(result.unwrap_err())
+            self._audit_api_call(
+                "domain_availability_check", domain_name, success=False, error=str(result.unwrap_err())
+            )
+
+        return result
+
+    def verify_webhook_signature(self, payload: str, signature: str) -> bool:
+        """Verify webhook signature. Fail-closed: returns False on any error."""
+        if not signature:
+            return False
+
+        try:
+            secret = self.registrar.get_decrypted_webhook_secret()
+        except Exception:
+            self.logger.error("Webhook secret decryption failed for %s", self.registrar.name)
+            return False
+
+        if not secret or not secret.strip():
+            self.logger.error("Webhook secret for %s is empty", self.registrar.name)
+            return False
+
+        return self._do_verify_webhook(payload, signature, secret.strip())
+
+    # -- HTTP helper for subclasses ------------------------------------------
+
+    def _api_request(
+        self,
+        method: str,
+        url: str,
+        **kwargs: Any,
+    ) -> requests.Response:
+        """Make an API request using safe_request() with this gateway's OutboundPolicy.
+
+        Raises requests.RequestException on transport errors.
+        """
+        return safe_request(method, url, policy=self._get_outbound_policy(), **kwargs)
+
+    def _safe_json(self, response: requests.Response) -> Any:
+        """Parse a JSON response, rejecting oversized payloads (M5, defense-in-depth).
+
+        ``safe_request`` does not cap body size, so guard before deserializing —
+        a 5 MB JSON body explodes into a far larger Python object graph. Mirrors
+        ``VirtualminGateway._validate_response_size``. Raises an INVALID_RESPONSE
+        ``RegistrarAPIError`` when the declared or actual body exceeds the cap.
+        """
+        content_length = response.headers.get("content-length", "")
+        if content_length.isdigit() and int(content_length) > MAX_RESPONSE_SIZE_BYTES:
+            raise RegistrarAPIError(
+                f"{self.gateway_name} response too large: {content_length} bytes",
+                code=RegistrarErrorCode.INVALID_RESPONSE,
+                registrar_name=self.registrar.name,
+            )
+        if len(response.content) > MAX_RESPONSE_SIZE_BYTES:
+            raise RegistrarAPIError(
+                f"{self.gateway_name} response exceeds size limit ({MAX_RESPONSE_SIZE_BYTES} bytes)",
+                code=RegistrarErrorCode.INVALID_RESPONSE,
+                registrar_name=self.registrar.name,
+            )
+        return response.json()
+
+    # -- Audit logging -------------------------------------------------------
+
+    def _audit_api_call(
+        self,
+        event_type: str,
+        domain_name: str,
+        *,
+        success: bool,
+        error: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Log an audit event for a registrar API call."""
+        try:
+            from apps.audit.services import AuditService  # noqa: PLC0415
+
+            audit_metadata: dict[str, Any] = {
+                "registrar": self.registrar.name,
+                "gateway": self.gateway_name,
+                "domain_name": domain_name,
+                "success": success,
+            }
+            if error:
+                audit_metadata["error"] = error[:500]
+            if metadata:
+                audit_metadata.update(metadata)
+
+            AuditService.log_simple_event(
+                f"registrar_api_{event_type}",
+                description=f"{'OK' if success else 'FAIL'}: {event_type} for {domain_name} via {self.gateway_name}",
+                metadata=audit_metadata,
+                actor_type="system",
+            )
+        except Exception:
+            self.logger.warning("Audit logging failed for %s:%s", event_type, domain_name, exc_info=True)
+
+    # -- Circuit breaker (Django cache-backed) -------------------------------
+
+    def _circuit_breaker_key(self) -> str:
+        return f"cb:{self.gateway_name}:failures"
+
+    def _check_circuit_breaker(self) -> Err[RegistrarAPIError] | None:
+        failures = cache.get(self._circuit_breaker_key(), 0)
+        if failures >= CIRCUIT_BREAKER_THRESHOLD:
+            self.logger.warning("Circuit breaker OPEN for %s (%d failures)", self.gateway_name, failures)
+            return Err(
+                RegistrarTransientError(
+                    self.registrar.name,
+                    f"Circuit breaker open for {self.gateway_name} ({failures} consecutive failures)",
+                ),
+                # The call was never attempted while the breaker is open — provably safe to replay.
+                retriability=Retriability.RETRIABLE,
+            )
+        return None
+
+    def _record_failure(self, error: RegistrarAPIError) -> None:
+        key = self._circuit_breaker_key()
+        try:
+            # incr preserves the TTL set on the first failure — do NOT touch() here.
+            # Touching on every failure slid the window forward, so under sustained
+            # failures the counter never expired and the breaker never auto-recovered.
+            cache.incr(key)
+        except ValueError:
+            # First failure in this window: seed the counter with a fixed TTL so the
+            # breaker auto-closes CIRCUIT_BREAKER_RESET_SECONDS after it first opened.
+            cache.set(key, 1, CIRCUIT_BREAKER_RESET_SECONDS)
+
+    def _record_success(self) -> None:
+        cache.delete(self._circuit_breaker_key())
+
+    # -- Retry with exponential backoff --------------------------------------
+
+    def _retry(
+        self,
+        fn: Any,
+        operation: str,
+        max_retries: int = MAX_RETRIES,
+    ) -> Result[Any, RegistrarAPIError]:
+        last_result: Result[Any, RegistrarAPIError] = Err(
+            RegistrarAPIError("No attempts made", code=RegistrarErrorCode.INTERNAL_ERROR)
+        )
+
+        for attempt in range(max_retries):
+            last_result = fn()
+
+            if last_result.is_ok():
+                return last_result
+
+            error = last_result.unwrap_err()
+            is_retryable = isinstance(error, RegistrarTransientError | RegistrarRateLimitError)
+            if not is_retryable or attempt == max_retries - 1:
+                break
+
+            backoff = BACKOFF_BASE_SECONDS * (2**attempt)
+            self.logger.info(
+                "Retrying %s (attempt %d/%d, backoff %.1fs): %s",
+                operation,
+                attempt + 1,
+                max_retries,
+                backoff,
+                error,
+            )
+            time.sleep(backoff)
+
+        return last_result
+
+    # -- Default webhook HMAC-SHA256 verification ----------------------------
+
+    @staticmethod
+    def _verify_hmac_sha256(payload: str, signature: str, secret: str) -> bool:
+        """Standard HMAC-SHA256 verification with timing-safe comparison."""
+        expected = hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+        return hmac.compare_digest(f"sha256={expected}", signature)
+
+    # -- Shared HTTP error mapping -------------------------------------------
+
+    def _handle_error_response(
+        self, response: requests.Response, operation: str, domain_name: str = ""
+    ) -> Err[RegistrarAPIError]:
+        """Map HTTP error status codes to typed RegistrarAPIError variants.
+
+        ``operation`` is a human label for the generic message (e.g. "register
+        example.com"); ``domain_name`` is the bare domain used to build the typed
+        not-found/conflict errors so their message reads "Domain 'example.com' ..."
+        rather than leaking the operation label (M3).
+        """
+        status = response.status_code
+
+        try:
+            data = self._safe_json(response)
+            message = data.get("message", data.get("error", response.text[:200]))
+        except Exception:
+            message = response.text[:200]
+
+        if status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
+            detail = message if status == HTTP_UNAUTHORIZED else f"Forbidden: {message}"
+            return Err(RegistrarAuthError(self.registrar.name, detail=detail))
+
+        if status == HTTP_NOT_FOUND:
+            return Err(RegistrarNotFoundError(domain_name or operation, self.registrar.name))
+
+        if status == HTTP_CONFLICT:
+            return Err(RegistrarConflictError(domain_name or operation, self.registrar.name))
+
+        if status == HTTP_RATE_LIMITED:
+            retry_after = response.headers.get("Retry-After")
+            return Err(
+                RegistrarRateLimitError(self.registrar.name, int(retry_after) if retry_after else None),
+                # 429 means the registrar rejected the request before processing it — safe to replay.
+                retriability=Retriability.RETRIABLE,
+            )
+
+        if status >= HTTP_SERVER_ERROR:
+            # A 5xx on a mutating call (register/renew) may have committed server-side;
+            # this generic handler can't prove non-application, so leave it UNKNOWN (the default).
+            return Err(
+                RegistrarTransientError(self.registrar.name, f"{self.gateway_name} server error ({status}): {message}"),
+            )
+
+        return Err(
+            RegistrarAPIError(
+                f"{self.gateway_name} API error for {operation}: {status} {message}",
+                code=RegistrarErrorCode.INTERNAL_ERROR,
+                registrar_name=self.registrar.name,
+            )
+        )
+
+
+# ===============================================================================
+# GATEWAY FACTORY
+# ===============================================================================
+
+
+class RegistrarGatewayFactory:
+    """Factory for creating registrar gateway instances.
+
+    Follows the PaymentGatewayFactory pattern from apps/billing/gateways/.
+    """
+
+    _gateways: ClassVar[dict[str, type[BaseRegistrarGateway]]] = {}
+
+    @classmethod
+    def register_gateway(cls, name: str, gateway_cls: type[BaseRegistrarGateway]) -> None:
+        cls._gateways[name] = gateway_cls
+
+    @classmethod
+    def create_gateway(cls, registrar: Registrar) -> BaseRegistrarGateway:
+        """Create a gateway instance for the given registrar.
+
+        The registrar's `name` field must match a registered gateway name.
+        """
+        gateway_cls = cls._gateways.get(registrar.name)
+        if not gateway_cls:
+            raise ValueError(f"No gateway registered for registrar: {registrar.name}")
+        return gateway_cls(registrar)
+
+    @classmethod
+    def list_available_gateways(cls) -> list[str]:
+        return list(cls._gateways.keys())

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -12,7 +12,7 @@ import hmac
 import logging
 import time
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -46,6 +46,19 @@ IDEMPOTENCY_TTL_SECONDS = 3600  # 1 hour
 # second concurrent request for the same domain is rejected instead of issuing a
 # duplicate (and chargeable) registration. Replaced with the real result on success.
 _IDEMPOTENCY_IN_PROGRESS = "__in_progress__"
+
+
+def _redact_secrets(result: Any) -> Any:
+    """Return a copy of a gateway result with any secret-bearing field cleared.
+
+    Used before writing a result to the plaintext idempotency cache — the EPP/auth
+    transfer code must never be persisted there (it is stored encrypted on the
+    Domain row instead).
+    """
+    if isinstance(result, DomainRegistrationResult) and result.epp_code:
+        return replace(result, epp_code="")
+    return result
+
 
 # Retry defaults
 MAX_RETRIES = 3
@@ -229,7 +242,11 @@ class BaseRegistrarGateway(ABC):
         result = self._retry(fn, operation=operation)
 
         if result.is_ok():
-            cache.set(idempotency_key, result.unwrap(), IDEMPOTENCY_TTL_SECONDS)
+            # Cache a secret-free copy: the EPP/auth code is a transfer credential and
+            # the idempotency cache is plaintext (DatabaseCache/Redis). The immediate
+            # caller still receives the full result (with the EPP) to store encrypted;
+            # only the replay copy is redacted.
+            cache.set(idempotency_key, _redact_secrets(result.unwrap()), IDEMPOTENCY_TTL_SECONDS)
             self._record_success()
             self.logger.info("%s succeeded via %s", operation, self.gateway_name)
             self._audit_api_call(audit_event, domain_name, success=True, metadata=audit_metadata)

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -264,7 +264,23 @@ class BaseRegistrarGateway(ABC):
             self.logger.warning("Concurrent %s already in progress — rejecting duplicate", operation)
             return Err(RegistrarConflictError(domain_name, self.registrar.name))
 
-        result = self._retry(fn, operation=operation)
+        # Exception-safety: _retry(fn) can raise (e.g. _safe_json → RegistrarAPIError on
+        # an oversized body). Convert any escape to an Err so the claim-release path below
+        # always runs — otherwise the in-progress claim would strand the key for the full
+        # TTL and block every legitimate retry.
+        try:
+            result = self._retry(fn, operation=operation)
+        except RegistrarAPIError as exc:
+            result = Err(exc)
+        except Exception as exc:
+            result = Err(
+                RegistrarAPIError(
+                    f"Unexpected error during {operation}",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                    detail=str(exc),
+                )
+            )
 
         if result.is_ok():
             # Cache a secret-free copy: the EPP/auth code is a transfer credential and
@@ -277,10 +293,13 @@ class BaseRegistrarGateway(ABC):
             self._audit_api_call(audit_event, domain_name, success=True, metadata=audit_metadata)
         else:
             cache.delete(idempotency_key)  # release the claim so a legitimate retry can proceed
-            self._record_failure(result.unwrap_err())
-            self.logger.error("%s failed: %s", operation, result.unwrap_err())
+            error = result.unwrap_err()
+            self._record_failure(error)
+            # Log/audit the machine-readable code, never the raw registrar body — it can
+            # echo registrant PII (CNP, address) supplied in the request (W4).
+            self.logger.error("%s failed with %s", operation, error.code.value)
             self._audit_api_call(
-                audit_event, domain_name, success=False, error=str(result.unwrap_err()), metadata=audit_metadata
+                audit_event, domain_name, success=False, error=error.code.value, metadata=audit_metadata
             )
 
         return result
@@ -418,15 +437,24 @@ class BaseRegistrarGateway(ABC):
         return None
 
     def _record_failure(self, error: RegistrarAPIError) -> None:
+        # Only systemic failures (transport/rate-limit/5xx) indicate a registrar-wide
+        # outage worth tripping the breaker. A domain conflict, auth error, or invalid
+        # registrant is request-specific and must NOT count — otherwise a burst of bad
+        # requests would open the breaker for healthy traffic (W3).
+        if not isinstance(error, RegistrarTransientError | RegistrarRateLimitError):
+            return
+
         key = self._circuit_breaker_key()
+        # Atomic first-failure seed: add() only succeeds if the key is absent, so two
+        # concurrent first failures can't both reset the counter to 1 (W3). incr on an
+        # existing key preserves the TTL set here, so the window doesn't slide and the
+        # breaker auto-closes CIRCUIT_BREAKER_RESET_SECONDS after it first opened.
+        if cache.add(key, 1, CIRCUIT_BREAKER_RESET_SECONDS):
+            return
         try:
-            # incr preserves the TTL set on the first failure — do NOT touch() here.
-            # Touching on every failure slid the window forward, so under sustained
-            # failures the counter never expired and the breaker never auto-recovered.
             cache.incr(key)
         except ValueError:
-            # First failure in this window: seed the counter with a fixed TTL so the
-            # breaker auto-closes CIRCUIT_BREAKER_RESET_SECONDS after it first opened.
+            # The key expired between add() and incr() — reseed.
             cache.set(key, 1, CIRCUIT_BREAKER_RESET_SECONDS)
 
     def _record_success(self) -> None:

--- a/services/platform/apps/domains/gateways/errors.py
+++ b/services/platform/apps/domains/gateways/errors.py
@@ -1,0 +1,104 @@
+"""
+Domain registrar error types.
+
+Modeled after the Virtualmin gateway exception hierarchy.
+Each error carries a machine-readable code and optional registrar-specific detail.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class RegistrarErrorCode(StrEnum):
+    """Machine-readable error codes for registrar operations."""
+
+    AUTH_FAILED = "auth_failed"
+    DOMAIN_ALREADY_REGISTERED = "domain_already_registered"
+    DOMAIN_NOT_FOUND = "domain_not_found"
+    DOMAIN_LOCKED = "domain_locked"
+    DOMAIN_NOT_ELIGIBLE = "domain_not_eligible"
+    INVALID_REGISTRANT_DATA = "invalid_registrant_data"
+    INVALID_NAMESERVERS = "invalid_nameservers"
+    RATE_LIMITED = "rate_limited"
+    TIMEOUT = "timeout"
+    NETWORK_ERROR = "network_error"
+    INVALID_RESPONSE = "invalid_response"
+    WEBHOOK_SIGNATURE_INVALID = "webhook_signature_invalid"
+    INTERNAL_ERROR = "internal_error"
+
+
+class RegistrarAPIError(Exception):
+    """Base exception for all registrar API errors."""
+
+    def __init__(
+        self,
+        message: str,
+        code: RegistrarErrorCode = RegistrarErrorCode.INTERNAL_ERROR,
+        registrar_name: str = "",
+        detail: str = "",
+    ) -> None:
+        self.code = code
+        self.registrar_name = registrar_name
+        self.detail = detail
+        super().__init__(message)
+
+
+class RegistrarAuthError(RegistrarAPIError):
+    """Authentication or authorization failure with the registrar API."""
+
+    def __init__(self, registrar_name: str, detail: str = "") -> None:
+        super().__init__(
+            f"Authentication failed for registrar '{registrar_name}'",
+            code=RegistrarErrorCode.AUTH_FAILED,
+            registrar_name=registrar_name,
+            detail=detail,
+        )
+
+
+class RegistrarConflictError(RegistrarAPIError):
+    """Domain already exists at the registrar (registration conflict)."""
+
+    def __init__(self, domain_name: str, registrar_name: str) -> None:
+        super().__init__(
+            f"Domain '{domain_name}' already registered at '{registrar_name}'",
+            code=RegistrarErrorCode.DOMAIN_ALREADY_REGISTERED,
+            registrar_name=registrar_name,
+        )
+
+
+class RegistrarNotFoundError(RegistrarAPIError):
+    """Domain not found at the registrar."""
+
+    def __init__(self, domain_name: str, registrar_name: str) -> None:
+        super().__init__(
+            f"Domain '{domain_name}' not found at '{registrar_name}'",
+            code=RegistrarErrorCode.DOMAIN_NOT_FOUND,
+            registrar_name=registrar_name,
+        )
+
+
+class RegistrarRateLimitError(RegistrarAPIError):
+    """Registrar API rate limit exceeded."""
+
+    def __init__(self, registrar_name: str, retry_after: int | None = None) -> None:
+        self.retry_after = retry_after
+        detail = f"retry_after={retry_after}s" if retry_after else ""
+        super().__init__(
+            f"Rate limit exceeded for registrar '{registrar_name}'",
+            code=RegistrarErrorCode.RATE_LIMITED,
+            registrar_name=registrar_name,
+            detail=detail,
+        )
+
+
+class RegistrarTransientError(RegistrarAPIError):
+    """Transient/retryable error (timeout, network issue, 5xx)."""
+
+    def __init__(self, registrar_name: str, message: str, detail: str = "") -> None:
+        super().__init__(
+            message,
+            code=RegistrarErrorCode.NETWORK_ERROR,
+            registrar_name=registrar_name,
+            detail=detail,
+        )

--- a/services/platform/apps/domains/gateways/errors.py
+++ b/services/platform/apps/domains/gateways/errors.py
@@ -25,6 +25,7 @@ class RegistrarErrorCode(StrEnum):
     NETWORK_ERROR = "network_error"
     INVALID_RESPONSE = "invalid_response"
     WEBHOOK_SIGNATURE_INVALID = "webhook_signature_invalid"
+    NOT_CONFIGURED = "not_configured"
     INTERNAL_ERROR = "internal_error"
 
 

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -1,0 +1,246 @@
+"""
+Gandi REST API gateway for international domain registration.
+
+API docs: https://api.gandi.net/docs/domains/
+Auth: Personal Access Token via Authorization header.
+Rate limit: 30 requests / 2 seconds (negotiable for resellers).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from apps.common.outbound_http import OutboundPolicy
+from apps.common.types import Err, Ok, Result, Retriability
+
+from .base import (
+    HTTP_ACCEPTED,
+    HTTP_OK,
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import RegistrarAPIError, RegistrarErrorCode, RegistrarTransientError
+
+logger = logging.getLogger(__name__)
+
+GANDI_API_BASE = "https://api.gandi.net/v5"
+
+GANDI_POLICY = OutboundPolicy(
+    name="gandi_registrar",
+    allowed_domains=frozenset({"api.gandi.net"}),
+    timeout_seconds=30.0,
+    connect_timeout_seconds=10.0,
+    verify_tls=True,
+    max_retries=0,  # we handle retries in base class
+)
+
+
+class GandiGateway(BaseRegistrarGateway):
+    """Gandi REST API gateway for international domains (.com, .net, .org, .eu, etc.)."""
+
+    @property
+    def gateway_name(self) -> str:
+        return "gandi"
+
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        return GANDI_POLICY
+
+    def _auth_headers(self) -> dict[str, str]:
+        _, api_key = self.registrar.get_api_credentials()
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _get_sharing_id(self) -> str | None:
+        """Reseller sharing_id for per-customer billing (stored in api_username)."""
+        username = self.registrar.api_username
+        return username if username else None
+
+    # -- Core operations -----------------------------------------------------
+
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains"
+
+        body: dict[str, Any] = {
+            "fqdn": domain_name,
+            "duration": years,
+            "owner": self._map_registrant_to_gandi(registrant_data),
+        }
+
+        if nameservers:
+            body["nameservers"] = nameservers
+
+        sharing_id = self._get_sharing_id()
+        if sharing_id:
+            body["sharing_id"] = sharing_id
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # A registration POST may have reached the registrar before the network
+                # error — not provably safe to replay, so leave UNKNOWN (the default).
+                RegistrarTransientError(self.registrar.name, f"Network error during registration: {exc}"),
+            )
+
+        if response.status_code == HTTP_ACCEPTED:
+            data = self._safe_json(response)
+            expires_at = _parse_gandi_date(data.get("expires_at", ""))
+            if expires_at is None:
+                return Err(
+                    RegistrarAPIError(
+                        f"Gandi registration response missing/invalid expires_at for {domain_name}",
+                        code=RegistrarErrorCode.INVALID_RESPONSE,
+                        registrar_name=self.registrar.name,
+                    )
+                )
+            return Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id=data.get("id", domain_name),
+                    expires_at=expires_at,
+                    nameservers=nameservers or self.registrar.default_nameservers or [],
+                    epp_code=data.get("auth_info", ""),
+                )
+            )
+
+        return self._handle_error_response(response, f"register {domain_name}", domain_name=domain_name)
+
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}/renew"
+
+        body = {"duration": years}
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # Renewal is not idempotent (a second renewal double-charges/double-extends)
+                # and the POST may have landed — leave UNKNOWN (the default).
+                RegistrarTransientError(self.registrar.name, f"Network error during renewal: {exc}"),
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            data = self._safe_json(response)
+            new_expires_at = _parse_gandi_date(data.get("expires_at", ""))
+            if new_expires_at is None:
+                return Err(
+                    RegistrarAPIError(
+                        f"Gandi renewal response missing/invalid expires_at for {domain_name}",
+                        code=RegistrarErrorCode.INVALID_RESPONSE,
+                        registrar_name=self.registrar.name,
+                    )
+                )
+            return Ok(DomainRenewalResult(new_expires_at=new_expires_at))
+
+        return self._handle_error_response(response, f"renew {domain_name}", domain_name=domain_name)
+
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        url = f"{GANDI_API_BASE}/domain/check"
+        params = {"name": domain_name}
+
+        try:
+            response = self._api_request("GET", url, params=params, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # Availability is a read-only GET — safe to replay after a network error.
+                RegistrarTransientError(self.registrar.name, f"Network error during availability check: {exc}"),
+                retriability=Retriability.RETRIABLE,
+            )
+
+        if response.status_code == HTTP_OK:
+            data = self._safe_json(response)
+            products = data.get("products", [])
+            if products:
+                product = products[0]
+                status = product.get("status", "unavailable")
+                price_data = product.get("prices", [{}])
+                price_cents = None
+                if price_data:
+                    price_raw = price_data[0].get("price_after_taxes")
+                    if price_raw is not None:
+                        # A malformed price must not raise out of the Result contract;
+                        # availability is the primary signal, so just omit the price.
+                        try:
+                            price_cents = int(float(price_raw) * 100)
+                        except (TypeError, ValueError):
+                            logger.warning("Gandi returned unparseable price %r for %s", price_raw, domain_name)
+                            price_cents = None
+
+                return Ok(
+                    DomainAvailabilityResult(
+                        domain_name=domain_name,
+                        available=status == "available",
+                        premium=product.get("premium", False),
+                        price_cents=price_cents,
+                    )
+                )
+
+            return Ok(
+                DomainAvailabilityResult(
+                    domain_name=domain_name,
+                    available=False,
+                )
+            )
+
+        return self._handle_error_response(response, f"check availability for {domain_name}", domain_name=domain_name)
+
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _map_registrant_to_gandi(self, registrant_data: dict[str, Any]) -> dict[str, Any]:
+        """Map PRAHO registrant data to Gandi's owner contact format."""
+        return {
+            "given": registrant_data.get("first_name", ""),
+            "family": registrant_data.get("last_name", ""),
+            "email": registrant_data.get("email", ""),
+            "phone": registrant_data.get("phone", ""),
+            "streetaddr": registrant_data.get("address", ""),
+            "city": registrant_data.get("city", ""),
+            "zip": registrant_data.get("postal_code", ""),
+            "country": registrant_data.get("country_code", "RO"),
+            "type": registrant_data.get("entity_type", "individual"),
+            "orgname": registrant_data.get("company_name", ""),
+        }
+
+
+def _parse_gandi_date(date_str: str) -> datetime | None:
+    """Parse ISO 8601 date from Gandi API response.
+
+    Returns None on missing/unparseable input — callers must treat that as an
+    INVALID_RESPONSE rather than fabricating a date (a registration must never
+    record a wrong/already-past expiry).
+    """
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# Register with factory
+RegistrarGatewayFactory.register_gateway("gandi", GandiGateway)

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -4,6 +4,15 @@ Gandi REST API gateway for international domain registration.
 API docs: https://api.gandi.net/docs/domains/
 Auth: Personal Access Token via Authorization header.
 Rate limit: 30 requests / 2 seconds (negotiable for resellers).
+
+PROVISIONAL — NOT SANDBOX-VERIFIED. The success-response parsing here (expecting
+id/expires_at/auth_info in the register/renew body) was written from documentation
+and has not been validated against the live Gandi API, which documents a 202
+"accepted" body (message + Location) that likely requires polling the returned
+operation/domain resource for the confirmed state and expiry. Chargeable
+register/renew calls are gated behind settings.REGISTRAR_ADAPTERS_VERIFIED (default
+off) so this cannot run against real credentials until an operator validates it and
+reworks the 202 handling. Tracked as a follow-up.
 """
 
 from __future__ import annotations
@@ -84,12 +93,14 @@ class GandiGateway(BaseRegistrarGateway):
         if nameservers:
             body["nameservers"] = nameservers
 
+        # Gandi documents sharing_id as a query parameter, not a body field.
+        params = {}
         sharing_id = self._get_sharing_id()
         if sharing_id:
-            body["sharing_id"] = sharing_id
+            params["sharing_id"] = sharing_id
 
         try:
-            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+            response = self._api_request("POST", url, json=body, params=params, headers=self._auth_headers())
         except requests.RequestException as exc:
             return Err(
                 # A registration POST may have reached the registrar before the network

--- a/services/platform/apps/domains/gateways/rotld.py
+++ b/services/platform/apps/domains/gateways/rotld.py
@@ -1,0 +1,236 @@
+"""
+ROTLD REST API v2.0 gateway for .ro domain registration.
+
+ROTLD is the sole authority for Romanian domains (.ro, .com.ro, etc.).
+Test environment: registrar2-test.rotld.ro
+Production: rest2.rotld.ro
+
+Romanian-specific requirements:
+- CUI (Company Unique Identifier) for businesses
+- CNP (Personal Numeric Code) for individuals
+- Registrar accreditation from ICI-Bucharest required
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from apps.common.outbound_http import OutboundPolicy
+from apps.common.types import Err, Ok, Result, Retriability
+
+from .base import (
+    HTTP_ACCEPTED,
+    HTTP_CREATED,
+    HTTP_OK,
+    BaseRegistrarGateway,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+    DomainRenewalResult,
+    RegistrarGatewayFactory,
+)
+from .errors import RegistrarAPIError, RegistrarErrorCode, RegistrarTransientError
+
+logger = logging.getLogger(__name__)
+
+ROTLD_POLICY = OutboundPolicy(
+    name="rotld_registrar",
+    allowed_domains=frozenset({"rest2.rotld.ro", "registrar2-test.rotld.ro"}),
+    timeout_seconds=30.0,
+    connect_timeout_seconds=10.0,
+    verify_tls=True,
+    max_retries=0,
+)
+
+
+class ROTLDGateway(BaseRegistrarGateway):
+    """ROTLD REST API gateway for .ro domains."""
+
+    @property
+    def gateway_name(self) -> str:
+        return "rotld"
+
+    def _get_outbound_policy(self) -> OutboundPolicy:
+        return ROTLD_POLICY
+
+    def _auth_headers(self) -> dict[str, str]:
+        _username, api_key = self.registrar.get_api_credentials()
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    @property
+    def _api_base(self) -> str:
+        """Use the registrar's configured API endpoint."""
+        return self.registrar.api_endpoint.rstrip("/")
+
+    # -- Core operations -----------------------------------------------------
+
+    def _do_register(
+        self,
+        domain_name: str,
+        years: int,
+        registrant_data: dict[str, Any],
+        nameservers: list[str] | None,
+    ) -> Result[DomainRegistrationResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/register"
+
+        body: dict[str, Any] = {
+            "domain": domain_name,
+            "period": years,
+            "registrant": self._map_registrant_to_rotld(registrant_data),
+        }
+
+        if nameservers:
+            body["nameservers"] = [{"hostname": ns} for ns in nameservers]
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # A registration POST may have reached the registrar before the network
+                # error — not provably safe to replay, so leave UNKNOWN (the default).
+                RegistrarTransientError(self.registrar.name, f"Network error during registration: {exc}"),
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_CREATED, HTTP_ACCEPTED):
+            data = self._safe_json(response)
+            domain_data = data.get("domain", data)
+            expires_at = _parse_rotld_date(domain_data.get("expire_at", ""))
+            if expires_at is None:
+                return Err(
+                    RegistrarAPIError(
+                        f"ROTLD registration response missing/invalid expire_at for {domain_name}",
+                        code=RegistrarErrorCode.INVALID_RESPONSE,
+                        registrar_name=self.registrar.name,
+                    )
+                )
+            return Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id=str(domain_data.get("id", domain_name)),
+                    expires_at=expires_at,
+                    nameservers=nameservers or self.registrar.default_nameservers or [],
+                    epp_code=domain_data.get("authcode", ""),
+                )
+            )
+
+        return self._handle_error_response(response, f"register {domain_name}", domain_name=domain_name)
+
+    def _do_renew(
+        self,
+        registrar_domain_id: str,
+        domain_name: str,
+        years: int,
+    ) -> Result[DomainRenewalResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/renew"
+
+        body = {
+            "domain": domain_name,
+            "period": years,
+        }
+
+        try:
+            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # Renewal is not idempotent (a second renewal double-charges/double-extends)
+                # and the POST may have landed — leave UNKNOWN (the default).
+                RegistrarTransientError(self.registrar.name, f"Network error during renewal: {exc}"),
+            )
+
+        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
+            data = self._safe_json(response)
+            domain_data = data.get("domain", data)
+            new_expires_at = _parse_rotld_date(domain_data.get("expire_at", ""))
+            if new_expires_at is None:
+                return Err(
+                    RegistrarAPIError(
+                        f"ROTLD renewal response missing/invalid expire_at for {domain_name}",
+                        code=RegistrarErrorCode.INVALID_RESPONSE,
+                        registrar_name=self.registrar.name,
+                    )
+                )
+            return Ok(DomainRenewalResult(new_expires_at=new_expires_at))
+
+        return self._handle_error_response(response, f"renew {domain_name}", domain_name=domain_name)
+
+    def _do_check_availability(
+        self,
+        domain_name: str,
+    ) -> Result[DomainAvailabilityResult, RegistrarAPIError]:
+        url = f"{self._api_base}/domain/check"
+        params = {"domain": domain_name}
+
+        try:
+            response = self._api_request("GET", url, params=params, headers=self._auth_headers())
+        except requests.RequestException as exc:
+            return Err(
+                # Availability is a read-only GET — safe to replay after a network error.
+                RegistrarTransientError(self.registrar.name, f"Network error during availability check: {exc}"),
+                retriability=Retriability.RETRIABLE,
+            )
+
+        if response.status_code == HTTP_OK:
+            data = self._safe_json(response)
+            return Ok(
+                DomainAvailabilityResult(
+                    domain_name=domain_name,
+                    available=data.get("available", False),
+                    premium=False,
+                    price_cents=None,
+                )
+            )
+
+        return self._handle_error_response(response, f"check availability for {domain_name}", domain_name=domain_name)
+
+    def _do_verify_webhook(self, payload: str, signature: str, secret: str) -> bool:
+        return self._verify_hmac_sha256(payload, signature, secret)
+
+    # -- Helpers -------------------------------------------------------------
+
+    def _map_registrant_to_rotld(self, registrant_data: dict[str, Any]) -> dict[str, Any]:
+        """Map PRAHO registrant data to ROTLD's registrant format.
+
+        Romanian domains require CUI for businesses or CNP for individuals.
+        """
+        entity_type = registrant_data.get("entity_type", "individual")
+        result: dict[str, Any] = {
+            "name": f"{registrant_data.get('first_name', '')} {registrant_data.get('last_name', '')}".strip(),
+            "email": registrant_data.get("email", ""),
+            "phone": registrant_data.get("phone", ""),
+            "address": registrant_data.get("address", ""),
+            "city": registrant_data.get("city", ""),
+            "postal_code": registrant_data.get("postal_code", ""),
+            "country": registrant_data.get("country_code", "RO"),
+        }
+
+        if entity_type == "company":
+            result["org"] = registrant_data.get("company_name", "")
+            result["fiscal_code"] = registrant_data.get("cui", "")
+        else:
+            result["cnp"] = registrant_data.get("cnp", "")
+
+        return result
+
+
+def _parse_rotld_date(date_str: str) -> datetime | None:
+    """Parse date from ROTLD API response.
+
+    Returns None on missing/unparseable input so callers treat it as an
+    INVALID_RESPONSE rather than fabricating a (possibly already-past) expiry.
+    """
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+# Register with factory
+RegistrarGatewayFactory.register_gateway("rotld", ROTLDGateway)

--- a/services/platform/apps/domains/gateways/rotld.py
+++ b/services/platform/apps/domains/gateways/rotld.py
@@ -9,6 +9,12 @@ Romanian-specific requirements:
 - CUI (Company Unique Identifier) for businesses
 - CNP (Personal Numeric Code) for individuals
 - Registrar accreditation from ICI-Bucharest required
+
+PROVISIONAL — NOT SANDBOX-VERIFIED. The success-response parsing was written from
+documentation and has not been validated against the live ROTLD API. Chargeable
+register/renew calls are gated behind settings.REGISTRAR_ADAPTERS_VERIFIED (default
+off) so this cannot run against real credentials until an operator validates it.
+Tracked as a follow-up.
 """
 
 from __future__ import annotations

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -56,9 +56,30 @@ class DomainRegistrationConfig:
     domain_name: str
     tld: Any
     registrar: Any
+    registrant_data: dict[str, Any]
     years: int = 1
     whois_privacy: bool = False
     auto_renew: bool = True
+
+
+# Minimal country-name → ISO 3166-1 alpha-2 mapping for the registrant address.
+# The platform is Romania-first; unrecognized already-2-letter codes pass through.
+_COUNTRY_NAME_TO_CODE = {
+    "românia": "RO",
+    "romania": "RO",
+    "moldova": "MD",
+    "republica moldova": "MD",
+}
+
+
+def _country_to_iso_code(country: str) -> str:
+    """Best-effort ISO alpha-2 code from a free-text country field."""
+    normalized = country.strip().lower()
+    if normalized in _COUNTRY_NAME_TO_CODE:
+        return _COUNTRY_NAME_TO_CODE[normalized]
+    if len(country.strip()) == 2:  # noqa: PLR2004  # already an alpha-2 code
+        return country.strip().upper()
+    return ""
 
 
 # ===============================================================================
@@ -365,12 +386,19 @@ class DomainLifecycleService:
 
         tld, registrar = components.unwrap()
 
-        # Execute registration
+        # Build + validate registrant data BEFORE creating any row, so a customer
+        # missing required contact/tax data is rejected without leaving an orphan
+        # pending domain and without a blank-data call to the registrar.
+        registrant_result = DomainLifecycleService._build_registrant_data(customer)
+        if registrant_result.is_err():
+            return Err(registrant_result.unwrap_err())
+
         config = DomainRegistrationConfig(
             customer=customer,
             domain_name=domain_name,
             tld=tld,
             registrar=registrar,
+            registrant_data=registrant_result.unwrap(),
             years=years,
             whois_privacy=whois_privacy,
             auto_renew=auto_renew,
@@ -478,9 +506,8 @@ class DomainLifecycleService:
                                  because the registrar may hold the registration.
         Never raises.
         """
-        registrant_data = DomainLifecycleService._build_registrant_data(config.customer)
         success, payload = DomainRegistrarGateway.register_domain(
-            config.registrar, domain.name, config.years, registrant_data
+            config.registrar, domain.name, config.years, config.registrant_data
         )
 
         if not success:
@@ -522,13 +549,51 @@ class DomainLifecycleService:
             return "pending_unknown", str(e)
 
     @staticmethod
-    def _build_registrant_data(customer: Customer) -> dict[str, Any]:
-        """Assemble registrant contact data for a registrar from the customer."""
-        return {
-            "name": customer.get_display_name(),
-            "email": customer.primary_email,
-            "company": customer.company_name or "",
+    def _build_registrant_data(customer: Customer) -> Result[dict[str, Any], str]:
+        """Assemble registrar-ready registrant data from the customer, address, and tax profile.
+
+        Produces exactly the keys the Gandi/ROTLD mappers read (first_name, last_name,
+        email, phone, address, city, postal_code, country_code, entity_type,
+        company_name, cui, cnp) and validates that every registrar-required field is
+        present. Returns Err(message) listing any missing fields so registration is
+        rejected in PRAHO instead of sending blank contact data to the registrar.
+        """
+        entity_type = "company" if customer.customer_type == "company" else "individual"
+        address = customer.get_billing_address()
+        tax = customer.get_tax_profile()
+
+        name_parts = (customer.name or "").strip().split(None, 1)
+        first_name = name_parts[0] if name_parts else ""
+        last_name = name_parts[1] if len(name_parts) > 1 else ""
+
+        data: dict[str, Any] = {
+            "first_name": first_name,
+            "last_name": last_name,
+            "email": customer.primary_email or "",
+            "phone": customer.primary_phone or "",
+            "address": address.address_line1 if address else "",
+            "city": address.city if address else "",
+            "postal_code": address.postal_code if address else "",
+            "country_code": _country_to_iso_code(address.country) if address else "",
+            "entity_type": entity_type,
+            "company_name": customer.company_name or "",
+            "cui": tax.cui if tax else "",
+            "cnp": tax.cnp if tax else "",
         }
+
+        # Required for every registrant, plus entity-specific identity fields.
+        required = ["first_name", "email", "phone", "address", "city", "postal_code", "country_code"]
+        required.append("company_name" if entity_type == "company" else "last_name")
+        required.append("cui" if entity_type == "company" else "cnp")  # ROTLD regulatory requirement
+
+        missing = [field for field in required if not data[field]]
+        if missing:
+            return Err(
+                cast(str, _("Cannot register: customer is missing required registrant data: {fields}")).format(
+                    fields=", ".join(missing)
+                )
+            )
+        return Ok(data)
 
     @staticmethod
     def _validate_renewal_preconditions(domain: Domain) -> str | None:

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -15,8 +15,6 @@ Provides business logic for domain operations including:
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -27,7 +25,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.encryption import DecryptionError
+from apps.common.types import Err, Ok, Result
 from apps.settings.services import SettingsService
 
 from .models import TLD, Domain, DomainOrderItem, Registrar
@@ -58,6 +56,7 @@ class DomainRegistrationConfig:
     domain_name: str
     tld: Any
     registrar: Any
+    years: int = 1
     whois_privacy: bool = False
     auto_renew: bool = True
 
@@ -148,6 +147,13 @@ class DomainValidationService:
 
         # Remove leading/trailing whitespace
         domain_name = domain_name.strip().lower()
+
+        # Reject non-ASCII before any other check. str.isalnum() is True for Unicode
+        # letters, so a Cyrillic/Greek homograph would otherwise pass the character
+        # check below and be forwarded verbatim to the registrar. IDNs must be
+        # punycode-encoded (ASCII) by the caller.
+        if not domain_name.isascii():
+            return False, cast(str, _("Domain name must be ASCII (punycode-encode internationalized domains)"))
 
         # Check length
         if len(domain_name) < MIN_DOMAIN_NAME_LENGTH:
@@ -342,20 +348,22 @@ class DomainLifecycleService:
     @staticmethod
     def create_domain_registration(
         customer: Customer, domain_name: str, years: int = 1, whois_privacy: bool = False, auto_renew: bool = True
-    ) -> tuple[bool, Domain | str]:
-        """🆕 Create new domain registration"""
+    ) -> Result[Domain, str]:
+        """Create new domain registration.
 
+        Returns Ok(Domain) on success, Err(message) on failure.
+        """
         # Run all validation checks
         validation_result = DomainLifecycleService._validate_registration_preconditions(domain_name, years)
         if validation_result is not None:
-            return False, validation_result
+            return Err(validation_result)
 
         # Get validated components
-        components_result = DomainLifecycleService._get_registration_components(domain_name)
-        if isinstance(components_result, str):
-            return False, components_result
+        components = DomainLifecycleService._get_registration_components(domain_name)
+        if components.is_err():
+            return Err(components.unwrap_err())
 
-        tld, registrar = components_result
+        tld, registrar = components.unwrap()
 
         # Execute registration
         config = DomainRegistrationConfig(
@@ -363,6 +371,7 @@ class DomainLifecycleService:
             domain_name=domain_name,
             tld=tld,
             registrar=registrar,
+            years=years,
             whois_privacy=whois_privacy,
             auto_renew=auto_renew,
         )
@@ -370,13 +379,11 @@ class DomainLifecycleService:
 
     @staticmethod
     def _validate_registration_preconditions(domain_name: str, years: int) -> str | None:
-        """Validate all preconditions for domain registration"""
-        # Validate domain name format
+        """Validate all preconditions for domain registration."""
         is_valid, error_msg = DomainValidationService.validate_domain_name(domain_name)
         if not is_valid:
             return error_msg
 
-        # Validate registration period
         if years < MIN_REGISTRATION_YEARS or years > MAX_REGISTRATION_YEARS:
             return str(
                 _("Registration period must be between {min} and {max} years").format(
@@ -384,31 +391,40 @@ class DomainLifecycleService:
                 )
             )
 
-        # Check if domain already exists
         if Domain.objects.filter(name=domain_name.lower()).exists():
             return cast(str, _("Domain is already registered in the system"))
 
         return None
 
     @staticmethod
-    def _get_registration_components(domain_name: str) -> tuple[Any, Any] | str:
-        """Get TLD and registrar for domain registration"""
-        # Extract and validate TLD
+    def _get_registration_components(domain_name: str) -> Result[tuple[Any, Any], str]:
+        """Get TLD and registrar for domain registration."""
         tld_extension = DomainValidationService.extract_tld_from_domain(domain_name)
         tld = TLDService.get_tld_pricing(tld_extension)
         if not tld:
-            return cast(str, _(f"TLD '.{tld_extension}' is not supported"))
+            return Err(cast(str, _(f"TLD '.{tld_extension}' is not supported")))
 
-        # Select registrar
         registrar = RegistrarService.select_best_registrar_for_tld(tld)
         if not registrar:
-            return cast(str, _("No available registrar for this TLD"))
+            return Err(cast(str, _("No available registrar for this TLD")))
 
-        return tld, registrar
+        return Ok((tld, registrar))
 
     @staticmethod
-    def _execute_domain_registration(config: DomainRegistrationConfig) -> tuple[bool, Domain | str]:
-        """Execute the actual domain registration"""
+    def _execute_domain_registration(config: DomainRegistrationConfig) -> Result[Domain, str]:
+        """Execute the actual domain registration.
+
+        Two-step so the external registrar call never runs inside a DB transaction:
+        1. Create the local Domain row in ``pending`` state (records intent).
+        2. Submit to the registrar via the gateway. On success, persist the
+           registrar-returned fields and FSM-transition the domain to ``active``.
+           On failure, the domain stays ``pending`` (no failed state exists) so a
+           later retry/worker can re-submit — the gateway is idempotent per domain.
+
+        Returns Ok(domain) in both the active and the still-pending case (the local
+        record exists and the order item must link to it); a pending domain means
+        registration was NOT confirmed at the registrar and must be completed later.
+        """
         try:
             with transaction.atomic():
                 domain = Domain.objects.create(
@@ -416,60 +432,113 @@ class DomainLifecycleService:
                     tld=config.tld,
                     registrar=config.registrar,
                     customer=config.customer,
-                    status="pending",
                     whois_privacy=config.whois_privacy,
                     auto_renew=config.auto_renew,
                 )
-
-                logger.info(
-                    f"🆕 [Domain] Created domain registration record: {config.domain_name} for customer {config.customer.id}"
-                )
-                return True, domain
-
+                logger.info("Created domain registration: %s for customer %s", config.domain_name, config.customer.id)
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to create domain registration: {e}")
-            return False, cast(str, _("Failed to create domain registration"))
+            logger.error("Failed to create domain registration: %s", e)
+            return Err(cast(str, _("Failed to create domain registration")))
+
+        # Submit to the registrar OUTSIDE the transaction above — never hold a DB
+        # transaction open across network I/O.
+        DomainLifecycleService._submit_registration_to_registrar(domain, config)
+        return Ok(domain)
 
     @staticmethod
-    def process_domain_renewal(domain: Domain, years: int = 1) -> tuple[bool, str]:
-        """🔄 Process domain renewal"""
-        if domain.status != "active":
-            return False, cast(str, _("Domain must be active to renew"))
+    def _submit_registration_to_registrar(domain: Domain, config: DomainRegistrationConfig) -> bool:
+        """Submit a pending domain to its registrar and activate it on success.
 
-        if not domain.expires_at:
-            return False, cast(str, _("Domain expiration date is not set"))
+        Returns True if the registrar confirmed registration (domain now active),
+        False if it failed (domain left pending for retry). Never raises.
+        """
+        registrant_data = DomainLifecycleService._build_registrant_data(config.customer)
+        success, payload = DomainRegistrarGateway.register_domain(
+            config.registrar, domain.name, config.years, registrant_data
+        )
+
+        if not success:
+            logger.warning(
+                "Registrar did not confirm %s (left pending for retry): %s",
+                domain.name,
+                payload.get("error", "unknown error"),
+            )
+            return False
 
         try:
             with transaction.atomic():
-                # Calculate new expiration date
-                new_expiration = domain.expires_at + timedelta(days=365 * years)
+                locked = Domain.objects.select_for_update().get(pk=domain.pk)
+                # Another worker may have already completed this domain.
+                if locked.status != "pending":
+                    return bool(locked.status == "active")
 
-                # Update domain
-                domain.expires_at = new_expiration
-                domain.renewal_notices_sent = 0  # Reset renewal notices
-                domain.save(update_fields=["expires_at", "renewal_notices_sent", "updated_at"])
+                locked.registrar_domain_id = payload.get("registrar_domain_id", "")
+                if payload.get("expires_at"):
+                    locked.expires_at = payload["expires_at"]
+                if payload.get("nameservers"):
+                    locked.nameservers = payload["nameservers"]
+                if payload.get("epp_code"):
+                    locked.set_encrypted_epp_code(payload["epp_code"])
+                locked.registered_at = timezone.now()
+                locked.activate()  # FSM transition: pending -> active
+                locked.save()
 
-                logger.info(f"🔄 [Domain] Renewed domain {domain.name} for {years} years, expires: {new_expiration}")
-
-                return True, cast(str, _("Domain renewed successfully"))
-
+            # Reflect the persisted state on the caller's instance.
+            domain.refresh_from_db()
+            logger.info("Registrar confirmed %s — domain active", domain.name)
+            return True
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to renew domain {domain.name}: {e}")
-            return False, cast(str, _("Failed to renew domain"))
+            logger.error("Failed to persist registrar result for %s (left pending): %s", domain.name, e)
+            return False
 
     @staticmethod
-    def update_domain_expiration(domain: Domain, new_expiration: datetime) -> bool:
-        """📅 Update domain expiration date (from registrar sync)"""
+    def _build_registrant_data(customer: Customer) -> dict[str, Any]:
+        """Assemble registrant contact data for a registrar from the customer."""
+        return {
+            "name": customer.get_display_name(),
+            "email": customer.primary_email,
+            "company": customer.company_name or "",
+        }
+
+    @staticmethod
+    def process_domain_renewal(domain: Domain, years: int = 1) -> Result[str, str]:
+        """Process domain renewal.
+
+        Returns Ok(success_message) on success, Err(error_message) on failure.
+        """
+        if domain.status != "active":
+            return Err(cast(str, _("Domain must be active to renew")))
+
+        if not domain.expires_at:
+            return Err(cast(str, _("Domain expiration date is not set")))
+
+        try:
+            with transaction.atomic():
+                new_expiration = domain.expires_at + timedelta(days=365 * years)
+                domain.expires_at = new_expiration
+                domain.renewal_notices_sent = 0
+                domain.save(update_fields=["expires_at", "renewal_notices_sent", "updated_at"])
+
+                logger.info("Renewed domain %s for %d years, expires: %s", domain.name, years, new_expiration)
+                return Ok(cast(str, _("Domain renewed successfully")))
+
+        except Exception as e:
+            logger.error("Failed to renew domain %s: %s", domain.name, e)
+            return Err(cast(str, _("Failed to renew domain")))
+
+    @staticmethod
+    def update_domain_expiration(domain: Domain, new_expiration: datetime) -> Result[bool, str]:
+        """Update domain expiration date (from registrar sync)."""
         try:
             domain.expires_at = new_expiration
             domain.save(update_fields=["expires_at", "updated_at"])
 
-            logger.info(f"📅 [Domain] Updated expiration for {domain.name}: {new_expiration}")
-            return True
+            logger.info("Updated expiration for %s: %s", domain.name, new_expiration)
+            return Ok(True)
 
         except Exception as e:
-            logger.error(f"🔥 [Domain] Failed to update expiration for {domain.name}: {e}")
-            return False
+            logger.error("Failed to update expiration for %s: %s", domain.name, e)
+            return Err(cast(str, _("Failed to update domain expiration")))
 
 
 # ===============================================================================
@@ -596,7 +665,7 @@ class DomainOrderService:
 
         for item in domain_items:
             if item.action == "register":
-                success, result = DomainLifecycleService.create_domain_registration(
+                result = DomainLifecycleService.create_domain_registration(
                     customer=order.customer,
                     domain_name=item.domain_name,
                     years=item.years,
@@ -604,23 +673,23 @@ class DomainOrderService:
                     auto_renew=item.auto_renew,
                 )
 
-                if success and isinstance(result, Domain):
-                    item.domain = result
+                if result.is_ok():
+                    domain = result.unwrap()
+                    item.domain = domain
                     item.save(update_fields=["domain"])
-                    processed_domains.append(result)
-
-                    logger.info(f"✅ [Domain] Processed registration: {item.domain_name}")
+                    processed_domains.append(domain)
+                    logger.info("Processed registration: %s", item.domain_name)
                 else:
-                    logger.error(f"🔥 [Domain] Failed to process registration: {item.domain_name}")
+                    logger.error("Failed to process registration %s: %s", item.domain_name, result.unwrap_err())
 
             elif item.action == "renew" and item.domain:
-                success, _msg = DomainLifecycleService.process_domain_renewal(domain=item.domain, years=item.years)
+                renewal_result = DomainLifecycleService.process_domain_renewal(domain=item.domain, years=item.years)
 
-                if success:
+                if renewal_result.is_ok():
                     processed_domains.append(item.domain)
-                    logger.info(f"✅ [Domain] Processed renewal: {item.domain_name}")
+                    logger.info("Processed renewal: %s", item.domain_name)
                 else:
-                    logger.error(f"🔥 [Domain] Failed to process renewal: {item.domain_name}")
+                    logger.error("Failed to process renewal %s: %s", item.domain_name, renewal_result.unwrap_err())
 
         return processed_domains
 
@@ -631,75 +700,90 @@ class DomainOrderService:
 
 
 class DomainRegistrarGateway:
-    """
-    🌐 External registrar API integration gateway
+    """Backward-compatible facade that delegates to the gateway layer.
 
-    Provides abstraction layer for different registrar APIs (Namecheap, GoDaddy, ROTLD).
-    This is a placeholder implementation for future registrar integrations.
+    The real implementations live in apps.domains.gateways (Gandi, ROTLD, etc.).
+    This class preserves the existing tuple-based return types so callers
+    (webhooks.py, DomainOrderService) don't need to change yet.
     """
 
     @staticmethod
     def register_domain(
         registrar: Registrar, domain_name: str, years: int, customer_data: dict[str, Any]
     ) -> tuple[bool, dict[str, Any]]:
-        """🆕 Register domain with external registrar"""
-        logger.info(f"🌐 [Gateway] Would register {domain_name} via {registrar.name}")
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual registrar API calls
-        # This is a placeholder implementation
-        return True, {
-            "registrar_domain_id": f"DOM_{domain_name}_{timezone.now().timestamp()}",
-            "expires_at": timezone.now() + timedelta(days=365 * years),
-            "nameservers": registrar.default_nameservers or [],
-            "epp_code": f"EPP_{domain_name[:10].upper()}",
-        }
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot register %s", registrar.name, domain_name)
+            return False, {"error": f"No gateway for registrar {registrar.name}"}
+
+        result = gateway.register_domain(domain_name, years, customer_data)
+        if result.is_ok():
+            reg = result.unwrap()
+            return True, {
+                "registrar_domain_id": reg.registrar_domain_id,
+                "expires_at": reg.expires_at,
+                "nameservers": reg.nameservers,
+                "epp_code": reg.epp_code,
+            }
+        return False, {"error": str(result.unwrap_err())}
 
     @staticmethod
     def renew_domain(registrar: Registrar, domain: Domain, years: int) -> tuple[bool, dict[str, Any]]:
-        """🔄 Renew domain with external registrar"""
-        logger.info(f"🌐 [Gateway] Would renew {domain.name} via {registrar.name}")
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual registrar API calls
-        return True, {
-            "new_expires_at": (domain.expires_at or timezone.now()) + timedelta(days=365 * years),
-        }
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot renew %s", registrar.name, domain.name)
+            return False, {"error": f"No gateway for registrar {registrar.name}"}
+
+        result = gateway.renew_domain(domain.registrar_domain_id, domain.name, years)
+        if result.is_ok():
+            renewal = result.unwrap()
+            return True, {"new_expires_at": renewal.new_expires_at}
+        return False, {"error": str(result.unwrap_err())}
 
     @staticmethod
-    def check_domain_availability(registrar: Registrar, domain_name: str) -> tuple[bool, bool]:  # (success, available)
-        """🔍 Check domain availability with registrar"""
-        logger.info(f"🌐 [Gateway] Would check availability for {domain_name} via {registrar.name}")
+    def check_domain_availability(registrar: Registrar, domain_name: str) -> tuple[bool, bool]:
+        from .gateways import RegistrarGatewayFactory  # noqa: PLC0415
 
-        # TODO: Implement actual availability check
-        # For now, assume domain is available if not in our database
-        is_available = not Domain.objects.filter(name=domain_name.lower()).exists()
+        try:
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            logger.error("No gateway registered for %s — cannot check %s", registrar.name, domain_name)
+            return False, False
 
-        return True, is_available
+        result = gateway.check_availability(domain_name)
+        if result.is_ok():
+            return True, result.unwrap().available
+        return False, False
 
     @staticmethod
     def verify_webhook_signature(registrar: Registrar, payload: str, signature: str) -> bool:
-        """🔐 Verify webhook signature using registrar's HMAC-SHA256 webhook secret.
+        from .gateways import BaseRegistrarGateway, RegistrarGatewayFactory  # noqa: PLC0415
 
-        Fail-closed: returns False on any error (missing secret, missing signature,
-        decryption failure, empty secret, mismatch, or unexpected exception).
-        Uses timing-safe comparison to prevent side-channel attacks.
-        """
-        if not registrar.webhook_secret or not signature:
-            logger.warning(f"⚠️ [Gateway] Missing webhook secret or signature for {registrar.name}")
-            return False
-
+        # Only the "no gateway registered" case should fall through to the fallback;
+        # don't swallow errors from the gateway's own verification.
         try:
-            decrypted = registrar.get_decrypted_webhook_secret()
-        except DecryptionError:
-            logger.error(
-                f"🔥 [Gateway] Webhook secret decryption failed for {registrar.name} — encryption key may have rotated"
-            )
+            gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        except ValueError:
+            gateway = None
+        if gateway is not None:
+            return gateway.verify_webhook_signature(payload, signature)
+
+        # Fallback: shared HMAC-SHA256 for registrars without a dedicated gateway.
+        if not registrar.webhook_secret or not signature:
             return False
-
-        if not decrypted or not decrypted.strip():
-            logger.error(f"🔥 [Gateway] Webhook secret for {registrar.name} decrypted to empty value")
+        try:
+            secret = registrar.get_decrypted_webhook_secret()
+        except Exception:
+            # Previously swallowed silently — log so a decryption/key-rotation outage
+            # is visible instead of every webhook quietly failing verification.
+            logger.error("Webhook secret decryption failed for %s (encryption key may have rotated)", registrar.name)
             return False
-
-        webhook_secret = decrypted.strip().encode("utf-8")
-
-        expected = hmac.new(webhook_secret, payload.encode("utf-8"), hashlib.sha256).hexdigest()
-        return hmac.compare_digest(f"sha256={expected}", signature)
+        if not secret or not secret.strip():
+            return False
+        return BaseRegistrarGateway._verify_hmac_sha256(payload, signature, secret.strip())

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -25,7 +25,7 @@ from django.db.models import Q, QuerySet
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 from apps.settings.services import SettingsService
 
 from .models import TLD, Domain, DomainOrderItem, Registrar
@@ -421,9 +421,13 @@ class DomainLifecycleService:
            On failure, the domain stays ``pending`` (no failed state exists) so a
            later retry/worker can re-submit — the gateway is idempotent per domain.
 
-        Returns Ok(domain) in both the active and the still-pending case (the local
-        record exists and the order item must link to it); a pending domain means
-        registration was NOT confirmed at the registrar and must be completed later.
+        Returns Ok(domain) ONLY when the registrar confirms and the domain is
+        active. On a definite rejection the pending row is removed and Err is
+        returned so the caller can cleanly retry. On an UNKNOWN outcome (network
+        error / 5xx — the registrar may already hold the registration) the row is
+        kept pending and Err is returned so the caller never reports success and
+        never orphans a possibly-real registration. Durable reconciliation of
+        pending rows is tracked separately (issue #237).
         """
         try:
             with transaction.atomic():
@@ -442,15 +446,37 @@ class DomainLifecycleService:
 
         # Submit to the registrar OUTSIDE the transaction above — never hold a DB
         # transaction open across network I/O.
-        DomainLifecycleService._submit_registration_to_registrar(domain, config)
-        return Ok(domain)
+        outcome, message = DomainLifecycleService._submit_registration_to_registrar(domain, config)
+
+        if outcome == "confirmed":
+            domain.refresh_from_db()
+            return Ok(domain)
+        if outcome == "pending_unknown":
+            return Err(
+                cast(
+                    str,
+                    _(
+                        "Registration was submitted but the registrar did not confirm it. "
+                        "It is pending verification — do not resubmit."
+                    ),
+                )
+            )
+        # Definite rejection: the pending row has been removed, retry is safe.
+        return Err(cast(str, _("Registrar rejected the registration: {error}")).format(error=message))
 
     @staticmethod
-    def _submit_registration_to_registrar(domain: Domain, config: DomainRegistrationConfig) -> bool:
-        """Submit a pending domain to its registrar and activate it on success.
+    def _submit_registration_to_registrar(domain: Domain, config: DomainRegistrationConfig) -> tuple[str, str]:
+        """Submit a pending domain to its registrar and resolve its final state.
 
-        Returns True if the registrar confirmed registration (domain now active),
-        False if it failed (domain left pending for retry). Never raises.
+        Returns one of:
+        - ("confirmed", "")      registrar confirmed; the domain is now active.
+        - ("rejected", message)  definite failure (conflict/auth/validation); the
+                                 pending row is DELETED so a retry isn't deadlocked
+                                 by the uniqueness precondition.
+        - ("pending_unknown", message)  network/5xx (UNKNOWN) or a post-confirm
+                                 persistence failure; the row is KEPT pending
+                                 because the registrar may hold the registration.
+        Never raises.
         """
         registrant_data = DomainLifecycleService._build_registrant_data(config.customer)
         success, payload = DomainRegistrarGateway.register_domain(
@@ -458,19 +484,23 @@ class DomainLifecycleService:
         )
 
         if not success:
-            logger.warning(
-                "Registrar did not confirm %s (left pending for retry): %s",
-                domain.name,
-                payload.get("error", "unknown error"),
-            )
-            return False
+            error = str(payload.get("error", "unknown error"))
+            if payload.get("retriability") == Retriability.UNKNOWN.value:
+                logger.warning(
+                    "Registrar outcome UNKNOWN for %s (kept pending, do not resubmit): %s", domain.name, error
+                )
+                return "pending_unknown", error
+            # Definite rejection — remove the row so the customer can re-register.
+            logger.warning("Registrar rejected %s (row removed for clean retry): %s", domain.name, error)
+            domain.delete()
+            return "rejected", error
 
         try:
             with transaction.atomic():
                 locked = Domain.objects.select_for_update().get(pk=domain.pk)
                 # Another worker may have already completed this domain.
                 if locked.status != "pending":
-                    return bool(locked.status == "active")
+                    return ("confirmed", "") if locked.status == "active" else ("pending_unknown", "")
 
                 locked.registrar_domain_id = payload.get("registrar_domain_id", "")
                 if payload.get("expires_at"):
@@ -483,13 +513,13 @@ class DomainLifecycleService:
                 locked.activate()  # FSM transition: pending -> active
                 locked.save()
 
-            # Reflect the persisted state on the caller's instance.
-            domain.refresh_from_db()
             logger.info("Registrar confirmed %s — domain active", domain.name)
-            return True
+            return "confirmed", ""
         except Exception as e:
-            logger.error("Failed to persist registrar result for %s (left pending): %s", domain.name, e)
-            return False
+            # The registrar confirmed but we failed to record it — the domain IS
+            # registered, so keep the row pending (never delete/orphan) for reconciliation.
+            logger.error("Failed to persist registrar result for %s (kept pending): %s", domain.name, e)
+            return "pending_unknown", str(e)
 
     @staticmethod
     def _build_registrant_data(customer: Customer) -> dict[str, Any]:
@@ -501,30 +531,59 @@ class DomainLifecycleService:
         }
 
     @staticmethod
-    def process_domain_renewal(domain: Domain, years: int = 1) -> Result[str, str]:
-        """Process domain renewal.
-
-        Returns Ok(success_message) on success, Err(error_message) on failure.
-        """
+    def _validate_renewal_preconditions(domain: Domain) -> str | None:
+        """Return an error message if the domain cannot be renewed, else None."""
         if domain.status != "active":
-            return Err(cast(str, _("Domain must be active to renew")))
-
+            return cast(str, _("Domain must be active to renew"))
         if not domain.expires_at:
-            return Err(cast(str, _("Domain expiration date is not set")))
+            return cast(str, _("Domain expiration date is not set"))
+        if not domain.registrar_domain_id:
+            # No registrar record to renew against — a local-only extension would be
+            # a lie about the registrar's expiry.
+            return cast(str, _("Domain has no registrar record; cannot renew"))
+        return None
+
+    @staticmethod
+    def process_domain_renewal(domain: Domain, years: int = 1) -> Result[str, str]:
+        """Process domain renewal by renewing at the registrar first.
+
+        The registrar is the source of truth for the new expiry — the local row is
+        updated ONLY after the registrar confirms, using the registrar-returned
+        date (never local ``365 * years`` math). On any registrar failure the local
+        expiry is left untouched (failing toward "not renewed" is the safe
+        direction; a later registrar-sync can correct it upward).
+
+        Returns Ok(success_message) on confirmed renewal, Err(error_message) otherwise.
+        """
+        precondition_error = DomainLifecycleService._validate_renewal_preconditions(domain)
+        if precondition_error is not None:
+            return Err(precondition_error)
+
+        success, payload = DomainRegistrarGateway.renew_domain(domain.registrar, domain, years)
+        if not success:
+            logger.warning("Registrar did not confirm renewal of %s: %s", domain.name, payload.get("error"))
+            return Err(
+                cast(str, _("Registrar did not confirm the renewal: {error}")).format(
+                    error=payload.get("error", "unknown error")
+                )
+            )
+
+        new_expiration = payload.get("new_expires_at")
+        if not new_expiration:
+            return Err(cast(str, _("Registrar renewal succeeded but returned no new expiry date")))
 
         try:
             with transaction.atomic():
-                new_expiration = domain.expires_at + timedelta(days=365 * years)
                 domain.expires_at = new_expiration
                 domain.renewal_notices_sent = 0
                 domain.save(update_fields=["expires_at", "renewal_notices_sent", "updated_at"])
 
-                logger.info("Renewed domain %s for %d years, expires: %s", domain.name, years, new_expiration)
-                return Ok(cast(str, _("Domain renewed successfully")))
+            logger.info("Renewed domain %s for %d years at registrar, expires: %s", domain.name, years, new_expiration)
+            return Ok(cast(str, _("Domain renewed successfully")))
 
         except Exception as e:
-            logger.error("Failed to renew domain %s: %s", domain.name, e)
-            return Err(cast(str, _("Failed to renew domain")))
+            logger.error("Failed to persist renewal for %s: %s", domain.name, e)
+            return Err(cast(str, _("Failed to record the renewal")))
 
     @staticmethod
     def update_domain_expiration(domain: Domain, new_expiration: datetime) -> Result[bool, str]:
@@ -728,7 +787,10 @@ class DomainRegistrarGateway:
                 "nameservers": reg.nameservers,
                 "epp_code": reg.epp_code,
             }
-        return False, {"error": str(result.unwrap_err())}
+        # Carry the retriability so the lifecycle can tell a definite rejection
+        # (safe to delete the pending row) from an UNKNOWN outcome (may have
+        # registered server-side — must keep the row, never resubmit blindly).
+        return False, {"error": str(result.unwrap_err()), "retriability": retriability_of(result).value}
 
     @staticmethod
     def renew_domain(registrar: Registrar, domain: Domain, years: int) -> tuple[bool, dict[str, Any]]:

--- a/services/platform/apps/domains/views.py
+++ b/services/platform/apps/domains/views.py
@@ -372,7 +372,7 @@ def domain_register(  # Complexity: multi-step workflow  # noqa: PLR0912  # Comp
                     messages.error(request, _("❌ You do not have permission for this customer"))
                 else:
                     # Validate domain and create registration
-                    success, result = DomainLifecycleService.create_domain_registration(
+                    result = DomainLifecycleService.create_domain_registration(
                         customer=customer,
                         domain_name=domain_name,
                         years=years,
@@ -380,14 +380,12 @@ def domain_register(  # Complexity: multi-step workflow  # noqa: PLR0912  # Comp
                         auto_renew=auto_renew,
                     )
 
-                    if success:
+                    if result.is_ok():
                         messages.success(request, _(f"✅ Domain {domain_name} registered successfully!"))
-                        # result is a Domain object when success is True
-                        domain = cast(Domain, result)
+                        domain = result.unwrap()
                         return redirect("domains:detail", domain_id=domain.id)
                     else:
-                        # result is a string error message when success is False
-                        messages.error(request, _(f"❌ Registration failed: {result}"))
+                        messages.error(request, _(f"❌ Registration failed: {result.unwrap_err()}"))
 
             except Customer.DoesNotExist:
                 messages.error(request, _("Invalid customer selected"))
@@ -494,13 +492,13 @@ def domain_renew(request: HttpRequest, domain_id: str) -> HttpResponse:
     if request.method == "POST":
         years = int(request.POST.get("years", 1))
 
-        success, message = DomainLifecycleService.process_domain_renewal(domain=domain, years=years)
+        renewal_result = DomainLifecycleService.process_domain_renewal(domain=domain, years=years)
 
-        if success:
+        if renewal_result.is_ok():
             messages.success(request, _(f"✅ Domain renewed for {years} year(s)!"))
             return redirect("domains:detail", domain_id=domain_id)
         else:
-            messages.error(request, _(f"❌ Renewal failed: {message}"))
+            messages.error(request, _(f"❌ Renewal failed: {renewal_result.unwrap_err()}"))
 
     # Calculate renewal costs
     renewal_costs = []

--- a/services/platform/apps/domains/views.py
+++ b/services/platform/apps/domains/views.py
@@ -26,6 +26,7 @@ from .forms import RegistrarForm, TLDForm
 from .models import TLD, Domain, DomainOrderItem, Registrar
 from .services import (
     DomainLifecycleService,
+    DomainRegistrarGateway,
     DomainRepository,
     DomainValidationService,
     RegistrarService,
@@ -415,7 +416,7 @@ def domain_register(  # Complexity: multi-step workflow  # noqa: PLR0912  # Comp
 
 @login_required
 @require_http_methods(["POST"])
-def check_availability(request: HttpRequest) -> JsonResponse:
+def check_availability(request: HttpRequest) -> JsonResponse:  # noqa: PLR0911  # sequential input/availability guards
     """🔍 AJAX endpoint to check domain availability"""
     domain_name = request.POST.get("domain_name", "").strip().lower()
 
@@ -443,13 +444,21 @@ def check_availability(request: HttpRequest) -> JsonResponse:
             }
         )
 
-    # Get registrar and check availability (placeholder implementation)
+    # Get registrar and check availability at the registrar.
     registrar = RegistrarService.select_best_registrar_for_tld(tld)
     if not registrar:
         return JsonResponse({"success": False, "error": _("No available registrar for this TLD")})
 
-    # For now, assume available if not in our database
-    # TODO: Implement actual registrar API availability check
+    # Ask the registrar. Fail closed: if we cannot confirm availability, never claim
+    # the domain is available — a domain registered elsewhere but absent locally would
+    # otherwise be reported free (W1).
+    check_ok, is_available = DomainRegistrarGateway.check_domain_availability(registrar, domain_name)
+    if not check_ok:
+        return JsonResponse({"success": False, "error": _("Could not verify domain availability. Please try again.")})
+    if not is_available:
+        return JsonResponse(
+            {"success": True, "available": False, "message": _("Domain is not available"), "domain_name": domain_name}
+        )
 
     # Calculate pricing
     pricing_1yr = TLDService.calculate_domain_cost(tld, 1, False)

--- a/services/platform/config/settings/base.py
+++ b/services/platform/config/settings/base.py
@@ -366,6 +366,14 @@ REST_FRAMEWORK = {
 API_TOKEN_DEFAULT_TTL_DAYS = int(os.environ.get("API_TOKEN_DEFAULT_TTL_DAYS", "90"))
 API_TOKEN_MAX_TTL_DAYS = int(os.environ.get("API_TOKEN_MAX_TTL_DAYS", "365"))
 
+# Registrar gateway safety gate (ADR/#93). The Gandi/ROTLD response schemas were
+# implemented against documentation and have NOT been validated against a live
+# registrar sandbox (blocked on accreditation). Until an operator confirms an
+# adapter against the real API and flips this flag, the concrete gateways refuse
+# chargeable register/renew calls — so an unverified adapter can never mis-handle a
+# real, paid registrar operation. Availability checks (read-only) are always allowed.
+REGISTRAR_ADAPTERS_VERIFIED = os.environ.get("REGISTRAR_ADAPTERS_VERIFIED", "false").lower() == "true"
+
 # ===============================================================================
 # ROMANIAN BUSINESS CONFIGURATION
 # ===============================================================================

--- a/services/platform/docs/plans/anaf-compliance-roadmap.md
+++ b/services/platform/docs/plans/anaf-compliance-roadmap.md
@@ -1,0 +1,63 @@
+# ANAF e-Factura compliance roadmap — what's mandatory, what's not, how to get there
+
+Honest framing of the compliance gaps. Romanian e-Factura is **mandatory** for invoices to Romanian
+businesses (since 1 Jan 2024) and consumers (since 1 Jan 2025); non-submission carries fines. This is
+Romanian law, not a product choice. BUT the work is far smaller and more gated than the gap table
+suggests. (Not legal advice — confirm the exact obligation/scope with the company's accountant.)
+
+## The single most important fact: it's gated on an ANAF account
+Everything in the "submission" bucket requires, as a hard prerequisite:
+1. The company's **qualified digital certificate** registered in ANAF SPV (Spațiul Privat Virtual).
+2. An **OAuth2 app** registered at anaf.ro/InregOauth → `client_id` + `client_secret`.
+3. **Sandbox/test** credentials (`EFACTURA_ENVIRONMENT=test`).
+Until these exist, the submission code **cannot be tested end-to-end** and shouldn't be written blind.
+This is an admin/business step (hours of portal paperwork), not engineering. **It is Phase 0.**
+
+## Bucketed verdict
+| Item | Verdict | Gated on ANAF account? |
+|---|---|---|
+| ANAF submission (cert, OAuth, /upload, /listaMesajeFactura) | **mandatory** | YES |
+| B2C `/uploadb2c` | mandatory **iff we have B2C (consumer) customers** | YES |
+| Working-days deadline (OUG 89/2025) | mandatory (if submitting) — **codeable + testable NOW** | no |
+| Electronic seal retrieval (download sealed XML/ZIP) | mandatory (if submitting) | YES |
+| Archiving/retention (10 yr) | mandatory — but plain storage, e-Factura-agnostic | no |
+| **Full Schematron (Saxon)** | **NOT needed** — ANAF validates server-side; native partial suffices | n/a |
+| 6 correctness bugs | just bugs (5/6 fixed) | no |
+| Refund lifecycle (#196) | separate product gap | no |
+
+## Phased plan
+
+### Phase 0 — Obtain ANAF credentials (BLOCKER, non-engineering)
+Register the digital certificate in SPV + the OAuth app; get test-environment credentials. Nothing in
+the submission bucket can be verified before this. **Do this first.**
+
+### Phase 1 — Codeable + testable NOW (no ANAF account)
+- **Working-days deadline (OUG 89/2025).** New `working_days.py::add_working_days(date, n)` using the
+  `holidays` lib (Romania, incl. moveable Orthodox Easter); convert `issued_at` to Romania-local date;
+  load holidays across the year boundary. Wire all three calendar-day sites (`efactura/models.py:411
+  submission_deadline`, `efactura/service.py:366` query window, `efactura/settings.py:745`; relabel the
+  setting at `:606`). TDD: pin 2026 RO holidays. **This is real legal compliance we can ship today.**
+- **The ANAF response-parsing fixes that ARE unit-testable** (#123 gaps 1/3/4) against documented
+  formats + recorded fixtures: `UploadResponse.from_response()` parses XML (`index_incarcare`,
+  `ExecutionStatus="0"`); `/listaMesaje`→`/listaMesajeFactura`; `upload_b2c()` POST shape. These can be
+  TDD'd with sample XML/mocked HTTP even though the LIVE round-trip needs the sandbox.
+
+### Phase 2 — Submission (after Phase 0 credentials exist)
+Implement + sandbox-verify the full flow: OAuth token exchange, `/upload` (B2B) + `/uploadb2c` (B2C)
+with `standard=UBL`, status polling, download + **store the ANAF-sealed XML as the legal original**.
+Resolve the content-type / standard-name unknowns (#123 gaps 2/7/8) against the live sandbox. This is
+the well-scoped #123 backlog — ~1–2 focused weeks once credentials exist; mostly UNVERIFIABLE before.
+
+### Phase 3 — Retention
+10-year archival of the sealed XML + a retrieval path. Storage concern; can reuse existing object
+storage. Small, independent.
+
+### Explicitly dropped
+Full client-side Schematron (Saxon). Keep the native partial validator as the pre-flight. Revisit only
+if rejected-submission rates justify the 40MB native dependency.
+
+## Recommendation
+1. Start the ANAF SPV account process now (Phase 0) — it's the gate and it's not our code.
+2. Ship Phase 1 (working-days deadline) now — real, legal, testable today.
+3. Hold Phase 2 (submission) until sandbox credentials exist; don't write the live paths blind.
+4. Don't build Schematron.

--- a/services/platform/docs/plans/efactura-billing-unified-plan.md
+++ b/services/platform/docs/plans/efactura-billing-unified-plan.md
@@ -1,0 +1,93 @@
+# Unified e-Factura / billing correctness plan — v2 (post dual-review REWORK)
+
+v1 was REWORKed by BOTH codex and the internal code-reviewer (2 CRITICAL each, verified against code).
+This v2 incorporates every CRITICAL/HIGH. Tax-compliance correctness is paramount; no overengineering.
+
+## What the reviews changed
+- **Phase A is a double-tax fix, not "just land #192."** `InvoiceService.create_from_order` (services.py:141-142)
+  feeds `order.total_cents` (GROSS, tax-inclusive — orders/models.py:130) into
+  `calculate_vat_for_document(subtotal_cents=…)`, which adds VAT again → header double-tax. PR #192 fixes
+  only the `InvoiceLine` field-name crash below it (lines 168-176), unmasking the double-tax. VERIFIED.
+- **Phase B shrinks; the "unify 4 emitters" spine is over-engineered.** The XML + PDF already reconcile via the
+  `_get_document_discount = Σ line.subtotal_cents − invoice.subtotal_cents` invariant (xml_builder.py:313),
+  which is legacy-safe. The meta allowances/charges path is DORMANT JSON; making `recalculate_totals`
+  meta-aware is a LEDGER-INTEGRITY risk (codex HIGH). The only real bug is `recalculate_totals` ignoring
+  `discount_cents`. So Phase B = fix that one bug + document the invariant; do NOT build a meta-aware spine.
+- **Phase D moves EARLIER** (before B): e-Factura `PrepaidAmount` depends on `get_remaining_amount`
+  (xml_builder.py:812). And the refund risk is broader than "double count": live refunds are created
+  `status="pending"` with blank `gateway_refund_id`, and `get_remaining_amount` counts ONLY `completed` —
+  so pending gateway refunds may be IGNORED for PrepaidAmount, while migration 0024 can dup/skip on
+  blank-id same-amount rows. Must investigate prod + the completion path FIRST.
+
+## Gross vs net contract (the invariant everything depends on — make it explicit, do not break it)
+- `Order.subtotal_cents` = GROSS line extension (Σ line nets, before discount). `Order.total_cents` = GROSS
+  final (subtotal − discount + tax). `calculate_document_totals(items, discount)` returns `subtotal_cents` =
+  GROSS, discount applied only inside `total_cents` (financial_arithmetic.py:76).
+- `Invoice/Proforma.subtotal_cents` = NET (gross − discount). The XML/PDF DERIVE the document discount as
+  `Σ line.subtotal_cents − header.subtotal_cents`, which equals the stored `discount_cents` for new invoices
+  AND bridges legacy ones with no backfill. **This invariant must be preserved by every change below.**
+
+## Phases (sequenced A → D → B → C → E → F; all codeable now)
+
+### Phase A — `create_from_order`: land the crash fix AND fix the double-tax — S/M, CRITICAL
+1. Apply PR #192's `InvoiceLine` field fix (description/kind/quantity/unit_price_cents/tax_rate), co-authored.
+2. **Fix the VAT base**: compute VAT on the NET taxable base like the proforma path
+   (`taxable = order.subtotal_cents − order.discount_cents`, proforma_service.py:176), NOT `order.total_cents`.
+   Carry `discount_cents=order.discount_cents` onto the invoice. (Or copy the order's already-correct
+   subtotal/tax/total — decide during impl.)
+3. TDD: assert invoice.subtotal/tax/total **equal the source order's** (no double-tax) AND lines reconcile
+   (Σ line.subtotal_cents − invoice.subtotal_cents == discount). Pins the contract before Phase B refactors.
+
+### Phase D — refund / PrepaidAmount correctness (move early; feeds e-Factura) — M, HIGH
+1. **Investigate first** (do not assume): grep the WHOLE repo for any live path that sets a `Refund` to
+   `status="completed"` (`.complete()` / `status="completed"`). `get_remaining_amount` (invoice_models.py:354)
+   counts only `completed`; live `_create_refund_record` creates `pending` with blank `gateway_refund_id`.
+   Run a prod-shape check: blank-`gateway_refund_id` same-amount refunds per invoice (dup risk) and
+   pending-refund coverage. Establish which failure is LIVE (pending ignored vs migration dup vs dedup skip).
+2. Fix what's proven live: (a) populate `gateway_refund_id` on live refund creation (refund_service.py:763,
+   source at :1261); (b) ensure `get_remaining_amount` reflects the right refund states; (c) harden 0024-style
+   dedup. Regression test on `get_remaining_amount` → XML `PrepaidAmount`/`PayableAmount`.
+
+### Phase B — `recalculate_totals` discount-aware + document the invariant — S, HIGH
+1. invoice_models.py:324 + proforma_models.py:213: pass the stored discount →
+   `calculate_document_totals(list(self.lines.all()), self.discount_cents)` so `subtotal_cents` stays NET and
+   `total_cents = net + tax`. Do NOT make it meta-aware (dormant JSON; ledger-integrity risk).
+2. Name the reachable caller that runs `recalculate_totals` on a discounted doc (the primary create paths
+   deliberately skip it — proforma_service.py:249). If none, mark it a latent guard + assert it's never
+   called on a discounted issued invoice (the freeze already blocks mutation).
+3. Add a module docstring stating the gross/net contract + the `gross − net == discount` invariant.
+4. Credit-note: the LIVE document-discount path is already correct (`line_gross − _get_document_discount`).
+   Leave the dormant meta parity alone (both reviews: don't expand dormant paths).
+
+### Phase C — working-days submission deadline (#123 Gap 6, OUG 89/2025, in force) — M, HIGH
+1. New `apps/billing/efactura/working_days.py::add_working_days(d, n)` using `holidays.Romania` (add the dep).
+   Convert `issued_at` to **Romania local date** before arithmetic; load holidays across the year boundary
+   (`years=[d.year, d.year+1]`) so a December issue sees January holidays.
+2. Wire ALL THREE calendar-day sites: `efactura/models.py:411 submission_deadline` (PRIMARY),
+   `efactura/service.py:366` (deadline query window), `efactura/settings.py:745`; update the setting label at
+   settings.py:606 ("calendar" → "working"). Tests pinning 2026 RO holidays (Orthodox Easter, Pentecost, fixed).
+
+### Phase E — dead-code + test hardening (#195) — M, MEDIUM
+1. Delete the dead `EFacturaXMLGenerator` helpers in **apps/billing/efactura_service.py:165-503** + 2 orphaned
+   dataclasses + dead test classes. KEEP `generate_invoice_xml` (delegates; `EFacturaSubmissionService` uses it).
+   HAZARD: 5 names (`_add_supplier_party`, `_add_customer_party`, `_add_payment_means`, `_add_payment_terms`,
+   `_add_invoice_lines`) also exist LIVE in `efactura/xml_builder.py` — delete ONLY the efactura_service.py copies.
+2. Strengthen the setup-fee + discount reconciliation lifecycle test (sum line subtotals + proforma totals +
+   XML LineExtension/AllowanceTotal reconcile). Harden the immutability test: it's a regression GUARD (behaviour
+   already holds) — must CHANGE the value (e.g. discount 500→600 on a locked invoice) so it isn't a no-op.
+
+### Phase F — ANAF response/endpoint fixes 1/3/4 (user-requested; unit-testable) — M
+Codeable + UNIT-testable against documented ANAF formats (the LIVE integration still needs a sandbox account):
+- Gap 1: `UploadResponse.from_response()` parse XML (lxml), extract `index_incarcare` from `<header>`,
+  `ExecutionStatus="0"`=success. Test against a sample ANAF XML response fixture.
+- Gap 3: `upload_b2c()` → POST `/uploadb2c?standard=UBL&cif={CUI}`; wire from the B2C detector. Mocked-HTTP test.
+- Gap 4: `/listaMesaje` → `/listaMesajeFactura` (+ paginated variant). Mocked-HTTP test.
+- Gaps 2/7/8 stay deferred (genuinely need a sandbox to determine content-types / standard names).
+
+## Deferred (justified)
+- Full Saxon Schematron (native partial validator already covers BR-CO/S/Z/CL); add saxonche at ANAF go-live.
+- #103 currency infra (separate program).
+
+## Process
+- Each phase = its own TDD'd, dual-reviewed, PR-sized commit; `make lint`/`check-types`/billing-suite gates;
+  lint every changed file incl. tests. Verify every agent CLAIM against code before acting (this rework proved why).

--- a/services/platform/tests/domains/test_availability_view.py
+++ b/services/platform/tests/domains/test_availability_view.py
@@ -1,0 +1,49 @@
+"""W1: the availability endpoint must consult the registrar, failing closed on uncertainty."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.domains.models import TLD, Registrar, TLDRegistrarAssignment
+
+User = get_user_model()
+
+
+class CheckAvailabilityViewTests(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(email="u@test.com", password="StrongPass123!")
+        self.client.force_login(self.user)
+        self.tld = TLD.objects.create(
+            extension="com", description=".com", registration_price_cents=1000, renewal_price_cents=1000,
+            transfer_price_cents=1000, registrar_cost_cents=500, min_registration_period=1, max_registration_period=10,
+        )
+        self.registrar = Registrar.objects.create(
+            name="reg", display_name="Reg", website_url="https://r.example",
+            api_endpoint="https://api.r.example", status="active",
+        )
+        TLDRegistrarAssignment.objects.create(tld=self.tld, registrar=self.registrar, is_primary=True, is_active=True, priority=1)
+        self.url = reverse("domains:check_availability")
+
+    def test_registrar_says_unavailable(self) -> None:
+        with patch("apps.domains.services.DomainRegistrarGateway.check_domain_availability", return_value=(True, False)):
+            resp = self.client.post(self.url, {"domain_name": "taken.com"})
+        data = resp.json()
+        self.assertTrue(data["success"])
+        self.assertFalse(data["available"])
+
+    def test_registrar_says_available(self) -> None:
+        with patch("apps.domains.services.DomainRegistrarGateway.check_domain_availability", return_value=(True, True)):
+            resp = self.client.post(self.url, {"domain_name": "free.com"})
+        data = resp.json()
+        self.assertTrue(data["available"])
+
+    def test_fails_closed_when_registrar_check_errors(self) -> None:
+        """A gateway error must NOT report the domain as available."""
+        with patch("apps.domains.services.DomainRegistrarGateway.check_domain_availability", return_value=(False, False)):
+            resp = self.client.post(self.url, {"domain_name": "unknown.com"})
+        data = resp.json()
+        self.assertFalse(data.get("available", False))

--- a/services/platform/tests/domains/test_domains_security.py
+++ b/services/platform/tests/domains/test_domains_security.py
@@ -8,9 +8,8 @@ from django.urls import reverse
 
 from apps.common.encryption import decrypt_sensitive_data, is_encrypted
 from apps.domains.forms import RegistrarForm
-from apps.domains.models import Registrar, TLD, Domain
-from apps.domains.services import DomainLifecycleService
-
+from apps.domains.models import TLD, Registrar
+from apps.domains.services import DomainLifecycleService, DomainValidationService
 
 User = get_user_model()
 
@@ -125,29 +124,29 @@ class DomainRegistrationRaceConditionTests(TestCase):
         )
 
     def test_duplicate_registration_returns_already_registered(self) -> None:
-        ok, res = DomainLifecycleService.create_domain_registration(
+        result = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="example.com",
             years=1,
         )
-        self.assertTrue(ok, res)
+        self.assertTrue(result.is_ok(), result)
 
-        ok2, res2 = DomainLifecycleService.create_domain_registration(
+        result2 = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="example.com",
             years=1,
         )
-        self.assertFalse(ok2)
-        self.assertIn("already registered", str(res2).lower())
+        self.assertTrue(result2.is_err())
+        self.assertIn("already registered", str(result2.unwrap_err()).lower())
 
     def test_years_out_of_range_rejected(self) -> None:
-        ok, res = DomainLifecycleService.create_domain_registration(
+        result = DomainLifecycleService.create_domain_registration(
             customer=self.customer,
             domain_name="too.com",
             years=20,
         )
-        self.assertFalse(ok)
-        self.assertIn("period", str(res).lower())
+        self.assertTrue(result.is_err())
+        self.assertIn("period", str(result.unwrap_err()).lower())
 
 
 class RegistrarAdminAuthorizationTests(TestCase):
@@ -170,3 +169,18 @@ class RegistrarAdminAuthorizationTests(TestCase):
         self.client.login(email="admin@example.com", password="testpass123")
         resp = self.client.get(reverse("domains:registrar_create"))
         self.assertEqual(resp.status_code, 200)
+
+
+class DomainNameHomographValidationTests(TestCase):
+    """validate_domain_name rejects non-ASCII homographs (PR #169 review M1)."""
+
+    def test_non_ascii_homograph_rejected(self) -> None:
+        # "example.com" with the ASCII 'a' replaced by Cyrillic small a (U+0430).
+        homograph = "ex\u0430mple.com"
+        is_valid, msg = DomainValidationService.validate_domain_name(homograph)
+        self.assertFalse(is_valid)
+        self.assertIn("ASCII", str(msg))
+
+    def test_ascii_domain_accepted(self) -> None:
+        is_valid, _msg = DomainValidationService.validate_domain_name("example.com")
+        self.assertTrue(is_valid)

--- a/services/platform/tests/domains/test_domains_security.py
+++ b/services/platform/tests/domains/test_domains_security.py
@@ -9,7 +9,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from apps.common.encryption import decrypt_sensitive_data, is_encrypted
-from apps.customers.models import Customer
+from apps.customers.models import Customer, CustomerAddress, CustomerTaxProfile
 from apps.domains.forms import RegistrarForm
 from apps.domains.models import TLD, Registrar, TLDRegistrarAssignment
 from apps.domains.services import DomainLifecycleService, DomainValidationService
@@ -118,9 +118,15 @@ class DomainRegistrationRaceConditionTests(TestCase):
         self.customer = Customer.objects.create(
             name="John Doe",
             primary_email="cust@example.com",
+            primary_phone="+40712345678",
             company_name="ACME",
             customer_type="individual",
         )
+        CustomerAddress.objects.create(
+            customer=self.customer, address_line1="Str. Test 1", city="Bucuresti", county="Bucuresti",
+            postal_code="010101", country="România", is_primary=True, is_current=True,
+        )
+        CustomerTaxProfile.objects.create(customer=self.customer, cnp="1900101123456")
 
     def test_duplicate_registration_returns_already_registered(self) -> None:
         # First registration must be registrar-confirmed to leave an active row —

--- a/services/platform/tests/domains/test_domains_security.py
+++ b/services/platform/tests/domains/test_domains_security.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
+from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
 
 from apps.common.encryption import decrypt_sensitive_data, is_encrypted
+from apps.customers.models import Customer
 from apps.domains.forms import RegistrarForm
-from apps.domains.models import TLD, Registrar
+from apps.domains.models import TLD, Registrar, TLDRegistrarAssignment
 from apps.domains.services import DomainLifecycleService, DomainValidationService
 
 User = get_user_model()
@@ -104,7 +107,6 @@ class DomainRegistrationRaceConditionTests(TestCase):
             status="active",
         )
         # Associate registrar as primary for the TLD
-        from apps.domains.models import TLDRegistrarAssignment
         TLDRegistrarAssignment.objects.create(
             tld=self.tld,
             registrar=self.registrar,
@@ -112,9 +114,6 @@ class DomainRegistrationRaceConditionTests(TestCase):
             is_active=True,
             priority=1,
         )
-
-        # Minimal user/customer – import lazily to avoid cross-app heavy setup
-        from apps.customers.models import Customer
 
         self.customer = Customer.objects.create(
             name="John Doe",
@@ -124,11 +123,26 @@ class DomainRegistrationRaceConditionTests(TestCase):
         )
 
     def test_duplicate_registration_returns_already_registered(self) -> None:
-        result = DomainLifecycleService.create_domain_registration(
-            customer=self.customer,
-            domain_name="example.com",
-            years=1,
+        # First registration must be registrar-confirmed to leave an active row —
+        # the uniqueness precondition then blocks the duplicate.
+        confirmed_payload = (
+            True,
+            {
+                "registrar_domain_id": "REG-1",
+                "expires_at": datetime(2027, 1, 1, tzinfo=UTC),
+                "nameservers": [],
+                "epp_code": "",
+            },
         )
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.register_domain",
+            return_value=confirmed_payload,
+        ):
+            result = DomainLifecycleService.create_domain_registration(
+                customer=self.customer,
+                domain_name="example.com",
+                years=1,
+            )
         self.assertTrue(result.is_ok(), result)
 
         result2 = DomainLifecycleService.create_domain_registration(

--- a/services/platform/tests/domains/test_gateway_registration_wiring.py
+++ b/services/platform/tests/domains/test_gateway_registration_wiring.py
@@ -15,10 +15,19 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from apps.customers.models import Customer
+from apps.customers.models import Customer, CustomerAddress, CustomerTaxProfile
 from apps.domains.gateways import RegistrarGatewayFactory
 from apps.domains.models import TLD, Domain, Registrar, TLDRegistrarAssignment
 from apps.domains.services import DomainLifecycleService
+
+
+def _give_registrant_data(customer: Customer, *, cui: str = "", cnp: str = "") -> None:
+    """Attach a billing address + tax profile so registrant-data validation passes."""
+    CustomerAddress.objects.create(
+        customer=customer, address_line1="Str. Test 1", city="Bucuresti", county="Bucuresti",
+        postal_code="010101", country="România", is_primary=True, is_current=True,
+    )
+    CustomerTaxProfile.objects.create(customer=customer, cui=cui, cnp=cnp)
 
 
 class GatewayFactoryRegistrationTests(TestCase):
@@ -64,9 +73,11 @@ class DomainRegistrationGatewayWiringTests(TestCase):
         self.customer = Customer.objects.create(
             name="John Doe",
             primary_email="cust@example.com",
+            primary_phone="+40712345678",
             company_name="ACME",
             customer_type="individual",
         )
+        _give_registrant_data(self.customer, cnp="1900101123456")
 
     def test_successful_registrar_call_activates_domain_and_persists_fields(self) -> None:
         expires = datetime(2027, 1, 1, tzinfo=UTC)
@@ -203,3 +214,84 @@ class RenewalGatewayWiringTests(TestCase):
 
         self.assertTrue(result.is_err(), result)
         mock_renew.assert_not_called()
+
+
+class RegistrantDataBuildingTests(TestCase):
+    """_build_registrant_data must produce the exact keys the gateway mappers read,
+    sourced from Customer + address + tax profile, and validate required fields."""
+
+    def setUp(self) -> None:
+        self.CustomerAddress = CustomerAddress
+        self.CustomerTaxProfile = CustomerTaxProfile
+        self.company = Customer.objects.create(
+            name="Acme Contact", primary_email="biz@acme.ro", primary_phone="+40712345678",
+            company_name="Acme SRL", customer_type="company",
+        )
+        CustomerAddress.objects.create(
+            customer=self.company, address_line1="Str. Test 1", city="Bucuresti", county="Bucuresti",
+            postal_code="010101", country="România",
+            is_primary=True, is_current=True,
+        )
+        CustomerTaxProfile.objects.create(customer=self.company, cui="RO12345678", is_vat_payer=True)
+
+    def test_company_registrant_data_has_all_mapper_keys(self) -> None:
+        result = DomainLifecycleService._build_registrant_data(self.company)
+        self.assertTrue(result.is_ok(), result)
+        data = result.unwrap()
+        for key in ("first_name", "last_name", "email", "phone", "address", "city",
+                    "postal_code", "country_code", "entity_type", "company_name", "cui", "cnp"):
+            self.assertIn(key, data)
+        self.assertEqual(data["entity_type"], "company")
+        self.assertEqual(data["company_name"], "Acme SRL")
+        self.assertEqual(data["cui"], "RO12345678")
+        self.assertEqual(data["phone"], "+40712345678")
+        self.assertEqual(data["country_code"], "RO")
+        self.assertEqual(data["address"], "Str. Test 1")
+
+    def test_individual_registrant_data_carries_cnp(self) -> None:
+        individual = Customer.objects.create(
+            name="Ion Popescu", primary_email="ion@example.ro", primary_phone="+40799999999",
+            customer_type="individual",
+        )
+        self.CustomerAddress.objects.create(
+            customer=individual, address_line1="Str. B 2", city="Cluj", county="Cluj",
+            postal_code="400001", country="România", is_primary=True, is_current=True,
+        )
+        self.CustomerTaxProfile.objects.create(customer=individual, cnp="1900101123456")
+
+        result = DomainLifecycleService._build_registrant_data(individual)
+        self.assertTrue(result.is_ok(), result)
+        data = result.unwrap()
+        self.assertEqual(data["entity_type"], "individual")
+        self.assertEqual(data["first_name"], "Ion")
+        self.assertEqual(data["last_name"], "Popescu")
+        self.assertEqual(data["cnp"], "1900101123456")
+
+    def test_missing_address_is_rejected(self) -> None:
+        no_addr = Customer.objects.create(
+            name="No Address", primary_email="na@example.ro", primary_phone="+40700000000",
+            customer_type="individual",
+        )
+        self.CustomerTaxProfile.objects.create(customer=no_addr, cnp="1900101123456")
+        result = DomainLifecycleService._build_registrant_data(no_addr)
+        self.assertTrue(result.is_err(), result)
+
+    def test_registration_rejected_up_front_when_registrant_incomplete(self) -> None:
+        """A customer with no address/tax data must not create a pending Domain row."""
+        bare = Customer.objects.create(
+            name="Bare", primary_email="bare@example.ro", customer_type="company",
+        )
+        # register.com TLD+registrar resolution reuses the class-level fixtures? build minimal:
+        tld = TLD.objects.create(
+            extension="net", description=".net", registration_price_cents=1000, renewal_price_cents=1000,
+            transfer_price_cents=1000, registrar_cost_cents=500, min_registration_period=1, max_registration_period=10,
+        )
+        reg = Registrar.objects.create(
+            name="reg2", display_name="Reg2", website_url="https://r2.example",
+            api_endpoint="https://api.r2.example", status="active",
+        )
+        TLDRegistrarAssignment.objects.create(tld=tld, registrar=reg, is_primary=True, is_active=True, priority=1)
+
+        result = DomainLifecycleService.create_domain_registration(customer=bare, domain_name="bare.net", years=1)
+        self.assertTrue(result.is_err(), result)
+        self.assertFalse(Domain.objects.filter(name="bare.net").exists())

--- a/services/platform/tests/domains/test_gateway_registration_wiring.py
+++ b/services/platform/tests/domains/test_gateway_registration_wiring.py
@@ -17,7 +17,7 @@ from django.test import TestCase
 
 from apps.customers.models import Customer
 from apps.domains.gateways import RegistrarGatewayFactory
-from apps.domains.models import TLD, Registrar, TLDRegistrarAssignment
+from apps.domains.models import TLD, Domain, Registrar, TLDRegistrarAssignment
 from apps.domains.services import DomainLifecycleService
 
 
@@ -106,10 +106,13 @@ class DomainRegistrationGatewayWiringTests(TestCase):
         self.assertNotEqual(domain.epp_code, "EPP-SECRET")
         self.assertEqual(domain.get_decrypted_epp_code(), "EPP-SECRET")
 
-    def test_registrar_failure_leaves_domain_pending(self) -> None:
+    def test_definite_rejection_returns_err_and_deletes_row(self) -> None:
+        """A definite registrar rejection (conflict/auth/validation) must return Err
+        AND remove the pending row, so the customer can cleanly re-register the name
+        (the uniqueness precondition would otherwise deadlock every retry)."""
         with patch(
             "apps.domains.services.DomainRegistrarGateway.register_domain",
-            return_value=(False, {"error": "registrar down"}),
+            return_value=(False, {"error": "domain already registered", "retriability": "not_retriable"}),
         ) as mock_register:
             result = DomainLifecycleService.create_domain_registration(
                 customer=self.customer,
@@ -117,10 +120,86 @@ class DomainRegistrationGatewayWiringTests(TestCase):
                 years=1,
             )
 
-        self.assertTrue(result.is_ok(), result)
+        self.assertTrue(result.is_err(), result)
         mock_register.assert_called_once()
+        # Row removed so a retry is not blocked by "already registered in the system".
+        self.assertFalse(Domain.objects.filter(name="example.com").exists())
 
-        domain = result.unwrap()
-        domain.refresh_from_db()
+    def test_unknown_outcome_returns_err_and_keeps_pending_row(self) -> None:
+        """A network/5xx (UNKNOWN) outcome may have registered the domain server-side,
+        so the row must stay pending (never orphan a possibly-real registration) and
+        the result must be Err (never report success)."""
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.register_domain",
+            return_value=(False, {"error": "connection reset", "retriability": "unknown"}),
+        ) as mock_register:
+            result = DomainLifecycleService.create_domain_registration(
+                customer=self.customer,
+                domain_name="example.com",
+                years=1,
+            )
+
+        self.assertTrue(result.is_err(), result)
+        mock_register.assert_called_once()
+        domain = Domain.objects.get(name="example.com")
         self.assertEqual(domain.status, "pending")
-        self.assertEqual(domain.registrar_domain_id, "")
+
+
+class RenewalGatewayWiringTests(TestCase):
+    """process_domain_renewal must contact the registrar, not just extend locally."""
+
+    def setUp(self) -> None:
+        self.tld = TLD.objects.create(
+            extension="com", description=".com",
+            registration_price_cents=1000, renewal_price_cents=1000,
+            transfer_price_cents=1000, registrar_cost_cents=500,
+            min_registration_period=1, max_registration_period=10,
+        )
+        self.registrar = Registrar.objects.create(
+            name="test-registrar", display_name="Test Registrar",
+            website_url="https://example.com", api_endpoint="https://api.example.com", status="active",
+        )
+        self.customer = Customer.objects.create(
+            name="John Doe", primary_email="cust@example.com",
+            company_name="ACME", customer_type="individual",
+        )
+        self.domain = Domain.objects.create(
+            name="renew.com", tld=self.tld, registrar=self.registrar, customer=self.customer,
+            status="active", registrar_domain_id="REG-1", expires_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+    def test_renewal_calls_gateway_and_persists_registrar_expiry(self) -> None:
+        registrar_expiry = datetime(2028, 1, 1, tzinfo=UTC)
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.renew_domain",
+            return_value=(True, {"new_expires_at": registrar_expiry}),
+        ) as mock_renew:
+            result = DomainLifecycleService.process_domain_renewal(self.domain, years=2)
+
+        self.assertTrue(result.is_ok(), result)
+        mock_renew.assert_called_once()
+        self.domain.refresh_from_db()
+        # Uses the registrar-returned expiry, NOT local 365*years date math.
+        self.assertEqual(self.domain.expires_at, registrar_expiry)
+
+    def test_renewal_failure_returns_err_and_does_not_extend(self) -> None:
+        original_expiry = self.domain.expires_at
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.renew_domain",
+            return_value=(False, {"error": "registrar rejected", "retriability": "unknown"}),
+        ):
+            result = DomainLifecycleService.process_domain_renewal(self.domain, years=2)
+
+        self.assertTrue(result.is_err(), result)
+        self.domain.refresh_from_db()
+        # Local expiry must be untouched — failing toward "not renewed" is the safe direction.
+        self.assertEqual(self.domain.expires_at, original_expiry)
+
+    def test_renewal_blocked_when_no_registrar_domain_id(self) -> None:
+        self.domain.registrar_domain_id = ""
+        self.domain.save(update_fields=["registrar_domain_id"])
+        with patch("apps.domains.services.DomainRegistrarGateway.renew_domain") as mock_renew:
+            result = DomainLifecycleService.process_domain_renewal(self.domain, years=1)
+
+        self.assertTrue(result.is_err(), result)
+        mock_renew.assert_not_called()

--- a/services/platform/tests/domains/test_gateway_registration_wiring.py
+++ b/services/platform/tests/domains/test_gateway_registration_wiring.py
@@ -1,0 +1,126 @@
+"""Regression tests for the registrar-gateway wiring (PR #169 review C1/C2).
+
+C1: the concrete gateways must be registered with the factory simply by importing
+    the gateways package — otherwise the registry is empty at runtime and the whole
+    gateway layer is dead code in production.
+C2: create_domain_registration must actually call the registrar gateway and only
+    activate the domain when the registrar confirms; a registrar failure must leave
+    the domain pending (not falsely report it registered).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.customers.models import Customer
+from apps.domains.gateways import RegistrarGatewayFactory
+from apps.domains.models import TLD, Registrar, TLDRegistrarAssignment
+from apps.domains.services import DomainLifecycleService
+
+
+class GatewayFactoryRegistrationTests(TestCase):
+    """C1 — importing the package alone must populate the factory registry."""
+
+    def test_importing_gateways_package_registers_concrete_gateways(self) -> None:
+        # The module-level `from apps.domains.gateways import ...` (no direct
+        # import of the concrete gandi/rotld modules) must be enough to register them.
+        available = RegistrarGatewayFactory.list_available_gateways()
+        self.assertIn("gandi", available)
+        self.assertIn("rotld", available)
+
+
+class DomainRegistrationGatewayWiringTests(TestCase):
+    """C2 — the live registration path must invoke the gateway."""
+
+    def setUp(self) -> None:
+        self.tld = TLD.objects.create(
+            extension="com",
+            description=".com",
+            registration_price_cents=1000,
+            renewal_price_cents=1000,
+            transfer_price_cents=1000,
+            registrar_cost_cents=500,
+            min_registration_period=1,
+            max_registration_period=10,
+        )
+        self.registrar = Registrar.objects.create(
+            name="test-registrar",
+            display_name="Test Registrar",
+            website_url="https://example.com",
+            api_endpoint="https://api.example.com",
+            status="active",
+        )
+        TLDRegistrarAssignment.objects.create(
+            tld=self.tld,
+            registrar=self.registrar,
+            is_primary=True,
+            is_active=True,
+            priority=1,
+        )
+
+        self.customer = Customer.objects.create(
+            name="John Doe",
+            primary_email="cust@example.com",
+            company_name="ACME",
+            customer_type="individual",
+        )
+
+    def test_successful_registrar_call_activates_domain_and_persists_fields(self) -> None:
+        expires = datetime(2027, 1, 1, tzinfo=UTC)
+        gateway_payload = {
+            "registrar_domain_id": "REG-12345",
+            "expires_at": expires,
+            "nameservers": ["ns1.example.com", "ns2.example.com"],
+            "epp_code": "EPP-SECRET",
+        }
+
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.register_domain",
+            return_value=(True, gateway_payload),
+        ) as mock_register:
+            result = DomainLifecycleService.create_domain_registration(
+                customer=self.customer,
+                domain_name="example.com",
+                years=2,
+            )
+
+        self.assertTrue(result.is_ok(), result)
+        mock_register.assert_called_once()
+        # Gateway was called with the resolved registrar, domain, and years.
+        args = mock_register.call_args.args
+        self.assertEqual(args[0], self.registrar)
+        self.assertEqual(args[1], "example.com")
+        self.assertEqual(args[2], 2)
+
+        domain = result.unwrap()
+        domain.refresh_from_db()
+        self.assertEqual(domain.status, "active")
+        self.assertEqual(domain.registrar_domain_id, "REG-12345")
+        self.assertEqual(domain.expires_at, expires)
+        self.assertEqual(domain.nameservers, ["ns1.example.com", "ns2.example.com"])
+        self.assertIsNotNone(domain.registered_at)
+        # epp_code is stored encrypted, not in plaintext.
+        self.assertNotEqual(domain.epp_code, "EPP-SECRET")
+        self.assertEqual(domain.get_decrypted_epp_code(), "EPP-SECRET")
+
+    def test_registrar_failure_leaves_domain_pending(self) -> None:
+        with patch(
+            "apps.domains.services.DomainRegistrarGateway.register_domain",
+            return_value=(False, {"error": "registrar down"}),
+        ) as mock_register:
+            result = DomainLifecycleService.create_domain_registration(
+                customer=self.customer,
+                domain_name="example.com",
+                years=1,
+            )
+
+        self.assertTrue(result.is_ok(), result)
+        mock_register.assert_called_once()
+
+        domain = result.unwrap()
+        domain.refresh_from_db()
+        self.assertEqual(domain.status, "pending")
+        self.assertEqual(domain.registrar_domain_id, "")

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -11,6 +11,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import TestCase
 
 from apps.common.types import Err, Ok
@@ -642,3 +643,47 @@ class SafeJsonResponseSizeTests(TestCase):
     def test_parses_normal_response(self) -> None:
         resp = self._resp(content_length="12", content=b'{"ok": true}', json_data={"ok": True})
         self.assertEqual(self.gateway._safe_json(resp), {"ok": True})
+
+
+class RetryHonorsRetriabilityTests(TestCase):
+    """_retry must key off the Err's Retriability tag, not the error class.
+
+    A registration/renewal POST network error is tagged UNKNOWN (the POST may
+    have reached the registrar), so it must NOT be auto-replayed — replay could
+    double-register/double-charge. An availability GET is a safe read, so its
+    network error IS retried.
+    """
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion", "last_name": "Pop", "email": "ion@example.ro",
+            "phone": "+40712345678", "address": "Str. Test 1", "city": "Bucuresti",
+            "postal_code": "010101", "country_code": "RO", "entity_type": "individual",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_registration_network_error_is_not_retried(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_request.side_effect = requests.RequestException("connection reset")
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        # UNKNOWN outcome — the POST may have landed, so exactly one attempt, no replay.
+        self.assertEqual(mock_request.call_count, 1)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_availability_network_error_is_retried(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0  # circuit breaker OK
+        mock_request.side_effect = requests.RequestException("connection reset")
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_err())
+        # Idempotent read — retried up to MAX_RETRIES.
+        self.assertEqual(mock_request.call_count, 3)

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -687,3 +687,44 @@ class RetryHonorsRetriabilityTests(TestCase):
         self.assertTrue(result.is_err())
         # Idempotent read — retried up to MAX_RETRIES.
         self.assertEqual(mock_request.call_count, 3)
+
+
+class IdempotencyCacheSecretRedactionTests(TestCase):
+    """The idempotency cache must never persist the EPP/auth transfer credential.
+
+    DatabaseCache/Redis serialize the cached value in plaintext; the EPP code is a
+    transfer secret (encrypted at rest in the Domain row), so it must be stripped
+    from the cached DomainRegistrationResult while the immediate caller still gets
+    the full result to persist.
+    """
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion", "last_name": "Pop", "email": "ion@example.ro",
+            "phone": "+40712345678", "address": "Str. Test 1", "city": "Bucuresti",
+            "postal_code": "010101", "country_code": "RO", "entity_type": "individual",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_register")
+    @patch("apps.domains.gateways.base.cache")
+    def test_epp_code_is_not_written_to_cache(self, mock_cache: MagicMock, mock_do_register: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]  # breaker OK, idempotency miss
+        mock_cache.add.return_value = True
+        mock_do_register.return_value = Ok(
+            DomainRegistrationResult(
+                registrar_domain_id="REG-1",
+                expires_at=datetime(2027, 1, 1, tzinfo=UTC),
+                nameservers=[],
+                epp_code="TOP-SECRET-EPP",
+            )
+        )
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        # Immediate caller still receives the real EPP to persist encrypted.
+        self.assertEqual(result.unwrap().epp_code, "TOP-SECRET-EPP")
+        # But nothing containing the secret was ever written to the cache.
+        for call in mock_cache.set.call_args_list:
+            self.assertNotIn("TOP-SECRET-EPP", repr(call))

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -12,7 +12,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import requests
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from apps.common.types import Err, Ok
 from apps.domains.gateways import (
@@ -134,6 +134,7 @@ class RegistrarGatewayFactoryTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class GandiGatewayRegisterTests(TestCase):
     """Gandi domain registration."""
 
@@ -277,6 +278,7 @@ class GandiGatewayAvailabilityTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class ROTLDGatewayRegisterTests(TestCase):
     """ROTLD domain registration."""
 
@@ -406,6 +408,7 @@ class CircuitBreakerTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class IdempotencyTests(TestCase):
     """Idempotency cache prevents duplicate registrations."""
 
@@ -455,6 +458,7 @@ class IdempotencyTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class DomainRegistrarGatewayFacadeTests(TestCase):
     """The facade in services.py delegates to the gateway layer."""
 
@@ -510,6 +514,7 @@ class DomainRegistrarGatewayFacadeTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class IdempotencyClaimTests(TestCase):
     """The idempotency key is claimed atomically before the call (H1)."""
 
@@ -574,6 +579,7 @@ class CircuitBreakerRecoveryTests(TestCase):
 # ===============================================================================
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class GandiInvalidResponseTests(TestCase):
     """Missing/invalid expiry and malformed price are handled gracefully."""
 
@@ -645,6 +651,7 @@ class SafeJsonResponseSizeTests(TestCase):
         self.assertEqual(self.gateway._safe_json(resp), {"ok": True})
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class RetryHonorsRetriabilityTests(TestCase):
     """_retry must key off the Err's Retriability tag, not the error class.
 
@@ -689,6 +696,7 @@ class RetryHonorsRetriabilityTests(TestCase):
         self.assertEqual(mock_request.call_count, 3)
 
 
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
 class IdempotencyCacheSecretRedactionTests(TestCase):
     """The idempotency cache must never persist the EPP/auth transfer credential.
 
@@ -728,3 +736,41 @@ class IdempotencyCacheSecretRedactionTests(TestCase):
         # But nothing containing the secret was ever written to the cache.
         for call in mock_cache.set.call_args_list:
             self.assertNotIn("TOP-SECRET-EPP", repr(call))
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=False)
+class UnverifiedAdapterGuardTests(TestCase):
+    """Until an adapter is validated against the real registrar sandbox, chargeable
+    register/renew calls are refused; read-only availability is still allowed."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion", "last_name": "Pop", "email": "ion@example.ro",
+            "phone": "+40712345678", "address": "Str. Test 1", "city": "Bucuresti",
+            "postal_code": "010101", "country_code": "RO", "entity_type": "individual",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    def test_register_refused_when_unverified(self, mock_request: MagicMock) -> None:
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err().code, RegistrarErrorCode.NOT_CONFIGURED)
+        # No outbound call was attempted.
+        mock_request.assert_not_called()
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    def test_renew_refused_when_unverified(self, mock_request: MagicMock) -> None:
+        result = self.gateway.renew_domain("REG-1", "example.com", 1)
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err().code, RegistrarErrorCode.NOT_CONFIGURED)
+        mock_request.assert_not_called()
+
+    @patch("apps.domains.gateways.base.cache")
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    def test_availability_allowed_when_unverified(self, mock_request: MagicMock, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {"products": [{"status": "available", "prices": [{}]}]})
+        result = self.gateway.check_availability("example.com")
+        self.assertTrue(result.is_ok(), result)

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -560,18 +560,23 @@ class CircuitBreakerRecoveryTests(TestCase):
 
     @patch("apps.domains.gateways.base.cache")
     def test_subsequent_failure_does_not_reset_ttl(self, mock_cache: MagicMock) -> None:
-        # Counter already exists → incr succeeds; the sliding-window touch() must be gone.
+        # Counter already exists → add() fails, incr() bumps it; the sliding-window
+        # touch() must be gone and set() must not reseed the TTL.
+        mock_cache.add.return_value = False
         mock_cache.incr.return_value = 2
         self.gateway._record_failure(RegistrarTransientError("gandi", "boom"))
         mock_cache.touch.assert_not_called()
+        mock_cache.set.assert_not_called()
 
     @patch("apps.domains.gateways.base.cache")
-    def test_first_failure_seeds_fixed_ttl(self, mock_cache: MagicMock) -> None:
+    def test_first_failure_seeds_fixed_ttl_atomically(self, mock_cache: MagicMock) -> None:
         from apps.domains.gateways.base import CIRCUIT_BREAKER_RESET_SECONDS  # noqa: PLC0415
 
-        mock_cache.incr.side_effect = ValueError  # key absent
+        # add() atomically seeds the counter + TTL on the first failure (no incr/set race).
+        mock_cache.add.return_value = True
         self.gateway._record_failure(RegistrarTransientError("gandi", "boom"))
-        mock_cache.set.assert_called_once_with("cb:gandi:failures", 1, CIRCUIT_BREAKER_RESET_SECONDS)
+        mock_cache.add.assert_called_once_with("cb:gandi:failures", 1, CIRCUIT_BREAKER_RESET_SECONDS)
+        mock_cache.incr.assert_not_called()
 
 
 # ===============================================================================
@@ -774,3 +779,64 @@ class UnverifiedAdapterGuardTests(TestCase):
         mock_request.return_value = _mock_response(200, {"products": [{"status": "available", "prices": [{}]}]})
         result = self.gateway.check_availability("example.com")
         self.assertTrue(result.is_ok(), result)
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
+class GatewayHardeningTests(TestCase):
+    """W2/W3/W4: exception-safe idempotency claim, breaker counts only systemic
+    failures, and audit never records raw registrar PII."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion", "last_name": "Pop", "email": "ion@example.ro",
+            "phone": "+40712345678", "address": "Str. Test 1", "city": "Bucuresti",
+            "postal_code": "010101", "country_code": "RO", "entity_type": "individual",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_register")
+    @patch("apps.domains.gateways.base.cache")
+    def test_idempotency_claim_released_when_operation_raises(self, mock_cache: MagicMock, mock_do: MagicMock) -> None:
+        """An unexpected exception (e.g. oversized-response RegistrarAPIError) must still
+        release the in-progress claim so a later retry isn't permanently blocked."""
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_do.side_effect = RegistrarAPIError("boom", code=RegistrarErrorCode.INVALID_RESPONSE)
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        mock_cache.delete.assert_called_once()  # claim released
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_breaker_ignores_non_systemic_errors(self, mock_cache: MagicMock) -> None:
+        """A domain conflict / auth error is not a registrar-wide outage — it must
+        not count toward tripping the circuit breaker; a transient one does."""
+        self.gateway._record_failure(RegistrarConflictError("example.com", self.registrar.name))
+        mock_cache.add.assert_not_called()
+        mock_cache.incr.assert_not_called()
+
+        mock_cache.add.return_value = True
+        self.gateway._record_failure(RegistrarTransientError(self.registrar.name, "5xx"))
+        mock_cache.add.assert_called_once()
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_register")
+    @patch("apps.domains.gateways.base.cache")
+    def test_audit_records_error_code_not_raw_registrar_body(self, mock_cache: MagicMock, mock_do: MagicMock) -> None:
+        """A registrar error echoing registrant PII must not reach the audit trail."""
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_do.return_value = Err(
+            RegistrarAPIError(
+                "invalid registrant: CNP 1900101123456 rejected",
+                code=RegistrarErrorCode.INVALID_REGISTRANT_DATA,
+            )
+        )
+        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+            self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(mock_audit.called)
+        recorded = repr(mock_audit.call_args)
+        self.assertNotIn("1900101123456", recorded)
+        self.assertIn("invalid_registrant_data", recorded)

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -1,0 +1,644 @@
+"""Tests for domain registrar gateway layer (issue #93).
+
+Tests the ABC, factory, circuit breaker, idempotency, error mapping,
+and the Gandi/ROTLD concrete gateways with mocked HTTP responses.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from apps.common.types import Err, Ok
+from apps.domains.gateways import (
+    RegistrarGatewayFactory,
+)
+from apps.domains.gateways.base import (
+    _IDEMPOTENCY_IN_PROGRESS,
+    CIRCUIT_BREAKER_THRESHOLD,
+    MAX_RESPONSE_SIZE_BYTES,
+    DomainAvailabilityResult,
+    DomainRegistrationResult,
+)
+from apps.domains.gateways.errors import (
+    RegistrarAPIError,
+    RegistrarAuthError,
+    RegistrarConflictError,
+    RegistrarErrorCode,
+    RegistrarNotFoundError,
+    RegistrarRateLimitError,
+    RegistrarTransientError,
+)
+from apps.domains.gateways.gandi import GandiGateway
+from apps.domains.gateways.rotld import ROTLDGateway
+from apps.domains.models import Registrar
+
+
+def _make_registrar(name: str = "gandi", **kwargs: Any) -> Registrar:
+    """Create a Registrar instance for testing (not saved to DB)."""
+    defaults = {
+        "display_name": name.upper(),
+        "website_url": f"https://{name}.net",
+        "api_endpoint": f"https://api.{name}.net/v5",
+        "api_username": "",
+        "api_key": "test-api-key-encrypted",
+        "api_secret": "",
+        "webhook_secret": "",
+        "status": "active",
+    }
+    defaults.update(kwargs)
+    return Registrar(name=name, **defaults)
+
+
+def _mock_response(status_code: int, json_data: dict | None = None, text: str = "") -> MagicMock:
+    """Create a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text or json.dumps(json_data or {})
+    resp.headers = {}
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = ValueError("No JSON")
+    return resp
+
+
+# ===============================================================================
+# ERROR TYPES
+# ===============================================================================
+
+
+class RegistrarErrorTests(TestCase):
+    """Error hierarchy carries correct codes and messages."""
+
+    def test_auth_error_has_code(self) -> None:
+        err = RegistrarAuthError("gandi")
+        self.assertEqual(err.code, RegistrarErrorCode.AUTH_FAILED)
+        self.assertEqual(err.registrar_name, "gandi")
+
+    def test_conflict_error_has_domain(self) -> None:
+        err = RegistrarConflictError("example.com", "gandi")
+        self.assertEqual(err.code, RegistrarErrorCode.DOMAIN_ALREADY_REGISTERED)
+        self.assertIn("example.com", str(err))
+
+    def test_not_found_error(self) -> None:
+        err = RegistrarNotFoundError("example.com", "rotld")
+        self.assertEqual(err.code, RegistrarErrorCode.DOMAIN_NOT_FOUND)
+
+    def test_rate_limit_error_with_retry_after(self) -> None:
+        err = RegistrarRateLimitError("gandi", retry_after=60)
+        self.assertEqual(err.retry_after, 60)
+        self.assertEqual(err.code, RegistrarErrorCode.RATE_LIMITED)
+
+    def test_transient_error_is_retryable(self) -> None:
+        err = RegistrarTransientError("gandi", "timeout")
+        self.assertEqual(err.code, RegistrarErrorCode.NETWORK_ERROR)
+
+
+# ===============================================================================
+# FACTORY
+# ===============================================================================
+
+
+class RegistrarGatewayFactoryTests(TestCase):
+    """Factory creates correct gateway instances."""
+
+    def test_creates_gandi_gateway(self) -> None:
+        registrar = _make_registrar("gandi")
+        gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        self.assertIsInstance(gateway, GandiGateway)
+
+    def test_creates_rotld_gateway(self) -> None:
+        registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        gateway = RegistrarGatewayFactory.create_gateway(registrar)
+        self.assertIsInstance(gateway, ROTLDGateway)
+
+    def test_unknown_registrar_raises(self) -> None:
+        registrar = _make_registrar("unknown_registrar")
+        with self.assertRaises(ValueError, msg="No gateway registered"):
+            RegistrarGatewayFactory.create_gateway(registrar)
+
+    def test_list_available_gateways(self) -> None:
+        gateways = RegistrarGatewayFactory.list_available_gateways()
+        self.assertIn("gandi", gateways)
+        self.assertIn("rotld", gateways)
+
+
+# ===============================================================================
+# GANDI GATEWAY
+# ===============================================================================
+
+
+class GandiGatewayRegisterTests(TestCase):
+    """Gandi domain registration."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "email": "ion@example.com",
+            "phone": "+40721000000",
+            "address": "Str. Exemplu 1",
+            "city": "Bucuresti",
+            "postal_code": "010101",
+            "country_code": "RO",
+        }
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_registration(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        # First get: circuit breaker (returns 0 = OK), second get: idempotency (None = cache miss)
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            202,
+            {
+                "id": "gandi-dom-123",
+                "expires_at": "2027-04-06T00:00:00Z",
+                "auth_info": "EPP-SECRET",
+            },
+        )
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_ok())
+        reg = result.unwrap()
+        self.assertEqual(reg.registrar_domain_id, "gandi-dom-123")
+        self.assertEqual(reg.epp_code, "EPP-SECRET")
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_auth_failure_returns_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(401, {"message": "Invalid token"})
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarAuthError)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_conflict_returns_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(409, {"message": "Domain already registered"})
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarConflictError)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_conflict_error_message_uses_bare_domain_not_operation_label(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """M3: typed not-found/conflict errors must carry the domain, not 'register <domain>'."""
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(409, {"message": "Domain already registered"})
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        message = str(result.unwrap_err())
+        self.assertIn("Domain 'example.com'", message)
+        self.assertNotIn("register example.com", message)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_rate_limit_returns_retriable_err(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        resp = _mock_response(429, {"message": "Too many requests"})
+        resp.headers = {"Retry-After": "30"}
+        mock_request.return_value = resp
+
+        result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarRateLimitError)
+
+
+class GandiGatewayAvailabilityTests(TestCase):
+    """Gandi domain availability check."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_available_domain(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0  # circuit breaker OK
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "products": [
+                    {
+                        "status": "available",
+                        "premium": False,
+                        "prices": [{"price_after_taxes": 12.50}],
+                    }
+                ],
+            },
+        )
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_ok())
+        avail = result.unwrap()
+        self.assertTrue(avail.available)
+        self.assertFalse(avail.premium)
+        self.assertEqual(avail.price_cents, 1250)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_unavailable_domain(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(
+            200,
+            {
+                "products": [{"status": "unavailable", "premium": False, "prices": []}],
+            },
+        )
+
+        result = self.gateway.check_availability("taken.com")
+
+        self.assertTrue(result.is_ok())
+        self.assertFalse(result.unwrap().available)
+
+
+# ===============================================================================
+# ROTLD GATEWAY
+# ===============================================================================
+
+
+class ROTLDGatewayRegisterTests(TestCase):
+    """ROTLD domain registration."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+        self.registrant = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "email": "ion@example.com",
+            "phone": "+40721000000",
+            "address": "Str. Exemplu 1",
+            "city": "Bucuresti",
+            "postal_code": "010101",
+            "country_code": "RO",
+            "entity_type": "company",
+            "company_name": "SC Exemplu SRL",
+            "cui": "RO12345678",
+        }
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_successful_registration(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(
+            201,
+            {
+                "domain": {
+                    "id": "rotld-12345",
+                    "expire_at": "2027-04-06T00:00:00Z",
+                    "authcode": "RO-EPP-SECRET",
+                },
+            },
+        )
+
+        result = self.gateway.register_domain("exemplu.ro", 1, self.registrant)
+
+        self.assertTrue(result.is_ok())
+        reg = result.unwrap()
+        self.assertEqual(reg.registrar_domain_id, "rotld-12345")
+        self.assertEqual(reg.epp_code, "RO-EPP-SECRET")
+
+    @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_server_error_returns_transient(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(503, {"error": "Service unavailable"})
+
+        result = self.gateway.register_domain("exemplu.ro", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarTransientError)
+
+
+class ROTLDGatewayRegistrantMappingTests(TestCase):
+    """ROTLD registrant data mapping includes Romanian-specific fields."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("rotld", api_endpoint="https://rest2.rotld.ro")
+        self.gateway = ROTLDGateway(self.registrar)
+
+    def test_company_registrant_includes_cui(self) -> None:
+        data = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "entity_type": "company",
+            "company_name": "SC Exemplu SRL",
+            "cui": "RO12345678",
+            "email": "ion@example.com",
+        }
+        mapped = self.gateway._map_registrant_to_rotld(data)
+
+        self.assertEqual(mapped["org"], "SC Exemplu SRL")
+        self.assertEqual(mapped["fiscal_code"], "RO12345678")
+        self.assertNotIn("cnp", mapped)
+
+    def test_individual_registrant_includes_cnp(self) -> None:
+        data = {
+            "first_name": "Ion",
+            "last_name": "Popescu",
+            "entity_type": "individual",
+            "cnp": "1234567890123",
+            "email": "ion@example.com",
+        }
+        mapped = self.gateway._map_registrant_to_rotld(data)
+
+        self.assertEqual(mapped["cnp"], "1234567890123")
+        self.assertNotIn("org", mapped)
+        self.assertNotIn("fiscal_code", mapped)
+
+
+# ===============================================================================
+# CIRCUIT BREAKER
+# ===============================================================================
+
+
+class CircuitBreakerTests(TestCase):
+    """Circuit breaker prevents calls to failing registrars."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_open_circuit_blocks_calls(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = CIRCUIT_BREAKER_THRESHOLD
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_err())
+        err = result.unwrap_err()
+        self.assertIsInstance(err, RegistrarTransientError)
+        self.assertIn("Circuit breaker", str(err))
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_below_threshold_allows_calls(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.return_value = CIRCUIT_BREAKER_THRESHOLD - 1
+        with patch.object(self.gateway, "_do_check_availability") as mock_do:
+            mock_do.return_value = Ok(DomainAvailabilityResult("example.com", True))
+            result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_ok())
+
+
+# ===============================================================================
+# IDEMPOTENCY
+# ===============================================================================
+
+
+class IdempotencyTests(TestCase):
+    """Idempotency cache prevents duplicate registrations."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_cached_registration_returned_immediately(self, mock_cache: MagicMock) -> None:
+        cached_result = DomainRegistrationResult(
+            registrar_domain_id="cached-123",
+            expires_at=datetime(2027, 1, 1, tzinfo=UTC),
+            nameservers=["ns1.example.com"],
+            epp_code="CACHED-EPP",
+        )
+        # First call returns None (circuit breaker), second returns cached result
+        mock_cache.get.side_effect = [0, cached_result]
+
+        result = self.gateway.register_domain("example.com", 1, {})
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap().registrar_domain_id, "cached-123")
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_concurrent_in_flight_registration_rejected(self, mock_cache: MagicMock) -> None:
+        """A second concurrent register for the same domain is refused, not duplicated.
+
+        The first request claims the idempotency key with _IDEMPOTENCY_IN_PROGRESS
+        via cache.add(); the second loses that atomic claim (add() returns False) and,
+        finding only the in-progress sentinel (no real result yet), must return a
+        RegistrarConflictError rather than issuing a second chargeable registration.
+        """
+        # get(): circuit-breaker check -> 0 (OK); idempotency read -> the in-progress
+        # sentinel (so the "cached real result" fast-path is skipped); after the lost
+        # add() race, the re-read -> sentinel again (no real result landed yet).
+        mock_cache.get.side_effect = [0, _IDEMPOTENCY_IN_PROGRESS, _IDEMPOTENCY_IN_PROGRESS]
+        mock_cache.add.return_value = False  # slot already claimed by the in-flight request
+
+        result = self.gateway.register_domain("example.com", 1, {})
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarConflictError)
+
+
+# ===============================================================================
+# BACKWARD-COMPATIBLE FACADE (services.py DomainRegistrarGateway)
+# ===============================================================================
+
+
+class DomainRegistrarGatewayFacadeTests(TestCase):
+    """The facade in services.py delegates to the gateway layer."""
+
+    def test_register_delegates_to_factory(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("gandi")
+
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway") as mock_factory:
+            mock_gw = MagicMock()
+            mock_gw.register_domain.return_value = Ok(
+                DomainRegistrationResult(
+                    registrar_domain_id="test-123",
+                    expires_at=datetime(2027, 1, 1, tzinfo=UTC),
+                    nameservers=["ns1.gandi.net"],
+                    epp_code="EPP123",
+                )
+            )
+            mock_factory.return_value = mock_gw
+
+            success, data = DomainRegistrarGateway.register_domain(registrar, "test.com", 1, {})
+
+        self.assertTrue(success)
+        self.assertEqual(data["registrar_domain_id"], "test-123")
+
+    def test_unknown_registrar_returns_failure(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("nonexistent")
+
+        success, data = DomainRegistrarGateway.register_domain(registrar, "test.com", 1, {})
+
+        self.assertFalse(success)
+        self.assertIn("error", data)
+
+    def test_verify_webhook_delegates(self) -> None:
+        from apps.domains.services import DomainRegistrarGateway  # noqa: PLC0415
+
+        registrar = _make_registrar("gandi")
+
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway") as mock_factory:
+            mock_gw = MagicMock()
+            mock_gw.verify_webhook_signature.return_value = True
+            mock_factory.return_value = mock_gw
+
+            result = DomainRegistrarGateway.verify_webhook_signature(registrar, "payload", "sig")
+
+        self.assertTrue(result)
+
+
+# ===============================================================================
+# IDEMPOTENCY CLAIM + CIRCUIT-BREAKER RECOVERY (PR #169 review H1/H2)
+# ===============================================================================
+
+
+class IdempotencyClaimTests(TestCase):
+    """The idempotency key is claimed atomically before the call (H1)."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+        self.registrant = {"first_name": "Ion", "last_name": "Popescu", "email": "ion@example.com"}
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_concurrent_in_progress_call_is_rejected(self, mock_cache: MagicMock) -> None:
+        # breaker OK, idempotency miss, then add() loses the race, then re-read shows in-progress.
+        mock_cache.get.side_effect = [0, None, _IDEMPOTENCY_IN_PROGRESS]
+        mock_cache.add.return_value = False
+
+        with patch.object(self.gateway, "_do_register") as mock_do:
+            result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), RegistrarConflictError)
+        # Crucially, the registrar was never called for the duplicate request.
+        mock_do.assert_not_called()
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_claim_is_released_on_failure(self, mock_cache: MagicMock) -> None:
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+
+        with patch.object(self.gateway, "_do_register") as mock_do:
+            mock_do.return_value = Err(RegistrarTransientError("gandi", "boom"))
+            result = self.gateway.register_domain("example.com", 1, self.registrant)
+
+        self.assertTrue(result.is_err())
+        # The in-progress claim must be deleted so a legitimate retry can proceed.
+        mock_cache.delete.assert_any_call("domain_reg:gandi:example.com")
+
+
+class CircuitBreakerRecoveryTests(TestCase):
+    """_record_failure keeps a fixed TTL window so the breaker auto-recovers (H2)."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_subsequent_failure_does_not_reset_ttl(self, mock_cache: MagicMock) -> None:
+        # Counter already exists → incr succeeds; the sliding-window touch() must be gone.
+        mock_cache.incr.return_value = 2
+        self.gateway._record_failure(RegistrarTransientError("gandi", "boom"))
+        mock_cache.touch.assert_not_called()
+
+    @patch("apps.domains.gateways.base.cache")
+    def test_first_failure_seeds_fixed_ttl(self, mock_cache: MagicMock) -> None:
+        from apps.domains.gateways.base import CIRCUIT_BREAKER_RESET_SECONDS  # noqa: PLC0415
+
+        mock_cache.incr.side_effect = ValueError  # key absent
+        self.gateway._record_failure(RegistrarTransientError("gandi", "boom"))
+        mock_cache.set.assert_called_once_with("cb:gandi:failures", 1, CIRCUIT_BREAKER_RESET_SECONDS)
+
+
+# ===============================================================================
+# INVALID-RESPONSE + ROBUSTNESS (PR #169 review M2/M4)
+# ===============================================================================
+
+
+class GandiInvalidResponseTests(TestCase):
+    """Missing/invalid expiry and malformed price are handled gracefully."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_registration_missing_expires_at_is_invalid_response(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        mock_cache.get.side_effect = [0, None]
+        # 202 success but NO expires_at → must not fabricate a date.
+        mock_request.return_value = _mock_response(202, {"id": "g-1", "auth_info": "EPP"})
+
+        result = self.gateway.register_domain("example.com", 1, {})
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.unwrap_err().code, RegistrarErrorCode.INVALID_RESPONSE)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_malformed_price_does_not_break_availability(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        mock_cache.get.return_value = 0  # circuit breaker OK
+        mock_request.return_value = _mock_response(
+            200,
+            {"products": [{"status": "available", "prices": [{"price_after_taxes": "not-a-number"}]}]},
+        )
+
+        result = self.gateway.check_availability("example.com")
+
+        self.assertTrue(result.is_ok())
+        self.assertTrue(result.unwrap().available)
+        self.assertIsNone(result.unwrap().price_cents)
+
+
+class SafeJsonResponseSizeTests(TestCase):
+    """M5: _safe_json rejects oversized bodies before deserializing."""
+
+    def setUp(self) -> None:
+        self.gateway = GandiGateway(_make_registrar("gandi"))
+
+    def _resp(self, *, content_length: str | None, content: bytes, json_data: dict | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.headers = {"content-length": content_length} if content_length is not None else {}
+        resp.content = content
+        resp.json.return_value = json_data or {}
+        return resp
+
+    def test_rejects_oversized_via_content_length_header(self) -> None:
+        resp = self._resp(content_length=str(MAX_RESPONSE_SIZE_BYTES + 1), content=b"{}")
+        with self.assertRaises(RegistrarAPIError) as ctx:
+            self.gateway._safe_json(resp)
+        self.assertEqual(ctx.exception.code, RegistrarErrorCode.INVALID_RESPONSE)
+        resp.json.assert_not_called()
+
+    def test_rejects_oversized_body_when_header_absent_or_lying(self) -> None:
+        # No content-length header, but the actual body exceeds the cap.
+        resp = self._resp(content_length=None, content=b"x" * (MAX_RESPONSE_SIZE_BYTES + 1))
+        with self.assertRaises(RegistrarAPIError) as ctx:
+            self.gateway._safe_json(resp)
+        self.assertEqual(ctx.exception.code, RegistrarErrorCode.INVALID_RESPONSE)
+
+    def test_parses_normal_response(self) -> None:
+        resp = self._resp(content_length="12", content=b'{"ok": true}', json_data={"ok": True})
+        self.assertEqual(self.gateway._safe_json(resp), {"ok": True})

--- a/services/platform/tests/domains/test_webhook_signature_verification.py
+++ b/services/platform/tests/domains/test_webhook_signature_verification.py
@@ -10,6 +10,7 @@ import hashlib
 import hmac
 import json
 from typing import Any
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -98,6 +99,18 @@ class WebhookSignatureVerificationTests(TestCase):
             self.registrar, self.payload, "sha256=anything"
         )
         self.assertFalse(result)
+
+    def test_decryption_failure_is_logged(self) -> None:
+        """A decryption failure must be logged, not silently swallowed (review H3)."""
+        with (
+            patch.object(type(self.registrar), "get_decrypted_webhook_secret", side_effect=Exception("boom")),
+            self.assertLogs("apps.domains.services", level="ERROR") as cm,
+        ):
+            result = DomainRegistrarGateway.verify_webhook_signature(
+                self.registrar, self.payload, "sha256=anything"
+            )
+        self.assertFalse(result)
+        self.assertTrue(any("decryption failed" in line.lower() for line in cm.output))
 
     def test_empty_decrypted_secret_rejected(self) -> None:
         """Unencrypted empty/whitespace value stored in DB should be rejected."""


### PR DESCRIPTION
## Summary

Lands the registrar gateway layer from PR #169 (thanks @b3lz3but) — reconciled onto the tri-state Retriability signal from #168 (which merged first and conflicted with #169's older `Err.retriable: bool` draft) and hardened against a full review round.

Could not use the base-change merge route the earlier PRs used: #169's `common/types.py` change conflicts with the #168 tri-state now on master, so the reconciliation can't pass through #169's own branch. #169 is credited here (Co-authored-by) and closed with a pointer to this PR.

### From #169 (verified sound)
Gateway ABC + factory (mirrors PaymentGatewayFactory), Gandi + ROTLD adapters, circuit breaker, per-domain idempotency, retry/backoff, SSRF-safe HTTP via per-registrar OutboundPolicy, audit logging, and the DomainLifecycleService Result[T,str] migration. The prior review's C1/C2/H1-H3/M1-M5 fixes were verified against the actual code.

### Review round found 6 CRITICALs + 4 warnings — all fixed here (TDD)
- **Retry honored the error class, not the Retriability tag** — register/renew POST errors tagged UNKNOWN were auto-replayed 3×, risking duplicate registrations/charges. Now retries only RETRIABLE (idempotent reads opt into UNKNOWN).
- **Registration/renewal reported success without registrar confirmation** — `Ok` now means confirmed-active; definite rejection deletes the pending row (no retry deadlock), UNKNOWN keeps it pending ('do not resubmit'). Renewal now actually calls the registrar and persists the registrar-returned expiry.
- **Registrant data was blank/mis-keyed** — assembled and validated from customer + address + tax profile (name split, phone, address, CUI/CNP), rejecting incomplete data up front.
- **Adapters were built against unverified response schemas** — chargeable register/renew now fail closed behind `REGISTRAR_ADAPTERS_VERIFIED` (default off) until validated against a real sandbox; Gandi sharing_id moved to a query param; adapters marked PROVISIONAL.
- **Plaintext EPP transfer credential was cached** — redacted before caching.
- **W1-W4**: availability endpoint wired to the registrar (fail-closed); idempotency claim released on any exception; circuit breaker counts only systemic failures and seeds atomically; audit records error codes, not PII-bearing registrar bodies.

Durable reconciliation of pending/unknown registration rows and the Gandi 202 async-poll rework are tracked as follow-ups (with #237).

### Test plan
- Full suite green: platform (failfast, parallel), portal, integration, cache, security; mypy + ruff clean on all changed files; makemigrations --check clean.

Closes #93

Co-authored-by: Ciprian Radulescu <craps2003@gmail.com>
Signed-off-by: Claudiu Ciungan <claudiu@captainpragmatic.com>