### PR TITLE
refactor(users): migrate remaining is_staff checks to is_staff_user (#174) (#179)

### DIFF
--- a/services/platform/apps/common/context_processors.py
+++ b/services/platform/apps/common/context_processors.py
@@ -58,7 +58,7 @@ def user_permissions(request: HttpRequest) -> dict[str, Any]:
             "can_view_audit": request.user.has_perm("audit.view_auditlog"),
         },
         "user_role": getattr(request.user, "role", "user"),
-        "can_access_admin": request.user.is_staff,
+        "can_access_admin": getattr(request.user, "is_staff_user", False),
     }
 
 

--- a/services/platform/apps/common/decorators.py
+++ b/services/platform/apps/common/decorators.py
@@ -202,7 +202,7 @@ def can_manage_financial_data(user: User) -> bool:
     if user.is_superuser:
         return True
 
-    if not user.is_staff:
+    if not user.is_staff_user:
         return False
 
     allowed_roles = ["admin", "billing", "manager"]

--- a/services/platform/apps/common/decorators.py
+++ b/services/platform/apps/common/decorators.py
@@ -202,7 +202,9 @@ def can_manage_financial_data(user: User) -> bool:
     if user.is_superuser:
         return True
 
-    if not user.is_staff_user:
+    # getattr guard: is_staff_user is a property on the custom User model that AnonymousUser
+    # lacks; a direct access would raise AttributeError where the old is_staff returned False.
+    if not getattr(user, "is_staff_user", False):
         return False
 
     allowed_roles = ["admin", "billing", "manager"]

--- a/services/platform/apps/infrastructure/permissions.py
+++ b/services/platform/apps/infrastructure/permissions.py
@@ -87,7 +87,7 @@ def can_deploy_nodes(user: User) -> bool:
         return True
 
     # Staff with deploy permission
-    if user.is_staff and user.has_perm(PERM_DEPLOY_NODES):
+    if user.is_staff_user and user.has_perm(PERM_DEPLOY_NODES):
         return True
 
     return user.has_perm(PERM_DEPLOY_NODES)

--- a/services/platform/apps/orders/views.py
+++ b/services/platform/apps/orders/views.py
@@ -144,14 +144,14 @@ def _validate_manual_price_override(
     manual_price_cents: int, product_price_cents: int, user: User, context: str = ""
 ) -> tuple[bool, str]:
     """🔒 Validate manual price override for security"""
-    if not hasattr(user, "is_staff") or not user.is_staff:
+    if not getattr(user, "is_staff_user", False):
         logger.warning(
             f"⛔ [Orders] Price Security: Unauthorized price override attempt by user {getattr(user, 'id', 'Unknown')} ({getattr(user, 'email', 'Unknown')}) in context: {context}"
         )
         return False, "Insufficient permissions for price override"
 
     # Check for specific financial permissions (staff role required)
-    if not (user.is_superuser or (hasattr(user, "staff_role") and user.staff_role in ["admin", "billing"])):
+    if not (user.is_superuser or getattr(user, "staff_role", "") in ["admin", "billing"]):
         logger.warning(
             f"⛔ [Orders] Price Security: Staff user {getattr(user, 'id', 'Unknown')} ({getattr(user, 'email', 'Unknown')}) lacks financial permissions for price override in context: {context}"
         )

--- a/services/platform/tests/orders/test_orders_security.py
+++ b/services/platform/tests/orders/test_orders_security.py
@@ -588,7 +588,7 @@ class SecurityRegressionTests(OrderSecurityTestCase):
             (True, False, ""): False,  # Staff with no role
             (True, False, None): False,  # Staff with None role
             (False, True, ""): True,  # Superuser overrides everything
-            (False, False, "admin"): False,  # Non-staff with admin role should be False
+            (False, False, "admin"): True,  # staff_role="admin" is staff via is_staff_user
         }
 
         for (is_staff, is_superuser, staff_role), expected in permission_matrix.items():

--- a/services/platform/tests/orders/test_orders_security.py
+++ b/services/platform/tests/orders/test_orders_security.py
@@ -9,6 +9,7 @@ Tests the critical security fixes implemented for:
 """
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.test import TestCase
 from django.test.client import Client
@@ -460,6 +461,15 @@ class AccessControlSecurityTests(OrderSecurityTestCase):
         user_invalid_role.staff_role = "invalid_role"
 
         self.assertFalse(can_manage_financial_data(user_invalid_role))
+
+    def test_can_manage_financial_data_anonymous_user_returns_false(self) -> None:
+        """AnonymousUser has no is_staff_user attribute — must fail safely to False, not raise.
+
+        Regression guard: is_staff_user is a property on the custom User model; the Django
+        AnonymousUser lacks it, so a direct access would raise AttributeError (a 500) where
+        the previous is_staff check returned False. The check must stay getattr-guarded.
+        """
+        self.assertFalse(can_manage_financial_data(AnonymousUser()))
 
 
 class SecurityLoggingTests(OrderSecurityTestCase):


### PR DESCRIPTION
Integration branch for #179 (Ciprian Radulescu / @b3lz3but's is_staff → is_staff_user migration), carrying the contributor's commit plus a regression fix. Opened against `master` because the source PR is from a fork.

Contributor change (#179 / #174): migrate the generic staff permission helpers (can_access_admin, can_manage_financial_data, can_deploy_nodes, price-override validation) to is_staff_user so staff-by-role users are recognized consistently.

Fix on top: can_manage_financial_data accessed is_staff_user directly, which raises AttributeError on AnonymousUser where is_staff returned False — added the same getattr guard used at the other sites, with a regression test.

Remaining generic is_staff gates tracked for a deliberate sweep in #271 (some are sensitive boundaries needing a policy decision).

Closes #179. Closes #174.
