### PR TITLE
fix(domains): atomic transfer idempotency + bulk-check exception safety (post-#264)

### DIFF
--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -494,7 +494,15 @@ class BaseRegistrarGateway(ABC):
         domain_name: str,
         epp_code: str,
     ) -> Result[DomainTransferResult, RegistrarAPIError]:
-        """Initiate domain transfer with circuit breaker and idempotency."""
+        """Initiate domain transfer with circuit breaker and atomic idempotency.
+
+        The idempotency slot is claimed atomically (cache.add) BEFORE the registrar
+        call, so two concurrent transfer requests for the same domain can't both submit
+        a chargeable transfer — the loser of the add() race is rejected. The claim is
+        replaced with the result on success and released on failure so a legitimate
+        retry can proceed. (A bare get-then-call had a window where both requests missed
+        the cache and both posted.)
+        """
         if guard := self._verified_adapter_guard():
             return guard
         if err := self._check_circuit_breaker():
@@ -502,9 +510,19 @@ class BaseRegistrarGateway(ABC):
 
         idempotency_key = f"domain_transfer:{self.gateway_name}:{domain_name}"
         cached = cache.get(idempotency_key)
-        if cached is not None:
+        if cached is not None and cached != _IDEMPOTENCY_IN_PROGRESS:
             self.logger.info("Idempotency hit for %s transfer", domain_name)
             return Ok(cached)
