### PR TITLE
fix(api): scope customer_users_create throttle to verified portal id (#181) (#186)

### DIFF
--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -21,6 +21,11 @@ from apps.api.core import ReadOnlyAPIViewSet
 from apps.api.core.permissions import IsAuthenticatedAndAccessible
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle
 from apps.api.secure_auth import public_api_endpoint, require_customer_authentication, require_portal_authentication
+from apps.common.performance.rate_limiting import (
+    PortalHMACBurstThrottle,
+    PortalHMACCreateUserThrottle,
+    PortalHMACRateThrottle,
+)
 from apps.common.request_ip import get_safe_client_ip
 from apps.common.validators import SecureInputValidator
 from apps.customers.contact_models import CustomerAddress
@@ -982,10 +987,18 @@ def customer_users_add(request: HttpRequest, customer: Customer) -> Response:  #
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
-@throttle_classes([BurstAPIThrottle])
+@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle, PortalHMACCreateUserThrottle])
 @require_customer_authentication
 def customer_users_create(request: HttpRequest, customer: Customer) -> Response:  # noqa: PLR0911
-    """Create a new user and add them to the customer organization."""
+    """Create a new user and add them to the customer organization.
+
+    Throttling: a per-view ``@throttle_classes`` overrides DEFAULT_THROTTLE_CLASSES,
+    so we re-list the global per-portal HMAC throttles and layer a stricter
+    create-user cap on top. The previous BurstAPIThrottle (api_burst, 120/min)
+    was a regression here — it extends UserRateThrottle and this endpoint runs
+    with authentication_classes([]), so it keyed on client IP and a caller
+    distributing requests across IPs could bypass it. All three throttles below
+    key on the verified portal id (X-Portal-Id)."""
     data = _get_request_data(request)
     try:
         user_id = _extract_user_id(data)

