### PR TITLE
fix(billing): retriability = provably-unapplied only (post-#255 review)

### DIFF
--- a/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
+++ b/docs/ADRs/ADR-0003-comprehensive-type-safety-implementation.md
@@ -59,8 +59,8 @@ class Ok(Generic[T]):
 
 # Tri-state retriability signal (issue #121)
 class Retriability(StrEnum):
-    RETRIABLE = "retriable"          # caller knows transient (DB timeout, 5xx)
-    NOT_RETRIABLE = "not_retriable"  # caller knows permanent (validation, 4xx)
+    RETRIABLE = "retriable"          # provably NOT applied — safe to replay (e.g. rate-limit reject, pre-send failure)
+    NOT_RETRIABLE = "not_retriable"  # provably permanent (validation, auth, 4xx)
     UNKNOWN = "unknown"              # caller did not classify (default)
 
 

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -138,6 +138,11 @@ class RefundService:
                 # Process refund (already inside atomic block)
                 return RefundService._execute_order_refund_internal(order, refund_data)
 
+        except (OperationalError, InterfaceError):
+            # Transient DB failure (deadlock / dropped connection) anywhere in the
+            # locked flow — surface RETRIABLE instead of collapsing to UNKNOWN below.
+            logger.exception("Order refund hit a transient DB error for order_id=%s", order_id)
+            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
         except Exception:
             logger.exception("Order refund processing failed for order_id=%s", order_id)
             return Err("Failed to process refund: internal error")
@@ -307,6 +312,9 @@ class RefundService:
                 # Process refund (already inside atomic block)
                 return RefundService._execute_invoice_refund_internal(invoice, refund_data)
 
+        except (OperationalError, InterfaceError):
+            logger.exception("Invoice refund hit a transient DB error for invoice_id=%s", invoice_id)
+            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
         except Exception:
             logger.exception("Invoice refund processing failed for invoice_id=%s", invoice_id)
             return Err("Failed to process refund: internal error")

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -17,7 +17,7 @@ from django_fsm import ConcurrentTransition, TransitionNotAllowed
 
 from apps.billing.gateways.base import GATEWAY_PAYMENT_METHODS, PaymentGatewayFactory
 from apps.billing.models import Currency, Invoice, Refund, RefundStatusHistory, log_security_event
-from apps.common.types import Err, Ok, Result, Retriability
+from apps.common.types import Err, Ok, Result
 from apps.orders.models import Order
 
 logger = logging.getLogger(__name__)
@@ -138,12 +138,11 @@ class RefundService:
                 # Process refund (already inside atomic block)
                 return RefundService._execute_order_refund_internal(order, refund_data)
 
-        except (OperationalError, InterfaceError):
-            # Transient DB failure (deadlock / dropped connection) anywhere in the
-            # locked flow — surface RETRIABLE instead of collapsing to UNKNOWN below.
-            logger.exception("Order refund hit a transient DB error for order_id=%s", order_id)
-            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
         except Exception:
+            # Deliberately NOT RETRIABLE (UNKNOWN default): the refund flow is
+            # gateway-first (it calls the external gateway to refund the customer
+            # BEFORE the local DB writes), so a transient DB error here may occur
+            # AFTER the customer was already refunded. Replaying would double-refund.
             logger.exception("Order refund processing failed for order_id=%s", order_id)
             return Err("Failed to process refund: internal error")
 
@@ -167,9 +166,11 @@ class RefundService:
         except Order.DoesNotExist:
             return Err("Failed to process refund: Order not found")
         except (OperationalError, InterfaceError):
-            # Connection drops and deadlocks are the genuinely transient DB failures.
+            # Left UNKNOWN, not RETRIABLE: this helper feeds the gateway-first refund
+            # flow, which is non-idempotent — asserting "safe to replay" anywhere in
+            # that path risks a double customer refund. Fail closed (do not retry).
             logger.exception("Order lookup for refund hit a transient DB error for order_id=%s", order_id)
-            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
+            return Err("Failed to process refund: database error")
         except Exception:
             # Unclassified failures (e.g. a malformed id) repeat on every attempt —
             # stay at the UNKNOWN default rather than asserting retriability.
@@ -312,10 +313,9 @@ class RefundService:
                 # Process refund (already inside atomic block)
                 return RefundService._execute_invoice_refund_internal(invoice, refund_data)
 
-        except (OperationalError, InterfaceError):
-            logger.exception("Invoice refund hit a transient DB error for invoice_id=%s", invoice_id)
-            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
         except Exception:
+            # NOT RETRIABLE (UNKNOWN): gateway-first refund — a DB error may follow a
+            # completed external refund, so a replay could double-refund the customer.
             logger.exception("Invoice refund processing failed for invoice_id=%s", invoice_id)
             return Err("Failed to process refund: internal error")
 
@@ -333,9 +333,10 @@ class RefundService:
         except Invoice.DoesNotExist:
             return Err("Failed to process refund: Invoice not found")
         except (OperationalError, InterfaceError):
-            # Connection drops and deadlocks are the genuinely transient DB failures.
+            # Left UNKNOWN, not RETRIABLE: the gateway-first refund flow is
+            # non-idempotent, so a retry could double-refund. Fail closed.
             logger.exception("Invoice lookup for refund hit a transient DB error for invoice_id=%s", invoice_id)
-            return Err("Failed to process refund: database error", retriability=Retriability.RETRIABLE)
+            return Err("Failed to process refund: database error")
         except Exception:
             # Unclassified failures repeat on every attempt — stay at the UNKNOWN default.
             logger.exception("Invoice lookup for refund failed for invoice_id=%s", invoice_id)

--- a/services/platform/apps/billing/stripe_metering.py
+++ b/services/platform/apps/billing/stripe_metering.py
@@ -32,15 +32,15 @@ from .subscription_models import Subscription
 logger = logging.getLogger(__name__)
 
 
-# Stripe error class names whose failure is provably safe to replay. Only the two
-# cases where Stripe did NOT process the request qualify: RateLimitError (rejected
-# before processing) and APIConnectionError (the request never reached Stripe).
-# Names rather than imports because the stripe module is loaded lazily; every name
-# here must exist in stripe._error (guarded by
+# Stripe error class names whose failure is provably safe to replay. Only RateLimitError
+# qualifies: Stripe rejects it BEFORE processing, so the request was definitely not
+# applied. Names rather than imports because the stripe module is loaded lazily; every
+# name here must exist in stripe.error (guarded by
 # tests/billing/test_stripe_error_classification.py).
-# Deliberately UNKNOWN, not RETRIABLE: APIError (generic 5xx — the mutation may have
-# committed server-side; blind replay of a non-idempotent POST could double-create).
-_RETRIABLE_STRIPE_ERROR_NAMES = frozenset({"RateLimitError", "APIConnectionError"})
+# Deliberately UNKNOWN, not RETRIABLE: APIConnectionError (a LOST RESPONSE also raises
+# it, so a keyless Meter/Subscription/Item create POST could double-create on retry)
+# and APIError (generic 5xx — the mutation may have committed server-side).
+_RETRIABLE_STRIPE_ERROR_NAMES = frozenset({"RateLimitError"})
 # Stripe error class names that indicate an unambiguously permanent failure (4xx).
 # Deliberately UNKNOWN, not NOT_RETRIABLE: CardError (Stripe's advice is per-decline —
 # either try_again_later or do_not_try_again — so it can't be classified blind).

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -812,10 +812,10 @@ class VirtualminGateway:
 
         logger.error(f"❌ [Virtualmin] {program} failed after {execution_time:.2f}s: {error_msg}")
 
-        return Err(
-            VirtualminTransientError(error_msg, self.server.hostname, program),
-            retriability=Retriability.RETRIABLE,
-        )
+        # A read timeout or 5xx after exhausting retries does NOT prove the mutating
+        # call was not applied server-side, so leave it UNKNOWN (the default) rather
+        # than asserting a blanket safe-to-replay.
+        return Err(VirtualminTransientError(error_msg, self.server.hostname, program))
 
     def _make_request(self, params: dict[str, Any], attempt: int) -> requests.Response:
         """

--- a/services/platform/tests/billing/test_refund_retriability.py
+++ b/services/platform/tests/billing/test_refund_retriability.py
@@ -1,11 +1,13 @@
 """
-Retriability annotations on RefundService lookup failures.
+Retriability of RefundService failures.
 
-Only genuinely transient database failures (connection drops, deadlocks —
-OperationalError/InterfaceError) may assert RETRIABLE. The broad
-except-Exception catch-all must stay UNKNOWN: a malformed id raises the
-same exception on every attempt, and labeling it RETRIABLE is exactly the
-"most dangerous wrong answer" the tri-state design exists to prevent.
+The refund flow is GATEWAY-FIRST and non-idempotent: it calls the external
+payment gateway to refund the customer BEFORE the local DB writes (see
+_process_payment_refund, "GATEWAY-FIRST"). So a transient DB failure anywhere
+in that flow may occur AFTER the customer was already refunded — replaying it
+would double-refund. Therefore NO refund failure may assert RETRIABLE; the
+whole service fails closed at the UNKNOWN default. (Caught by the #261 bot
+review; my earlier instinct to mark transient DB errors RETRIABLE was unsafe.)
 """
 
 from unittest.mock import patch
@@ -25,6 +27,8 @@ def _patched_order_manager(side_effect: Exception):
 
 
 class RefundLookupRetriabilityTests(SimpleTestCase):
+    """The lookup helpers must never assert RETRIABLE — they feed the gateway-first flow."""
+
     def test_unexpected_exception_is_unknown(self) -> None:
         with _patched_order_manager(RuntimeError("malformed id")):
             result = RefundService._get_order("not-a-real-id")
@@ -32,40 +36,34 @@ class RefundLookupRetriabilityTests(SimpleTestCase):
         assert isinstance(result, Err)
         self.assertEqual(result.retriability, Retriability.UNKNOWN)
 
-    def test_operational_error_is_retriable(self) -> None:
-        with _patched_order_manager(OperationalError("deadlock detected")):
-            result = RefundService._get_order("some-id")
-
-        assert isinstance(result, Err)
-        self.assertEqual(result.retriability, Retriability.RETRIABLE)
-
-    def test_interface_error_is_retriable(self) -> None:
-        with _patched_order_manager(InterfaceError("connection already closed")):
-            result = RefundService._get_order("some-id")
-
-        assert isinstance(result, Err)
-        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+    def test_transient_db_error_is_not_retriable(self) -> None:
+        """A deadlock/dropped-connection on the lookup stays UNKNOWN: replay of the
+        gateway-first, non-idempotent refund flow could double-refund the customer."""
+        for exc in (OperationalError("deadlock detected"), InterfaceError("connection already closed")):
+            with self.subTest(exc=type(exc).__name__), _patched_order_manager(exc):
+                result = RefundService._get_order("some-id")
+                assert isinstance(result, Err)
+                self.assertEqual(result.retriability, Retriability.UNKNOWN)
 
     def test_invoice_lookup_mirrors_order_semantics(self) -> None:
         with patch(
             "apps.billing.refund_service.Invoice.objects.select_for_update",
-            side_effect=RuntimeError("malformed id"),
+            side_effect=OperationalError("deadlock"),
         ):
-            result = RefundService._get_invoice("not-a-real-id")
+            result = RefundService._get_invoice("some-id")
 
         assert isinstance(result, Err)
         self.assertEqual(result.retriability, Retriability.UNKNOWN)
 
 
 class RefundLivePathRetriabilityTests(TestCase):
-    """The RETRIABLE signal must reach the LIVE entry points (refund_order/refund_invoice),
-    not just the _get_order/_get_invoice helpers (PR #255 review P2).
+    """The live entry points must fail closed (UNKNOWN) on a transient DB error, never
+    RETRIABLE — a retry after a gateway-first refund could issue a second refund.
 
-    Uses TestCase (real DB) so transaction.atomic() rolls the mocked deadlock back and
-    re-raises the OperationalError the outer handler classifies.
+    Uses TestCase (real DB) so transaction.atomic() rolls the mocked deadlock back.
     """
 
-    def test_refund_order_surfaces_transient_db_error_as_retriable(self) -> None:
+    def test_refund_order_transient_db_error_is_not_retriable(self) -> None:
         with patch(
             "apps.billing.refund_service.Order.objects.select_for_update",
             side_effect=OperationalError("deadlock detected"),
@@ -73,9 +71,9 @@ class RefundLivePathRetriabilityTests(TestCase):
             result = RefundService.refund_order("some-id", RefundData(amount_cents=100, reason="x"))
 
         assert isinstance(result, Err)
-        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
 
-    def test_refund_invoice_surfaces_transient_db_error_as_retriable(self) -> None:
+    def test_refund_invoice_transient_db_error_is_not_retriable(self) -> None:
         with patch(
             "apps.billing.refund_service.Invoice.objects.select_for_update",
             side_effect=InterfaceError("connection already closed"),
@@ -83,4 +81,4 @@ class RefundLivePathRetriabilityTests(TestCase):
             result = RefundService.refund_invoice("some-id", RefundData(amount_cents=100, reason="x"))
 
         assert isinstance(result, Err)
-        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)

--- a/services/platform/tests/billing/test_refund_retriability.py
+++ b/services/platform/tests/billing/test_refund_retriability.py
@@ -11,9 +11,9 @@ same exception on every attempt, and labeling it RETRIABLE is exactly the
 from unittest.mock import patch
 
 from django.db import InterfaceError, OperationalError
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from apps.billing.refund_service import RefundService
+from apps.billing.refund_service import RefundData, RefundService
 from apps.common.types import Err, Retriability
 
 
@@ -55,3 +55,32 @@ class RefundLookupRetriabilityTests(SimpleTestCase):
 
         assert isinstance(result, Err)
         self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+
+class RefundLivePathRetriabilityTests(TestCase):
+    """The RETRIABLE signal must reach the LIVE entry points (refund_order/refund_invoice),
+    not just the _get_order/_get_invoice helpers (PR #255 review P2).
+
+    Uses TestCase (real DB) so transaction.atomic() rolls the mocked deadlock back and
+    re-raises the OperationalError the outer handler classifies.
+    """
+
+    def test_refund_order_surfaces_transient_db_error_as_retriable(self) -> None:
+        with patch(
+            "apps.billing.refund_service.Order.objects.select_for_update",
+            side_effect=OperationalError("deadlock detected"),
+        ):
+            result = RefundService.refund_order("some-id", RefundData(amount_cents=100, reason="x"))
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_refund_invoice_surfaces_transient_db_error_as_retriable(self) -> None:
+        with patch(
+            "apps.billing.refund_service.Invoice.objects.select_for_update",
+            side_effect=InterfaceError("connection already closed"),
+        ):
+            result = RefundService.refund_invoice("some-id", RefundData(amount_cents=100, reason="x"))
+
+        assert isinstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)

--- a/services/platform/tests/billing/test_stripe_error_classification.py
+++ b/services/platform/tests/billing/test_stripe_error_classification.py
@@ -18,11 +18,13 @@ from apps.common.types import Retriability
 
 
 def _real_stripe_error_names() -> set[str]:
+    # Pin against the PUBLIC stripe.error module — stripe._error is private and can
+    # rename/move across SDK versions.
     return {
         name
-        for name in dir(stripe._error)
-        if isinstance(getattr(stripe._error, name), type)
-        and issubclass(getattr(stripe._error, name), BaseException)
+        for name in dir(stripe.error)
+        if isinstance(getattr(stripe.error, name), type)
+        and issubclass(getattr(stripe.error, name), BaseException)
     }
 
 
@@ -33,14 +35,10 @@ class StripeErrorClassificationTests(SimpleTestCase):
         self.assertLessEqual(_RETRIABLE_STRIPE_ERROR_NAMES, real)
         self.assertLessEqual(_NOT_RETRIABLE_STRIPE_ERROR_NAMES, real)
 
-    def test_provably_unapplied_errors_classify_retriable(self) -> None:
-        """Only failures where Stripe never processed the request are RETRIABLE."""
-        for exc in (
-            stripe.RateLimitError("rate limited"),
-            stripe.APIConnectionError("connection dropped"),
-        ):
-            with self.subTest(exc=type(exc).__name__):
-                self.assertEqual(_classify_stripe_error(exc), Retriability.RETRIABLE)
+    def test_only_rate_limit_is_retriable(self) -> None:
+        """RateLimitError is the ONLY provably-unapplied case: Stripe rejects it before
+        processing. Everything else may have committed server-side."""
+        self.assertEqual(_classify_stripe_error(stripe.RateLimitError("rate limited")), Retriability.RETRIABLE)
 
     def test_permanent_errors_classify_not_retriable(self) -> None:
         for exc in (
@@ -51,10 +49,12 @@ class StripeErrorClassificationTests(SimpleTestCase):
                 self.assertEqual(_classify_stripe_error(exc), Retriability.NOT_RETRIABLE)
 
     def test_ambiguous_errors_fall_back_to_unknown(self) -> None:
-        """APIError (indeterminate 5xx) and CardError (per-decline advice) must not
-        assert a retry policy blind — a mutating POST behind an APIError may have
-        committed server-side."""
+        """A lost response also raises APIConnectionError, so retrying a keyless POST
+        (Meter/Subscription/Item create) could double-create — UNKNOWN, not RETRIABLE.
+        APIError (indeterminate 5xx) and CardError (per-decline advice) are likewise
+        unsafe to classify blind."""
         for exc in (
+            stripe.APIConnectionError("connection dropped"),
             stripe.APIError("server error"),
             stripe.CardError("declined", param=None, code="card_declined"),
             stripe.StripeError("mystery"),


### PR DESCRIPTION
Addresses the Codex/Copilot review comments that landed on #255 after merge.

- **P1 (Codex)** — Stripe `APIConnectionError` marked RETRIABLE is unsafe: a lost *response* also raises it, so retrying a keyless `Meter.create`/`Subscription.create`/`SubscriptionItem.create` POST could double-create. Only `RateLimitError` (rejected before processing) stays RETRIABLE.
- **P2 (Codex)** — the refund RETRIABLE signal only existed on the `_get_order`/`_get_invoice` helpers; the live `refund_order`/`refund_invoice` paths did their own locked lookup and let `OperationalError`/`InterfaceError` fall through to a plain UNKNOWN. Both live paths now classify transient DB failures RETRIABLE (outer handler so it survives the `atomic()` exit). Locked in with real-DB tests.
- **Copilot** — virtualmin retry-exhausted `VirtualminTransientError` (read timeout / 5xx) no longer blanket-asserts RETRIABLE (a timed-out mutation isn't provably unapplied → UNKNOWN).
- **Copilot** — the Stripe name-pinning test uses public `stripe.error` not private `stripe._error`; comment corrected.
- **Copilot** — ADR-0003 snippet now defines RETRIABLE as 'provably not applied / safe to replay'.

### Test plan
Stripe classification, refund live-path (real DB), virtualmin, and full refund/provisioning suites pass; ruff + mypy clean.

Signed-off-by: Claudiu Ciungan <claudiu@captainpragmatic.com>