+
+        # Atomically claim the slot before posting. add() only succeeds if the key is
+        # absent, so a concurrent in-flight request loses the race and is rejected
+        # instead of issuing a duplicate, chargeable transfer.
+        if not cache.add(idempotency_key, _IDEMPOTENCY_IN_PROGRESS, IDEMPOTENCY_TTL_SECONDS):
+            existing = cache.get(idempotency_key)
+            if existing is not None and existing != _IDEMPOTENCY_IN_PROGRESS:
+                return Ok(existing)
+            self.logger.warning("Concurrent %s transfer already in progress — rejecting duplicate", domain_name)
+            return Err(RegistrarConflictError(domain_name, self.registrar.name))
 
         result = self._run_phase2_op(
             lambda: self._do_initiate_transfer(domain_name, epp_code),
@@ -517,6 +535,7 @@ class BaseRegistrarGateway(ABC):
             self._record_success()
             self._audit_api_call("domain_transfer", domain_name, success=True)
         else:
+            cache.delete(idempotency_key)  # release the claim so a legitimate retry can proceed
             error = result.unwrap_err()
             self._record_failure(error)
             self._audit_api_call("domain_transfer", domain_name, success=False, error=error.code.value)
@@ -606,10 +625,25 @@ class BaseRegistrarGateway(ABC):
         if err := self._check_circuit_breaker():
             return err
 
-        result = self._retry(
-            lambda: self._do_check_availability_bulk(domain_names),
-            operation=f"bulk_check:{len(domain_names)}_domains",
-        )
+        # Exception-safety: _retry can raise (RegistrarAPIError / malformed body) out of
+        # the bulk lambda; convert to an Err so a registrar outage fails closed instead of
+        # surfacing as an unhandled 500 (mirrors check_availability).
+        try:
+            result = self._retry(
+                lambda: self._do_check_availability_bulk(domain_names),
+                operation=f"bulk_check:{len(domain_names)}_domains",
+            )
+        except RegistrarAPIError as exc:
+            result = Err(exc)
+        except Exception as exc:
+            result = Err(
+                RegistrarAPIError(
+                    f"Unexpected error during bulk availability check ({len(domain_names)} domains)",
+                    code=RegistrarErrorCode.INTERNAL_ERROR,
+                    registrar_name=self.registrar.name,
+                    detail=str(exc),
+                )
+            )
 
         if result.is_ok():
             self._record_success()

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -706,8 +706,10 @@ class DomainLifecycleService:
             logger.error("Failed to create transfer records for %s: %s", domain_name, e)
             return Err(cast(str, _("Failed to initiate transfer")))
 
-        # Phase 2: submit to registrar (outside the transaction above).
-        result = gateway.initiate_transfer(domain_name, epp_code)
+        # Phase 2: submit to registrar (outside the transaction above). Use the stored
+        # (lowercased) domain.name so the gateway idempotency key matches on any retry —
+        # passing the raw domain_name would key "Example.com" separately from "example.com".
+        result = gateway.initiate_transfer(domain.name, epp_code)
         if result.is_ok():
             transfer = result.unwrap()
             op.mark_submitted(registrar_operation_id=transfer.transfer_id)

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -542,7 +542,7 @@ class LifecycleServicePhase2FailureContractTests(TestCase):
         retry and a duplicate chargeable transfer can slip through (Copilot finding)."""
         captured: dict[str, str] = {}
 
-        def _capture(name: str, epp: str) -> Ok:
+        def _capture(name: str, epp: str) -> Ok[DomainTransferResult]:
             captured["name"] = name
             return Ok(DomainTransferResult(transfer_id="t-1", status="pending"))
 

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -17,8 +17,10 @@ from django_fsm import TransitionNotAllowed
 from apps.common.types import Err, Ok, Retriability
 from apps.customers.models import Customer
 from apps.domains.gateways.base import (
+    _IDEMPOTENCY_IN_PROGRESS,
     DomainAvailabilityResult,
     DomainInfoResult,
+    DomainTransferResult,
 )
 from apps.domains.gateways.errors import RegistrarAPIError, RegistrarErrorCode, RegistrarTransientError
 from apps.domains.gateways.gandi import GandiGateway
@@ -163,6 +165,71 @@ class GandiTransferTests(TestCase):
         result = self.gateway.initiate_transfer("example.com", "BAD-EPP")
 
         self.assertTrue(result.is_err())
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
+class TransferIdempotencyClaimTests(TestCase):
+    """initiate_transfer must claim the idempotency slot atomically BEFORE posting,
+    so two concurrent requests can't both submit a chargeable transfer (Codex P1)."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_initiate_transfer")
+    @patch("apps.domains.gateways.base.cache")
+    def test_transfer_claims_slot_with_sentinel_before_posting(
+        self, mock_cache: MagicMock, mock_do: MagicMock
+    ) -> None:
+        # circuit breaker closed (0), idempotency slot free (None), claim wins.
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_do.return_value = Ok(DomainTransferResult(transfer_id="t-1", status="pending"))
+
+        result = self.gateway.initiate_transfer("example.com", "EPP")
+
+        self.assertTrue(result.is_ok(), result)
+        # The atomic claim (cache.add of the in-progress sentinel) must have happened —
+        # the naive get-then-set path never calls add().
+        self.assertTrue(mock_cache.add.called)
+        self.assertEqual(mock_cache.add.call_args.args[1], _IDEMPOTENCY_IN_PROGRESS)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_initiate_transfer")
+    @patch("apps.domains.gateways.base.cache")
+    def test_concurrent_transfer_loses_claim_and_does_not_post(
+        self, mock_cache: MagicMock, mock_do: MagicMock
+    ) -> None:
+        # slot free on first look, but the atomic add loses the race (another request
+        # already claimed it) and the recheck finds no completed result yet.
+        mock_cache.get.side_effect = [0, None, None]
+        mock_cache.add.return_value = False  # claim lost
+
+        result = self.gateway.initiate_transfer("example.com", "EPP")
+
+        self.assertTrue(result.is_err(), result)
+        # The chargeable registrar call must NOT be made when the claim is lost.
+        mock_do.assert_not_called()
+
+
+class BulkAvailabilityExceptionSafetyTests(TestCase):
+    """check_availability_bulk must convert a raised registrar error into an Err,
+    not let it propagate as a 500 (Copilot base.py finding)."""
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_check_availability_bulk")
+    @patch("apps.domains.gateways.base.cache")
+    def test_raised_registrar_error_becomes_err(self, mock_cache: MagicMock, mock_bulk: MagicMock) -> None:
+        mock_cache.get.return_value = 0  # circuit breaker closed
+        mock_bulk.side_effect = RegistrarAPIError(
+            "boom", code=RegistrarErrorCode.INTERNAL_ERROR, registrar_name="gandi"
+        )
+
+        result = self.gateway.check_availability_bulk(["a.com", "b.com"])
+
+        self.assertTrue(result.is_err(), result)  # outage != unhandled 500
 
 
 class GandiDomainInfoTests(TestCase):
@@ -468,6 +535,24 @@ class LifecycleServicePhase2FailureContractTests(TestCase):
 
         self.assertTrue(result.is_err(), result)
         self.assertFalse(self.Domain.objects.filter(name="transfer2.com").exists())
+
+    def test_transfer_passes_lowercased_domain_to_gateway(self) -> None:
+        """The DB row stores domain.name lowercased; the gateway call must use the SAME
+        casing, or the gateway idempotency key (keyed on the passed name) won't match a
+        retry and a duplicate chargeable transfer can slip through (Copilot finding)."""
+        captured: dict[str, str] = {}
+
+        def _capture(name: str, epp: str) -> Ok:
+            captured["name"] = name
+            return Ok(DomainTransferResult(transfer_id="t-1", status="pending"))
+
+        gw = MagicMock()
+        gw.initiate_transfer.side_effect = _capture
+        with patch("apps.domains.gateways.RegistrarGatewayFactory.create_gateway", return_value=gw):
+            result = DomainLifecycleService.initiate_transfer("Example.COM", "EPP", self.customer, self.registrar)
+
+        self.assertTrue(result.is_ok(), result)
+        self.assertEqual(captured["name"], "example.com")
 
     def test_transfer_unknown_keeps_pending_row(self) -> None:
         with self._mock_gateway(initiate_transfer=self._err(RegistrarErrorCode.NETWORK_ERROR, Retriability.UNKNOWN)):


### PR DESCRIPTION
## Post-merge review follow-ups on the Phase 2 gateway layer (#264)

Addresses the review findings that landed on #264 after it merged.

### Fixed here (base/service layer — reachable regardless of adapter)
- **Transfer idempotency is now claimed atomically (P1).** `initiate_transfer` claimed
  the idempotency slot with a get-then-set, leaving a window where two concurrent
  transfer requests for the same domain both missed the cache and both submitted a
  **chargeable** transfer. It now claims the slot with `cache.add` of the in-progress
  sentinel *before* posting (mirroring the registration path); the loser of the race is
  rejected and the claim is released on failure so a legitimate retry proceeds.
- **`check_availability_bulk` is exception-safe.** It called `_retry` without the wrapper
  the other operations use, so a raised `RegistrarAPIError` / malformed body propagated
  as an unhandled 500. It now converts any escape to an `Err` (outage fails closed).
- **Service passes the lowercased domain to the gateway.** `initiate_transfer` stored the
  row as `domain.name` (lowercased) but called the gateway with the raw argument, so the
  gateway idempotency key wouldn't match on a retry with different casing.

### Deferred (tracked in #265)
The three Gandi-specific payload-shape findings (transfer `authinfo`/owner, nameserver
object wrapper, transfer-lock `/status` endpoint) are gated behind the verified-adapter
guard and can't reach production. They need correction **and** verification against a
Gandi sandbox, so they're tracked in #265 with the ROTLD adapter verification.

### Tests (all fail on revert)
Atomic-claim-before-post, concurrent-claim-rejected-without-posting, bulk
raised-error-to-Err, service lowercases-domain-for-gateway. Full `tests.domains` green
(127), mypy clean, lint clean.

Signed-off-by: Claudiu Ciungan <claudiu@captainpragmatic.com>