--- a/services/platform/apps/common/apps.py
+++ b/services/platform/apps/common/apps.py
@@ -86,6 +86,7 @@ def _validate_throttle_rates_at_startup() -> None:
     # Global defaults + known per-view throttle classes must all have valid scopes.
     scoped_class_paths: list[str | type[Any]] = [
         *default_classes,
+        "apps.common.performance.rate_limiting.PortalHMACCreateUserThrottle",
         "apps.api.core.throttling.StandardAPIThrottle",
         "apps.api.core.throttling.BurstAPIThrottle",
         "apps.api.core.throttling.AuthThrottle",

--- a/services/platform/apps/common/performance/rate_limiting.py
+++ b/services/platform/apps/common/performance/rate_limiting.py
@@ -195,6 +195,28 @@ class PortalHMACBurstThrottle(_CustomTimeRateMixin, SimpleRateThrottle):  # type
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
+class PortalHMACCreateUserThrottle(SimpleRateThrottle):  # type: ignore[misc]  # DRF throttle base uses dynamic attrs
+    """Strict per-portal throttle for the HMAC user-creation mutation.
+
+    Layered on top of the global PortalHMAC*Throttle limits to bound account
+    creation specifically. Keyed on the verified portal identity (X-Portal-Id)
+    rather than client IP: customer_users_create runs with authentication_classes([])
+    so request.user is AnonymousUser, which means any UserRateThrottle/AnonRateThrottle
+    here would key on IP and be diluted by a caller distributing requests across IPs.
+    Returns None (no throttling) for non-portal traffic — the endpoint already
+    rejects unauthenticated callers via @require_customer_authentication.
+    """
+
+    scope = "portal_hmac_create_user"
+    cache_format = "throttle_portal_hmac_%(scope)s_%(ident)s"
+
+    def get_cache_key(self, request: Request, view: Any) -> str | None:
+        if not _is_portal_authenticated(request):
+            return None
+        ident = _extract_hmac_identity(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
 class CustomerRateThrottle(SimpleRateThrottle):  # type: ignore[misc]
     """
     Rate throttling based on customer account.

--- a/services/platform/apps/common/performance/rate_limiting.py
+++ b/services/platform/apps/common/performance/rate_limiting.py
@@ -52,6 +52,7 @@ _RATE_UNIT_SECONDS: dict[str, int] = {
 _KNOWN_THROTTLE_CLASS_SCOPES: dict[str, str] = {
     "apps.common.performance.rate_limiting.PortalHMACRateThrottle": "portal_hmac",
     "apps.common.performance.rate_limiting.PortalHMACBurstThrottle": "portal_hmac_burst",
+    "apps.common.performance.rate_limiting.PortalHMACCreateUserThrottle": "portal_hmac_create_user",
     "apps.common.performance.rate_limiting.CustomerRateThrottle": "customer",
     "apps.common.performance.rate_limiting.BurstRateThrottle": "burst",
     "apps.api.core.throttling.StandardAPIThrottle": "sustained",
@@ -195,7 +196,7 @@ class PortalHMACBurstThrottle(_CustomTimeRateMixin, SimpleRateThrottle):  # type
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
 
-class PortalHMACCreateUserThrottle(SimpleRateThrottle):  # type: ignore[misc]  # DRF throttle base uses dynamic attrs
+class PortalHMACCreateUserThrottle(_CustomTimeRateMixin, SimpleRateThrottle):  # type: ignore[misc]  # DRF throttle base uses dynamic attrs
     """Strict per-portal throttle for the HMAC user-creation mutation.
 
     Layered on top of the global PortalHMAC*Throttle limits to bound account

--- a/services/platform/config/settings/base.py
+++ b/services/platform/config/settings/base.py
@@ -623,6 +623,8 @@ THROTTLE_RATES = {
     # Global DRF defaults (apps.common.performance.rate_limiting)
     "portal_hmac": os.environ.get("THROTTLE_RATE_PORTAL_HMAC", "200/minute"),
     "portal_hmac_burst": "100/10s",
+    # Strict per-portal cap on the user-creation mutation (apps.api.customers.views)
+    "portal_hmac_create_user": os.environ.get("THROTTLE_RATE_PORTAL_CREATE_USER", "30/min"),
     "customer": os.environ.get("THROTTLE_RATE_CUSTOMER", "200/minute"),
     "burst": "60/10s",
     # Per-view API throttles (apps.api.core.throttling)

--- a/services/platform/tests/api/test_throttle_architecture_guardrails.py
+++ b/services/platform/tests/api/test_throttle_architecture_guardrails.py
@@ -9,6 +9,7 @@ from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle
 
 from apps.api.core import throttling as core_throttling
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle, StandardAPIThrottle
+from apps.api.customers.views import customer_users_create
 from apps.api.orders.views import (
     OrderCalculateThrottle,
     OrderCreateThrottle,
@@ -51,6 +52,7 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
         required_scopes = {
             "portal_hmac",
             "portal_hmac_burst",
+            "portal_hmac_create_user",
             "customer",
             "burst",
             "auth",
@@ -81,6 +83,43 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
             "get_throttle_rate_for_endpoint",
         ):
             self.assertFalse(hasattr(rate_limiting, removed_name))
+
+    def test_create_user_view_uses_portal_scoped_throttles_not_burst(self) -> None:
+        """customer_users_create must key throttling on the verified portal id.
+
+        Regression guard: the endpoint runs with authentication_classes([]), so an
+        IP-keyed throttle (BurstAPIThrottle / any UserRateThrottle) is bypassable by
+        distributing requests across IPs. The view must layer the per-portal HMAC
+        throttles plus the strict create-user cap instead.
+        """
+        throttle_classes = customer_users_create.cls.throttle_classes
+        self.assertIn(rate_limiting.PortalHMACCreateUserThrottle, throttle_classes)
+        self.assertIn(rate_limiting.PortalHMACRateThrottle, throttle_classes)
+        self.assertIn(rate_limiting.PortalHMACBurstThrottle, throttle_classes)
+        self.assertNotIn(BurstAPIThrottle, throttle_classes)
+
+    def test_create_user_throttle_is_portal_keyed_and_noops_without_portal_auth(self) -> None:
+        factory = RequestFactory()
+        throttle = rate_limiting.PortalHMACCreateUserThrottle()
+
+        # No portal authentication → throttle must not engage (returns None).
+        unauth = factory.post("/api/users/customers/1/users/", content_type="application/json")
+        self.assertIsNone(throttle.get_cache_key(unauth, view=None))
+
+        # Same portal, different payloads → same key (keyed on portal id, not body).
+        req_a = factory.post("/api/users/customers/1/users/", content_type="application/json")
+        req_b = factory.post("/api/users/customers/99999/users/", content_type="application/json")
+        req_a._portal_authenticated = True  # type: ignore[attr-defined]  # test sets internal HMAC flag
+        req_b._portal_authenticated = True  # type: ignore[attr-defined]  # test sets internal HMAC flag
+        req_a.META["HTTP_X_PORTAL_ID"] = "portal-a"
+        req_b.META["HTTP_X_PORTAL_ID"] = "portal-a"
+        self.assertEqual(throttle.get_cache_key(req_a, view=None), throttle.get_cache_key(req_b, view=None))
+
+        # Different portal → different key (no cross-portal collateral throttling).
+        req_c = factory.post("/api/users/customers/1/users/", content_type="application/json")
+        req_c._portal_authenticated = True  # type: ignore[attr-defined]  # test sets internal HMAC flag
+        req_c.META["HTTP_X_PORTAL_ID"] = "portal-b"
+        self.assertNotEqual(throttle.get_cache_key(req_a, view=None), throttle.get_cache_key(req_c, view=None))
 
     def test_portal_hmac_throttle_key_is_stable_for_same_portal(self) -> None:
         factory = RequestFactory()

--- a/services/platform/tests/api/test_throttle_architecture_guardrails.py
+++ b/services/platform/tests/api/test_throttle_architecture_guardrails.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import inspect
+from copy import deepcopy
 
 from django.conf import settings
-from django.test import RequestFactory, SimpleTestCase
+from django.core.exceptions import ImproperlyConfigured
+from django.test import RequestFactory, SimpleTestCase, override_settings
 from django.utils.module_loading import import_string
 from rest_framework.throttling import AnonRateThrottle, SimpleRateThrottle
 
@@ -17,6 +19,7 @@ from apps.api.orders.views import (
     ProductCatalogThrottle,
 )
 from apps.api.users import views as users_views
+from apps.common.apps import _validate_throttle_rates_at_startup
 from apps.common.performance import rate_limiting
 
 
@@ -41,6 +44,7 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
             OrderListThrottle,
             ProductCatalogThrottle,
             AnonRateThrottle,
+            rate_limiting.PortalHMACCreateUserThrottle,
         ]
         for throttle_cls in classes:
             scope = getattr(throttle_cls, "scope", None)
@@ -120,6 +124,28 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
         req_c._portal_authenticated = True  # type: ignore[attr-defined]  # test sets internal HMAC flag
         req_c.META["HTTP_X_PORTAL_ID"] = "portal-b"
         self.assertNotEqual(throttle.get_cache_key(req_a, view=None), throttle.get_cache_key(req_c, view=None))
+
+    def test_create_user_throttle_parses_env_configurable_shorthand_rates(self) -> None:
+        """THROTTLE_RATE_PORTAL_CREATE_USER must accept shorthand windows (e.g. 30/10s).
+
+        Startup validation (parse_rate_string) accepts shorthand rates, so the
+        throttle class must parse them too — otherwise an env value that passes
+        the fail-fast startup check would 500 on the first request instead.
+        """
+        throttle = rate_limiting.PortalHMACCreateUserThrottle()
+        self.assertEqual(throttle.parse_rate("30/10s"), (30, 10))
+
+    def test_startup_validation_covers_create_user_throttle_scope(self) -> None:
+        """Dropping the create-user rate must fail at startup, not at request time.
+
+        PortalHMACCreateUserThrottle is a per-view throttle, so it is not covered
+        by DEFAULT_THROTTLE_CLASSES validation — it must be explicitly registered
+        in the startup validation list like the other per-view throttles.
+        """
+        rest_framework = deepcopy(settings.REST_FRAMEWORK)
+        del rest_framework["DEFAULT_THROTTLE_RATES"]["portal_hmac_create_user"]
+        with override_settings(REST_FRAMEWORK=rest_framework), self.assertRaises(ImproperlyConfigured):
+            _validate_throttle_rates_at_startup()
 
     def test_portal_hmac_throttle_key_is_stable_for_same_portal(self) -> None:
         factory = RequestFactory()

--- a/services/platform/tests/common/test_throttle_rate_validation.py
+++ b/services/platform/tests/common/test_throttle_rate_validation.py
@@ -52,6 +52,7 @@ class StartupThrottleValidationTests(SimpleTestCase):
                 "order_calculate": "30/min",
                 "order_list": "100/min",
                 "product_catalog": "200/min",
+                "portal_hmac_create_user": "30/min",
             },
         }
     )
@@ -102,6 +103,7 @@ class StartupThrottleValidationTests(SimpleTestCase):
                 "order_calculate": "30/min",
                 "order_list": "100/min",
                 "product_catalog": "200/min",
+                "portal_hmac_create_user": "30/min",
             },
         }
     )


### PR DESCRIPTION
Integration branch for #186 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus review fixes. Opened against `master` (source PR is from a fork).

Contributor change (#186 / #181): the HMAC portal→platform account-creation endpoint used `@throttle_classes([BurstAPIThrottle])`, which overrode DEFAULT_THROTTLE_CLASSES (dropping the per-portal PortalHMAC throttles) and keyed on client IP (AnonymousUser fallback), so distributed callers bypassed it. Fix: new PortalHMACCreateUserThrottle keyed on the verified X-Portal-Id (30/min), re-listing the global portal throttles so the strict cap layers on top.

Review fixes on top:
- Registered the new throttle scope in both startup-validation registries — without it a bad rate would pass startup and 500 at request time.
- Added shorthand-window rate parsing so env-configured rates like `30/10s` don't KeyError at request time.

Closes #186. Closes #181.
