### PR TITLE
fix(domains): definite registrar rejections NOT_RETRIABLE (post-#256 review)

### DIFF
--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -226,7 +226,11 @@ class BaseRegistrarGateway(ABC):
                 "refusing chargeable operation (set REGISTRAR_ADAPTERS_VERIFIED=true once validated)",
                 code=RegistrarErrorCode.NOT_CONFIGURED,
                 registrar_name=self.registrar.name,
-            )
+            ),
+            # Definite refusal, not a transient state: the registration lifecycle must
+            # delete the pending row so the domain can be registered once verified,
+            # rather than stranding it as pending_unknown forever.
+            retriability=Retriability.NOT_RETRIABLE,
         )
 
     def _execute_idempotent_operation(  # noqa: PLR0913  # cohesive call + audit context for one op
@@ -312,19 +316,33 @@ class BaseRegistrarGateway(ABC):
         if err := self._check_circuit_breaker():
             return err
 
-        result = self._retry(
-            lambda: self._do_check_availability(domain_name),
-            operation=f"check:{domain_name}",
-            retry_on_unknown=True,  # availability is a safe read — replaying it is harmless
-        )
+        # Exception-safety: _safe_json (oversized/malformed body) or credential
+        # decryption can raise out of the availability lambda. Convert to an Err so the
+        # AJAX endpoint fails closed ("could not verify") instead of returning a 500.
+        try:
+            result = self._retry(
+                lambda: self._do_check_availability(domain_name),
+                operation=f"check:{domain_name}",
+                retry_on_unknown=True,  # availability is a safe read — replaying it is harmless
+            )
+        except RegistrarAPIError as exc:
+            result = Err(exc)
+        except Exception as exc:
+            result = Err(
+                RegistrarAPIError(
+                    f"Unexpected error during availability check for {domain_name}",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                    detail=str(exc),
+                )
+            )
 
         if result.is_ok():
             self._record_success()
         else:
-            self._record_failure(result.unwrap_err())
-            self._audit_api_call(
-                "domain_availability_check", domain_name, success=False, error=str(result.unwrap_err())
-            )
+            error = result.unwrap_err()
+            self._record_failure(error)
+            self._audit_api_call("domain_availability_check", domain_name, success=False, error=error.code.value)
 
         return result
 
@@ -533,20 +551,32 @@ class BaseRegistrarGateway(ABC):
         except Exception:
             message = response.text[:200]
 
+        # 4xx auth/not-found/conflict are definite rejections: tag NOT_RETRIABLE so the
+        # registration lifecycle deletes the pending row rather than stranding it as
+        # pending_unknown (which the uniqueness precondition would then block forever).
         if status in (HTTP_UNAUTHORIZED, HTTP_FORBIDDEN):
             detail = message if status == HTTP_UNAUTHORIZED else f"Forbidden: {message}"
-            return Err(RegistrarAuthError(self.registrar.name, detail=detail))
+            return Err(RegistrarAuthError(self.registrar.name, detail=detail), retriability=Retriability.NOT_RETRIABLE)
 
         if status == HTTP_NOT_FOUND:
-            return Err(RegistrarNotFoundError(domain_name or operation, self.registrar.name))
+            return Err(
+                RegistrarNotFoundError(domain_name or operation, self.registrar.name),
+                retriability=Retriability.NOT_RETRIABLE,
+            )
 
         if status == HTTP_CONFLICT:
-            return Err(RegistrarConflictError(domain_name or operation, self.registrar.name))
+            return Err(
+                RegistrarConflictError(domain_name or operation, self.registrar.name),
+                retriability=Retriability.NOT_RETRIABLE,
+            )
 
         if status == HTTP_RATE_LIMITED:
-            retry_after = response.headers.get("Retry-After")
+            # Retry-After may be an integer (seconds) or an HTTP-date; only the integer
+            # form is usable and a non-integer must not raise out of error mapping.
+            retry_after_raw = response.headers.get("Retry-After")
+            retry_after = int(retry_after_raw) if retry_after_raw and retry_after_raw.isdigit() else None
             return Err(
-                RegistrarRateLimitError(self.registrar.name, int(retry_after) if retry_after else None),
+                RegistrarRateLimitError(self.registrar.name, retry_after),
                 # 429 means the registrar rejected the request before processing it — safe to replay.
                 retriability=Retriability.RETRIABLE,
             )

--- a/services/platform/tests/domains/test_gateway_registration_wiring.py
+++ b/services/platform/tests/domains/test_gateway_registration_wiring.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from apps.customers.models import Customer, CustomerAddress, CustomerTaxProfile
 from apps.domains.gateways import RegistrarGatewayFactory
@@ -295,3 +295,37 @@ class RegistrantDataBuildingTests(TestCase):
         result = DomainLifecycleService.create_domain_registration(customer=bare, domain_name="bare.net", years=1)
         self.assertTrue(result.is_err(), result)
         self.assertFalse(Domain.objects.filter(name="bare.net").exists())
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=False)
+class UnverifiedAdapterRegistrationTests(TestCase):
+    """P1 (PR #256 review): with adapters unverified, registration must fail cleanly —
+    return Err AND delete the pending row so the domain isn't deadlocked from retry."""
+
+    def setUp(self) -> None:
+        self.tld = TLD.objects.create(
+            extension="com", description=".com", registration_price_cents=1000, renewal_price_cents=1000,
+            transfer_price_cents=1000, registrar_cost_cents=500, min_registration_period=1, max_registration_period=10,
+        )
+        # name="gandi" so the factory returns a REAL GandiGateway and the request
+        # reaches its unverified-adapter guard (not the no-gateway path).
+        self.registrar = Registrar.objects.create(
+            name="gandi", display_name="Gandi", api_username="",
+            website_url="https://gandi.net", api_endpoint="https://api.gandi.net/v5", status="active",
+        )
+        TLDRegistrarAssignment.objects.create(tld=self.tld, registrar=self.registrar, is_primary=True, is_active=True, priority=1)
+        self.customer = Customer.objects.create(
+            name="John Doe", primary_email="cust@example.com", primary_phone="+40712345678",
+            company_name="ACME", customer_type="individual",
+        )
+        _give_registrant_data(self.customer, cnp="1900101123456")
+
+    def test_unverified_registration_returns_err_and_deletes_row(self) -> None:
+        # No gateway mock — the real GandiGateway guard fires because the adapter is
+        # unverified. The NOT_CONFIGURED guard is NOT_RETRIABLE → definite rejection.
+        result = DomainLifecycleService.create_domain_registration(
+            customer=self.customer, domain_name="example.com", years=1,
+        )
+        self.assertTrue(result.is_err(), result)
+        # The pending row must be gone so the domain can be registered once verified.
+        self.assertFalse(Domain.objects.filter(name="example.com").exists())

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 import requests
 from django.test import TestCase, override_settings
 
