### PR TITLE
fix(notifications): dedupe marketing_consent audit, single canonical writer (#182) (#185)

### DIFF
--- a/services/platform/apps/audit/compliance.py
+++ b/services/platform/apps/audit/compliance.py
@@ -623,9 +623,24 @@ class ComplianceReportService:
         privacy_events = [e for e in events if e.category == "privacy"]
         data_events = [e for e in events if e.category == "data_protection"]
 
-        # Consent management
+        # Consent management. Customer marketing-consent changes are recorded as the
+        # canonical ComplianceLog (compliance_type="marketing_consent") rather than an
+        # AuditEvent (issue #182), so count those here IN ADDITION to the privacy
+        # AuditEvents (which still carry User/gdpr/cookie consent). Sources are disjoint
+        # going forward. NOTE: a report window that straddles the #182 migration date can
+        # briefly over-count Customer marketing consent, which existed in both tables during
+        # the transition — acceptable for this coarse, on-demand metric.
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415  # avoid import cycle
+
+        marketing_logs = ComplianceLog.objects.filter(
+            compliance_type="marketing_consent",
+            timestamp__gte=report.period_start,
+            timestamp__lte=report.period_end,
+        )
         consent_granted = len([e for e in privacy_events if "granted" in e.action])
+        consent_granted += marketing_logs.filter(evidence__new_consent=True).count()
         consent_withdrawn = len([e for e in privacy_events if "withdrawn" in e.action])
+        consent_withdrawn += marketing_logs.filter(evidence__new_consent=False).count()
 
         # Data subject requests
         export_requests = len([e for e in data_events if e.action == "data_export_requested"])

--- a/services/platform/apps/customers/signals.py
+++ b/services/platform/apps/customers/signals.py
@@ -751,12 +751,31 @@ def _handle_marketing_consent_change(customer: Customer, old_consent: bool, new_
     """
     consent_action = "granted" if new_consent else "withdrawn"
 
+    # Source attribution: callers (EmailPreferenceService.update_preferences,
+    # process_unsubscribe, admin actions) set instance._consent_source before
+    # save() so the signal records WHERE the change originated. Falls back to
+    # "system" for direct Customer.save() callers (data imports, fixtures,
+    # ad-hoc shell commands). GDPR Art. 7 requires this attribution; collapsing
+    # the prior service-layer log_simple_event call into the signal keeps a
+    # single audit record per consent flip.
+    source = getattr(customer, "_consent_source", "system")
+    category = getattr(customer, "_consent_category", None)
+
+    evidence: dict[str, Any] = {
+        "customer_id": str(customer.id),
+        "old_consent": old_consent,
+        "new_consent": new_consent,
+        "source": source,
+    }
+    if category is not None:
+        evidence["category"] = category
+
     compliance_request = ComplianceEventRequest(
         compliance_type="marketing_consent",
         reference_id=f"customer_{customer.id}",
-        description=f"Marketing consent {consent_action}",
+        description=f"Marketing consent {consent_action} via {source}",
         status="success",
-        evidence={"customer_id": str(customer.id), "old_consent": old_consent, "new_consent": new_consent},
+        evidence=evidence,
     )
 
     try:

--- a/services/platform/apps/customers/signals.py
+++ b/services/platform/apps/customers/signals.py
@@ -82,15 +82,22 @@ def handle_customer_created_or_updated(
 
             event_type = "customer_created" if created else "customer_updated"
 
-            CustomersAuditService.log_customer_event(
-                event_type=event_type,
-                customer=instance,
-                user=getattr(instance, "_audit_user", None),
-                context=AuditContext(actor_type="system"),
-                old_values=old_values,
-                new_values=new_values,
-                description=f"Customer {instance.get_display_name()} {'created' if created else 'updated'}",
-            )
+            # Best-effort + savepoint-isolated: a failure in this generic audit write must
+            # neither poison the surrounding transaction nor skip the consent-change handlers
+            # below (the canonical audit path for marketing/GDPR consent — issue #182).
+            try:
+                with transaction.atomic():
+                    CustomersAuditService.log_customer_event(
+                        event_type=event_type,
+                        customer=instance,
+                        user=getattr(instance, "_audit_user", None),
+                        context=AuditContext(actor_type="system"),
+                        old_values=old_values,
+                        new_values=new_values,
+                        description=f"Customer {instance.get_display_name()} {'created' if created else 'updated'}",
+                    )
+            except Exception:
+                logger.exception("🔥 [Customer Signal] Generic customer audit write failed")
 
         if created:
             # New customer created
@@ -119,6 +126,11 @@ def handle_customer_created_or_updated(
 
     except Exception as e:
         logger.exception(f"🔥 [Customer Signal] Failed to handle customer save: {e}")
+    finally:
+        # Clear the captured originals so a later meta-only save on the SAME instance
+        # (which skips the pre_save refresh) cannot re-detect and duplicate a prior
+        # consent change.
+        instance.__dict__.pop("_original_customer_values", None)
 
 
 @receiver(pre_save, sender=Customer)
@@ -751,15 +763,19 @@ def _handle_marketing_consent_change(customer: Customer, old_consent: bool, new_
     """
     consent_action = "granted" if new_consent else "withdrawn"
 
-    # Source attribution: callers (EmailPreferenceService.update_preferences,
-    # process_unsubscribe, admin actions) set instance._consent_source before
-    # save() so the signal records WHERE the change originated. Falls back to
-    # "system" for direct Customer.save() callers (data imports, fixtures,
-    # ad-hoc shell commands). GDPR Art. 7 requires this attribution; collapsing
-    # the prior service-layer log_simple_event call into the signal keeps a
-    # single audit record per consent flip.
-    source = getattr(customer, "_consent_source", "system")
+    # Source attribution: the service callers (EmailPreferenceService.update_preferences
+    # and process_unsubscribe) set instance._consent_source before save() so the signal
+    # records WHERE the change originated. Falls back to "system" for any other path that
+    # does not set it — direct Customer.save(), data imports, fixtures, admin, ad-hoc shell.
+    # GDPR Art. 7 requires this attribution; collapsing the prior service-layer
+    # log_simple_event call into the signal keeps a single audit record per consent flip.
+    # `or "system"` normalizes a present-but-falsy value so we never record "via None".
+    source = getattr(customer, "_consent_source", None) or "system"
     category = getattr(customer, "_consent_category", None)
+    # Consume the transient attribution so a later save of the SAME instance cannot inherit
+    # a stale source/category and mis-attribute a subsequent consent change.
+    customer.__dict__.pop("_consent_source", None)
+    customer.__dict__.pop("_consent_category", None)
 
     evidence: dict[str, Any] = {
         "customer_id": str(customer.id),

--- a/services/platform/apps/customers/signals.py
+++ b/services/platform/apps/customers/signals.py
@@ -97,7 +97,11 @@ def handle_customer_created_or_updated(
                         description=f"Customer {instance.get_display_name()} {'created' if created else 'updated'}",
                     )
             except Exception:
-                logger.exception("🔥 [Customer Signal] Generic customer audit write failed")
+                logger.exception(
+                    "🔥 [Customer Signal] Generic customer audit write failed (customer_id=%s, %s)",
+                    instance.pk,
+                    "created" if created else "updated",
+                )
 
         if created:
             # New customer created
@@ -127,10 +131,12 @@ def handle_customer_created_or_updated(
     except Exception as e:
         logger.exception(f"🔥 [Customer Signal] Failed to handle customer save: {e}")
     finally:
-        # Clear the captured originals so a later meta-only save on the SAME instance
-        # (which skips the pre_save refresh) cannot re-detect and duplicate a prior
-        # consent change.
+        # Consume all transient per-save attribution on EVERY save (including saves that do
+        # not flip consent, where the consent handler never runs), so a stale source/category
+        # or captured originals cannot leak into a later save of the SAME instance.
         instance.__dict__.pop("_original_customer_values", None)
+        instance.__dict__.pop("_consent_source", None)
+        instance.__dict__.pop("_consent_category", None)
 
 
 @receiver(pre_save, sender=Customer)
@@ -772,10 +778,9 @@ def _handle_marketing_consent_change(customer: Customer, old_consent: bool, new_
     # `or "system"` normalizes a present-but-falsy value so we never record "via None".
     source = getattr(customer, "_consent_source", None) or "system"
     category = getattr(customer, "_consent_category", None)
-    # Consume the transient attribution so a later save of the SAME instance cannot inherit
-    # a stale source/category and mis-attribute a subsequent consent change.
-    customer.__dict__.pop("_consent_source", None)
-    customer.__dict__.pop("_consent_category", None)
+    # NOTE: the transient _consent_source/_consent_category are consumed (cleared) in the
+    # post_save receiver's finally block on EVERY save — not here — so a source set on a save
+    # that does NOT flip consent (this handler never runs) cannot leak into a later flip.
 
     evidence: dict[str, Any] = {
         "customer_id": str(customer.id),

--- a/services/platform/apps/notifications/services.py
+++ b/services/platform/apps/notifications/services.py
@@ -1384,13 +1384,17 @@ class EmailPreferenceService:
 
     @staticmethod
     def update_preferences(customer: Customer, preferences: dict[str, bool]) -> None:
-        """Update email preferences for a customer with atomic consent tracking."""
-        from apps.audit.services import AuditService  # noqa: PLC0415
+        """Update email preferences for a customer with atomic consent tracking.
+
+        Source attribution is threaded into the post_save signal via
+        ``_consent_source`` on the locked instance so a single compliance audit
+        record (the signal-driven one in apps.customers.signals) carries the
+        origin. Issue #182 — drops a duplicate service-layer audit call.
+        """
         from apps.customers.models import Customer as CustomerModel  # noqa: PLC0415
 
         with transaction.atomic():
             locked = CustomerModel.objects.select_for_update(of=("self",)).get(id=customer.id)
-            old_marketing = locked.marketing_consent
 
             # "marketing" is the canonical key; "newsletters" is accepted as an alias.
             # If both are present, "marketing" wins so an explicit opt-out cannot be
@@ -1400,26 +1404,11 @@ class EmailPreferenceService:
             elif "newsletters" in preferences:
                 locked.marketing_consent = preferences["newsletters"]
 
+            # The signal compares against the pre-save DB value, so we don't
+            # need to gate the attribution here — if no consent change occurs,
+            # the signal won't emit an audit event regardless.
+            locked._consent_source = "preference_center"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
             locked.save(update_fields=["marketing_consent"])
-
-            if old_marketing != locked.marketing_consent:
-                # Audit is best-effort — never block a GDPR consent change (Art. 7(3))
-                # because of an audit-table failure. Savepoint isolates audit DB writes
-                # so a failure here does not mark the outer transaction for rollback.
-                try:
-                    with transaction.atomic():
-                        AuditService.log_simple_event(
-                            "marketing_consent_granted" if locked.marketing_consent else "marketing_consent_withdrawn",
-                            content_object=locked,
-                            description=f"Email preferences updated for customer {locked.id}",
-                            old_values={"marketing_consent": old_marketing},
-                            new_values={"marketing_consent": locked.marketing_consent},
-                            metadata={"source": "preference_center"},
-                        )
-                except Exception:
-                    logger.exception(
-                        "🔥 [Consent] Audit logging failed for marketing_consent change on customer %s", locked.id
-                    )
 
     @staticmethod
     def can_send_category(customer: Customer, category: str) -> bool:
@@ -1451,7 +1440,6 @@ class EmailPreferenceService:
         Returns:
             True if unsubscribe was successful
         """
-        from apps.audit.services import AuditService  # noqa: PLC0415
         from apps.customers.models import (  # noqa: PLC0415  # Deferred: avoids circular import
             Customer,  # Circular: cross-app  # Deferred: avoids circular import
         )
@@ -1482,26 +1470,13 @@ class EmailPreferenceService:
                     EmailSuppressionService.suppress_email(email, "unsubscribe")
                     return True
 
-                old_marketing = customer.marketing_consent
                 if category == "marketing" or category is None:
                     customer.marketing_consent = False
+                # Source + category are threaded into the post_save signal so
+                # the single compliance audit record records origin (issue #182).
+                customer._consent_source = "unsubscribe_link"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
+                customer._consent_category = category or "all_marketing"  # type: ignore[attr-defined]  # transient signal-instance attr; read via getattr in customers.signals
                 customer.save(update_fields=["marketing_consent"])
-
-                if old_marketing != customer.marketing_consent:
-                    # Audit is best-effort — never block a GDPR consent withdrawal
-                    # (Art. 7(3)) because of an audit-table failure.
-                    try:
-                        with transaction.atomic():
-                            AuditService.log_simple_event(
-                                "marketing_consent_withdrawn",
-                                content_object=customer,
-                                description=f"Unsubscribe via token for {email[:3]}***",
-                                old_values={"marketing_consent": old_marketing},
-                                new_values={"marketing_consent": False},
-                                metadata={"source": "unsubscribe_link", "category": category or "all_marketing"},
-                            )
-                    except Exception:
-                        logger.exception("🔥 [Unsubscribe] Audit logging failed for customer %s", customer.id)
 
                 logger.info(f"✅ [Unsubscribe] Processed for {email[:3]}***")
                 return True

--- a/services/platform/tests/audit/test_audit_compliance.py
+++ b/services/platform/tests/audit/test_audit_compliance.py
@@ -407,6 +407,42 @@ class TestComplianceReportServiceGenerateReport(TestCase):
             self.assertIn("Authentication Summary", titles)
             self.assertIn("Security Events", titles)
 
+    def test_gdpr_report_counts_marketing_consent_from_both_sources(self) -> None:
+        """Issue #182: Customer marketing consent is now a ComplianceLog record, not an
+        AuditEvent. The GDPR report must count those canonical ComplianceLog records in
+        addition to the AuditEvent privacy consent events (User/gdpr/cookie), without
+        double-counting either source.
+        """
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
+        # User-path consent still writes an AuditEvent (privacy category) — must still count.
+        self._create_event(action="marketing_consent_granted", category="privacy", severity="info")
+        # Customer-path consent writes the canonical ComplianceLog (issue #182).
+        ComplianceLog.objects.create(
+            compliance_type="marketing_consent",
+            reference_id="customer_a",
+            status="success",
+            description="Marketing consent granted via preference_center",
+            evidence={"new_consent": True, "old_consent": False},
+        )
+        ComplianceLog.objects.create(
+            compliance_type="marketing_consent",
+            reference_id="customer_b",
+            status="success",
+            description="Marketing consent withdrawn via unsubscribe_link",
+            evidence={"new_consent": False, "old_consent": True},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            svc = self._service(tmpdir)
+            start, end = make_period()
+            report = svc.generate_report(ReportType.GDPR_COMPLIANCE, start, end)
+
+        gdpr = next(s for s in report.sections if s.title == "GDPR Compliance")
+        # 1 AuditEvent granted + 1 ComplianceLog granted; 1 ComplianceLog withdrawn.
+        self.assertEqual(gdpr.metrics["consent_granted"], 2)
+        self.assertEqual(gdpr.metrics["consent_withdrawn"], 1)
+
     def test_generate_access_review(self) -> None:
         self._create_event(action="role_assigned", category="authorization", severity="info")
         self._create_event(action="permission_granted", category="authorization", severity="info")

--- a/services/platform/tests/customers/test_customers_security.py
+++ b/services/platform/tests/customers/test_customers_security.py
@@ -4,20 +4,18 @@ Tests all OWASP Top 10 security enhancements implemented for the customers syste
 """
 
 import socket
-from unittest.mock import patch, Mock
-from django.test import TestCase, Client, RequestFactory
-from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError, PermissionDenied
-from django.urls import reverse
-from django.contrib.messages import get_messages
-from django.utils import timezone
-from datetime import timedelta
+from unittest.mock import Mock, patch
 
-from apps.customers.models import Customer, CustomerPaymentMethod, validate_bank_details
-from apps.customers.forms import CustomerTaxProfileForm
-from apps.customers.views import _handle_secure_error
-from apps.common.validators import SecureInputValidator
+from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.test import Client, RequestFactory, TestCase
+from django.urls import reverse
+
 from apps.billing.models import Currency
+from apps.common.validators import SecureInputValidator
+from apps.customers.forms import CustomerTaxProfileForm
+from apps.customers.models import Customer, CustomerPaymentMethod, validate_bank_details
+from apps.customers.views import _handle_secure_error
 
 User = get_user_model()
 
@@ -411,14 +409,17 @@ class SoftDeleteSecurityTests(TestCase):
 
     def test_soft_delete_atomic_transaction(self):
         """Test that soft delete uses atomic transactions"""
-        # This test ensures the soft_delete method uses transaction.atomic
+        # This test ensures the soft_delete method uses transaction.atomic. The signal
+        # handlers fired by the save may open additional savepoint-isolated atomic blocks
+        # (best-effort audit writes), so assert at-least-once rather than exactly-once —
+        # the behavior under test is "soft delete is wrapped", not the total call count.
         with patch('django.db.transaction.atomic') as mock_atomic:
             mock_atomic.return_value.__enter__ = Mock()
             mock_atomic.return_value.__exit__ = Mock()
 
             self.customer.soft_delete(self.user)
 
-            mock_atomic.assert_called_once()
+            mock_atomic.assert_called()
 
     def test_validation_methods_exist(self):
         """Test that validation methods are available for override"""

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -428,6 +428,34 @@ class UpdatePreferencesTests(TestCase):
         self.assertEqual(records[0].evidence["source"], "unsubscribe_link")
         self.assertEqual(records[1].evidence["source"], "system")  # not the stale source
 
+    def test_source_without_flip_does_not_leak_into_later_flip(self) -> None:
+        """A source set on a save that does NOT flip consent must not attribute a later flip.
+
+        The consent handler only runs on an actual flip, so the transient attrs must be
+        cleared by the receiver on EVERY save — otherwise an unsubscribe-when-already-
+        unsubscribed leaves "unsubscribe_link" on the instance and a later unrelated flip
+        inherits it.
+        """
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
+        customer = self._make_customer(marketing=False)
+
+        # Save with a source but NO consent change (already False → False).
+        customer._consent_source = "unsubscribe_link"  # type: ignore[attr-defined]
+        customer.marketing_consent = False
+        customer.save(update_fields=["marketing_consent"])
+        self.assertNotIn("_consent_source", customer.__dict__)  # cleared despite no flip
+
+        # Later flip on the same instance without a source → must be "system".
+        customer.marketing_consent = True
+        customer.save(update_fields=["marketing_consent"])
+
+        records = ComplianceLog.objects.filter(
+            compliance_type="marketing_consent", reference_id=f"customer_{customer.id}"
+        )
+        self.assertEqual(records.count(), 1)
+        self.assertEqual(records.get().evidence["source"], "system")
+
     def test_generic_audit_failure_does_not_skip_marketing_compliance_log(self) -> None:
         """A failure in the earlier generic customer-audit write must not skip the canonical
         marketing ComplianceLog write later in the same receiver (issue #182 review)."""

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -245,7 +245,7 @@ class ProcessUnsubscribeTests(TestCase):
             template_key="marketing",
         )
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             result = EmailPreferenceService.process_unsubscribe(
                 str(token.id), "marketing"
             )
@@ -254,60 +254,32 @@ class ProcessUnsubscribeTests(TestCase):
         customer.refresh_from_db()
         self.assertFalse(customer.marketing_consent)
 
+        # Issue #182: a single compliance audit record per consent flip,
+        # carrying source attribution in evidence.
         mock_audit.assert_called_once()
-        call_args = mock_audit.call_args
-        self.assertEqual(call_args.args[0], "marketing_consent_withdrawn")
-        self.assertEqual(call_args.kwargs["content_object"], customer)
-        self.assertEqual(call_args.kwargs["old_values"], {"marketing_consent": True})
-        self.assertEqual(call_args.kwargs["new_values"], {"marketing_consent": False})
-        self.assertEqual(call_args.kwargs["metadata"]["source"], "unsubscribe_link")
-        self.assertEqual(call_args.kwargs["metadata"]["category"], "marketing")
-
-    def test_unsubscribe_audit_failure_does_not_block_consent_withdrawal(self) -> None:
-        """GDPR Art. 7(3): service-layer audit errors must never block a consent withdrawal.
-
-        Note: patching log_simple_event raises a Python exception, which the savepoint
-        catches. It does NOT simulate the full PostgreSQL InFailedSqlTransaction recovery
-        path (that would require a real failed SQL statement inside the savepoint, which
-        is not feasible in a unit test). The savepoint pattern is correct by code reading;
-        this test verifies the Python-level exception handling.
-        """
-        customer = Customer.objects.create(
-            name="Resilient Customer",
-            customer_type="individual",
-            primary_email="resilient@example.com",
-            marketing_consent=True,
-        )
-        token = UnsubscribeToken.objects.create(
-            email="resilient@example.com",
-            template_key="marketing",
-        )
-
-        with patch(
-            "apps.audit.services.AuditService.log_simple_event",
-            side_effect=OperationalError("audit table down"),
-        ):
-            result = EmailPreferenceService.process_unsubscribe(str(token.id), "marketing")
-
-        self.assertTrue(result)
-        customer.refresh_from_db()
-        self.assertFalse(customer.marketing_consent)
+        request = mock_audit.call_args.args[0]
+        self.assertEqual(request.compliance_type, "marketing_consent")
+        self.assertEqual(request.evidence["customer_id"], str(customer.id))
+        self.assertTrue(request.evidence["old_consent"])
+        self.assertFalse(request.evidence["new_consent"])
+        self.assertEqual(request.evidence["source"], "unsubscribe_link")
+        self.assertEqual(request.evidence["category"], "marketing")
 
     def test_unsubscribe_signal_audit_failure_does_not_block_consent_withdrawal(self) -> None:
-        """GDPR Art. 7(3): signal-side audit errors must also not block consent.
+        """GDPR Art. 7(3): signal-side audit errors must not block consent.
 
-        Customer.save() fires post_save → _handle_marketing_consent_change → log_compliance_event.
-        On real Postgres, an OperationalError mid-SQL inside log_compliance_event would mark the
-        connection InFailedSqlTransaction and force a rollback of the outer transaction unless
-        wrapped in a savepoint. This test patches log_compliance_event (the signal-side path),
-        distinct from the log_simple_event test above (the service-layer path).
+        Issue #182 collapsed the duplicate service-layer audit call into the
+        signal handler, so this is now the sole audit path. Customer.save()
+        fires post_save → _handle_marketing_consent_change → log_compliance_event.
+        On real Postgres, an OperationalError mid-SQL would mark the connection
+        InFailedSqlTransaction and force a rollback unless wrapped in a
+        savepoint.
 
-        Test limitation: SQLite does not implement InFailedSqlTransaction state, so this test
-        cannot empirically distinguish "savepoint present" from "savepoint absent" — falsified
-        in this session by removing the savepoint and observing the test still pass. The
-        savepoint is required for production Postgres correctness; this test verifies the
-        Python-level exception flow only. Project-wide test-config limitation, also affects
-        select_for_update() coverage.
+        Test limitation: SQLite does not implement InFailedSqlTransaction
+        state, so this test cannot empirically distinguish "savepoint present"
+        from "savepoint absent". The savepoint is required for production
+        Postgres correctness; this test verifies the Python-level exception
+        flow only.
         """
         customer = Customer.objects.create(
             name="Signal Resilient",
@@ -343,24 +315,27 @@ class UpdatePreferencesTests(TestCase):
         )
 
     def test_update_preferences_persists_marketing_consent(self) -> None:
-        """Setting marketing=True persists and emits a granted audit event."""
+        """Setting marketing=True persists and emits a single compliance audit record with source."""
         customer = self._make_customer(marketing=False)
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
         customer.refresh_from_db()
         self.assertTrue(customer.marketing_consent)
+        # Issue #182: one compliance record with source="preference_center".
         mock_audit.assert_called_once()
-        self.assertEqual(mock_audit.call_args.args[0], "marketing_consent_granted")
-        self.assertEqual(mock_audit.call_args.kwargs["old_values"], {"marketing_consent": False})
-        self.assertEqual(mock_audit.call_args.kwargs["new_values"], {"marketing_consent": True})
+        request = mock_audit.call_args.args[0]
+        self.assertEqual(request.compliance_type, "marketing_consent")
+        self.assertFalse(request.evidence["old_consent"])
+        self.assertTrue(request.evidence["new_consent"])
+        self.assertEqual(request.evidence["source"], "preference_center")
 
     def test_update_preferences_no_audit_when_unchanged(self) -> None:
         """If consent value is unchanged, no audit event is emitted."""
         customer = self._make_customer(marketing=True)
 
-        with patch("apps.audit.services.AuditService.log_simple_event") as mock_audit:
+        with patch("apps.audit.services.AuditService.log_compliance_event") as mock_audit:
             EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
         mock_audit.assert_not_called()
@@ -385,29 +360,35 @@ class UpdatePreferencesTests(TestCase):
         customer.refresh_from_db()
         self.assertTrue(customer.marketing_consent)
 
-    def test_update_preferences_audit_failure_does_not_block_consent_change(self) -> None:
-        """GDPR Art. 7(3): service-layer audit errors must never block a consent change.
+    def test_single_compliance_record_per_consent_flip(self) -> None:
+        """Issue #182 acceptance: exactly one ComplianceLog row per consent flip.
 
-        See test_unsubscribe_audit_failure_does_not_block_consent_withdrawal for the
-        note on why a Python-level OperationalError mock is the practical limit of
-        unit testing here.
+        Before the fix, both the post_save signal and the service layer wrote
+        an audit record (ComplianceLog + AuditEvent) for a single consent
+        change, forcing downstream consumers to dedupe. After the fix, the
+        signal is the canonical writer and carries source attribution in
+        evidence.
         """
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
         customer = self._make_customer(marketing=False)
+        before = ComplianceLog.objects.filter(compliance_type="marketing_consent").count()
 
-        with patch(
-            "apps.audit.services.AuditService.log_simple_event",
-            side_effect=OperationalError("audit table down"),
-        ):
-            EmailPreferenceService.update_preferences(customer, {"marketing": True})
+        EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
-        customer.refresh_from_db()
-        self.assertTrue(customer.marketing_consent)
+        new_records = ComplianceLog.objects.filter(compliance_type="marketing_consent").order_by("-id")
+        self.assertEqual(new_records.count() - before, 1)
+        latest = new_records.first()
+        self.assertEqual(latest.evidence["source"], "preference_center")
+        self.assertEqual(latest.evidence["customer_id"], str(customer.id))
+        self.assertTrue(latest.evidence["new_consent"])
 
     def test_update_preferences_signal_audit_failure_does_not_block_consent_change(self) -> None:
-        """GDPR Art. 7(3): signal-side audit errors must also not block consent.
+        """GDPR Art. 7(3): signal-side audit errors must not block consent.
 
-        Counterpart to test_update_preferences_audit_failure: patches log_compliance_event
-        (the customers.signals path) instead of log_simple_event (the service-layer path).
+        Issue #182 made the signal handler the sole audit path for marketing
+        consent on Customer; an OperationalError inside log_compliance_event
+        must not propagate out of update_preferences.
         """
         customer = self._make_customer(marketing=False)
 

--- a/services/platform/tests/notifications/test_unsubscribe_tokens.py
+++ b/services/platform/tests/notifications/test_unsubscribe_tokens.py
@@ -372,16 +372,19 @@ class UpdatePreferencesTests(TestCase):
         from apps.audit.models import ComplianceLog  # noqa: PLC0415
 
         customer = self._make_customer(marketing=False)
-        before = ComplianceLog.objects.filter(compliance_type="marketing_consent").count()
 
         EmailPreferenceService.update_preferences(customer, {"marketing": True})
 
-        new_records = ComplianceLog.objects.filter(compliance_type="marketing_consent").order_by("-id")
-        self.assertEqual(new_records.count() - before, 1)
-        latest = new_records.first()
-        self.assertEqual(latest.evidence["source"], "preference_center")
-        self.assertEqual(latest.evidence["customer_id"], str(customer.id))
-        self.assertTrue(latest.evidence["new_consent"])
+        # Scope to THIS customer's canonical record via reference_id — deterministic, with no
+        # dependence on UUID ordering or on other tests' marketing_consent rows.
+        records = ComplianceLog.objects.filter(
+            compliance_type="marketing_consent", reference_id=f"customer_{customer.id}"
+        )
+        self.assertEqual(records.count(), 1)  # exactly one ComplianceLog per consent flip
+        record = records.get()
+        self.assertEqual(record.evidence["source"], "preference_center")
+        self.assertEqual(record.evidence["customer_id"], str(customer.id))
+        self.assertTrue(record.evidence["new_consent"])
 
     def test_update_preferences_signal_audit_failure_does_not_block_consent_change(self) -> None:
         """GDPR Art. 7(3): signal-side audit errors must not block consent.
@@ -400,3 +403,48 @@ class UpdatePreferencesTests(TestCase):
 
         customer.refresh_from_db()
         self.assertTrue(customer.marketing_consent)
+
+    def test_transient_source_is_consumed_and_not_reused_on_next_flip(self) -> None:
+        """The signal consumes _consent_source, so a later flip on the same instance without a
+        source falls back to "system" instead of inheriting the stale one (issue #182 review)."""
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
+        customer = self._make_customer(marketing=False)
+
+        # First flip with an explicit source.
+        customer._consent_source = "unsubscribe_link"  # type: ignore[attr-defined]
+        customer.marketing_consent = True
+        customer.save(update_fields=["marketing_consent"])
+        self.assertNotIn("_consent_source", customer.__dict__)  # consumed by the signal
+
+        # Second flip on the SAME instance without setting a source.
+        customer.marketing_consent = False
+        customer.save(update_fields=["marketing_consent"])
+
+        records = ComplianceLog.objects.filter(
+            compliance_type="marketing_consent", reference_id=f"customer_{customer.id}"
+        ).order_by("timestamp")
+        self.assertEqual(records.count(), 2)
+        self.assertEqual(records[0].evidence["source"], "unsubscribe_link")
+        self.assertEqual(records[1].evidence["source"], "system")  # not the stale source
+
+    def test_generic_audit_failure_does_not_skip_marketing_compliance_log(self) -> None:
+        """A failure in the earlier generic customer-audit write must not skip the canonical
+        marketing ComplianceLog write later in the same receiver (issue #182 review)."""
+        from apps.audit.models import ComplianceLog  # noqa: PLC0415
+
+        customer = self._make_customer(marketing=False)
+
+        with patch(
+            "apps.audit.services.CustomersAuditService.log_customer_event",
+            side_effect=Exception("generic audit down"),
+        ):
+            customer._consent_source = "preference_center"  # type: ignore[attr-defined]
+            customer.marketing_consent = True
+            customer.save(update_fields=["marketing_consent"])
+
+        records = ComplianceLog.objects.filter(
+            compliance_type="marketing_consent", reference_id=f"customer_{customer.id}"
+        )
+        self.assertEqual(records.count(), 1)
+        self.assertEqual(records.get().evidence["source"], "preference_center")


### PR DESCRIPTION
Integration branch for #185 (Ciprian Radulescu / @b3lz3but's marketing-consent audit dedup), carrying the contributor's commit plus review fixes. Opened against `master` because the source PR is from a fork.

Contributor change (#185 / #182): a Customer.marketing_consent change produced two audit records (post_save signal ComplianceLog + service-layer AuditEvent). Make the signal the single canonical writer with source attribution threaded via transient instance attrs; drop the service-layer audit calls.

Review fixes on top:
- GDPR compliance report now counts ComplianceLog(marketing_consent) in addition to privacy AuditEvents — Customer consent moved tables, and the report's consent metrics would have silently dropped (windows straddling the transition may briefly over-count; documented inline).
- Savepoint-isolate the generic customer-audit write so its failure can't skip the consent-change handlers or poison the outer transaction.
- Attribution hygiene: falsy source normalized to "system"; transient attrs consumed after read; captured originals cleared so meta-only saves can't re-detect a prior flip.
- Deterministic acceptance test (reference_id scoping) + regression tests for the report counts, stale-source, and generic-audit-failure paths.

Closes #185. Closes #182.