-from apps.common.types import Err, Ok
+from apps.common.types import Err, Ok, Retriability
 from apps.domains.gateways import (
     RegistrarGatewayFactory,
 )
@@ -840,3 +840,65 @@ class GatewayHardeningTests(TestCase):
         recorded = repr(mock_audit.call_args)
         self.assertNotIn("1900101123456", recorded)
         self.assertIn("invalid_registrant_data", recorded)
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
+class DefiniteRejectionRetriabilityTests(TestCase):
+    """Definite registrar rejections (404/409/401) and the unverified-adapter guard
+    must carry NOT_RETRIABLE so the lifecycle deletes the pending row (PR #256 review)."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    def _err_for(self, status: int, headers: dict | None = None):
+        resp = _mock_response(status, {"message": "nope"})
+        resp.headers = headers or {}
+        return self.gateway._handle_error_response(resp, "register example.com", domain_name="example.com")
+
+    def test_conflict_is_not_retriable(self) -> None:
+        self.assertEqual(self._err_for(409).retriability, Retriability.NOT_RETRIABLE)
+
+    def test_not_found_is_not_retriable(self) -> None:
+        self.assertEqual(self._err_for(404).retriability, Retriability.NOT_RETRIABLE)
+
+    def test_auth_error_is_not_retriable(self) -> None:
+        self.assertEqual(self._err_for(401).retriability, Retriability.NOT_RETRIABLE)
+
+    def test_rate_limit_stays_retriable(self) -> None:
+        self.assertEqual(self._err_for(429, {"Retry-After": "30"}).retriability, Retriability.RETRIABLE)
+
+    def test_http_date_retry_after_does_not_raise(self) -> None:
+        # A non-integer Retry-After (HTTP-date) must not blow up error mapping.
+        err = self._err_for(429, {"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        self.assertEqual(err.retriability, Retriability.RETRIABLE)
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=False)
+class UnverifiedGuardNotRetriableTests(TestCase):
+    """The unverified-adapter guard must be a definite rejection, or every registration
+    creates a pending row that can never be retried (Codex P1)."""
+
+    def setUp(self) -> None:
+        self.gateway = GandiGateway(_make_registrar("gandi"))
+
+    def test_guard_error_is_not_retriable(self) -> None:
+        result = self.gateway.register_domain("example.com", 1, {"first_name": "a"})
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.NOT_RETRIABLE)
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
+class AvailabilityExceptionSafetyTests(TestCase):
+    """A malformed/oversized availability response must fail closed (Err), not 500 (Codex P2)."""
+
+    def setUp(self) -> None:
+        self.gateway = GandiGateway(_make_registrar("gandi"))
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_check_availability")
+    @patch("apps.domains.gateways.base.cache")
+    def test_availability_exception_becomes_err(self, mock_cache: MagicMock, mock_do: MagicMock) -> None:
+        mock_cache.get.return_value = 0
+        mock_do.side_effect = RegistrarAPIError("oversized", code=RegistrarErrorCode.INVALID_RESPONSE)
+        result = self.gateway.check_availability("example.com")
+        self.assertTrue(result.is_err())


### PR DESCRIPTION
Addresses the Codex/Copilot review comments that landed on #256 after merge.

- **P1 (deadlock)** — the unverified-adapter guard returned a bare Err (UNKNOWN), which the registration lifecycle treats as pending_unknown → creates a Domain row it won't delete → the domain can never be registered, even once REGISTRAR_ADAPTERS_VERIFIED is enabled. Guard is now NOT_RETRIABLE (definite rejection → row deleted). Locked in by a lifecycle test that exercises the real guard path.
- **P2** — registrar 404/409/401/403 in _handle_error_response now carry NOT_RETRIABLE, so a domain already taken at the registrar deletes the local pending row rather than stranding it.
- **P2** — check_availability wraps _retry; a malformed/oversized availability response (_safe_json raising) now fails closed as an Err instead of a 500.
- **Copilot** — a non-integer Retry-After (HTTP-date) no longer raises ValueError out of error mapping.

The common cause: the #256 tri-state remap covered the network/5xx/429/circuit-breaker sites but not the definite-rejection sites, which defaulted to UNKNOWN and collided with the pending-row contract.

### Test plan
94 domains tests pass (5 new for the definite-rejection retriability, the guard deadlock, availability exception-safety, and the HTTP-date Retry-After); ruff + mypy clean.

Signed-off-by: Claudiu Ciungan <claudiu@captainpragmatic.com>