### PR TITLE
feat(portal): cover all service statuses in My Services filter tabs (#101) (#193)

### DIFF
--- a/services/portal/apps/services/views.py
+++ b/services/portal/apps/services/views.py
@@ -190,6 +190,7 @@ def service_search_api(request: HttpRequest) -> HttpResponse:
                 "paginator_data": paginator_data,
                 "pagination_params": pagination_params,
                 "status_filter": status_filter,
+                "search_query": search_query,
             },
         )
 
@@ -200,6 +201,7 @@ def service_search_api(request: HttpRequest) -> HttpResponse:
             "paginator_data": PaginatorData(total_count=0, current_page=1, page_size=20),
             "pagination_params": "",
             "status_filter": status_filter,
+            "search_query": search_query,
             **error_ctx,
         }
         return render(request, "services/partials/services_table.html", context)

--- a/services/portal/apps/services/views.py
+++ b/services/portal/apps/services/views.py
@@ -36,6 +36,19 @@ SERVICE_STATUS_TABS = [
     {"value": "expired", "label": _("Expired"), "border_class": "border-orange-500", "text_class": "text-orange-400"},
 ]
 
+# Allowlist for the ?status= query param ("" = All tab).
+_VALID_STATUS_FILTERS = {tab["value"] for tab in SERVICE_STATUS_TABS}
+
+
+def _validated_status_filter(raw: str) -> str:
+    """Allowlist ?status= against the known tabs.
+
+    The value is attacker-influenced (query string) and gets echoed into the
+    empty-state message and forwarded to the platform API — unknown values
+    fall back to the All tab instead of being reflected.
+    """
+    return raw if raw in _VALID_STATUS_FILTERS else ""
+
 
 def _filter_services_by_query(services: list[dict], query: str) -> list[dict]:
     """Client-side search filtering across all visible and detail fields."""
@@ -90,7 +103,7 @@ def service_list(request: HttpRequest) -> HttpResponse:
     if not customer_id or not user_id:
         return redirect("/login/")
 
-    status_filter = request.GET.get("status", "")
+    status_filter = _validated_status_filter(request.GET.get("status", ""))
     search_query = request.GET.get("q", "").strip()
     try:
         page = int(request.GET.get("page", 1))
@@ -152,7 +165,7 @@ def service_search_api(request: HttpRequest) -> HttpResponse:
         return redirect("/login/")
 
     search_query = request.GET.get("q", "").strip()
-    status_filter = request.GET.get("status", "")
+    status_filter = _validated_status_filter(request.GET.get("status", ""))
 
     try:
         response = services_api.get_customer_services(

--- a/services/portal/apps/services/views.py
+++ b/services/portal/apps/services/views.py
@@ -16,13 +16,24 @@ from .services import PlatformAPIError, services_api
 
 logger = logging.getLogger(__name__)
 
-# Tab configuration for service status filtering
+# Tab configuration for service status filtering.
+# Mirrors the platform Service.STATUS_CHOICES (provisioning/service_models.py) so
+# every real status is filterable — previously Provisioning/Failed/Terminated/Expired
+# had no tab and "Cancelled" was a dead tab (no such status). (#101)
 SERVICE_STATUS_TABS = [
     {"value": "", "label": _("All Services"), "border_class": "border-blue-500", "text_class": "text-blue-400"},
     {"value": "active", "label": _("Active"), "border_class": "border-green-500", "text_class": "text-green-400"},
-    {"value": "suspended", "label": _("Suspended"), "border_class": "border-red-500", "text_class": "text-red-400"},
     {"value": "pending", "label": _("Pending"), "border_class": "border-yellow-500", "text_class": "text-yellow-400"},
-    {"value": "cancelled", "label": _("Cancelled"), "border_class": "border-red-500", "text_class": "text-red-400"},
+    {
+        "value": "provisioning",
+        "label": _("Provisioning"),
+        "border_class": "border-blue-500",
+        "text_class": "text-blue-400",
+    },
+    {"value": "suspended", "label": _("Suspended"), "border_class": "border-red-500", "text_class": "text-red-400"},
+    {"value": "failed", "label": _("Failed"), "border_class": "border-red-500", "text_class": "text-red-400"},
+    {"value": "terminated", "label": _("Terminated"), "border_class": "border-gray-500", "text_class": "text-gray-400"},
+    {"value": "expired", "label": _("Expired"), "border_class": "border-orange-500", "text_class": "text-orange-400"},
 ]
 
 
@@ -165,6 +176,7 @@ def service_search_api(request: HttpRequest) -> HttpResponse:
                 "services": services,
                 "paginator_data": paginator_data,
                 "pagination_params": pagination_params,
+                "status_filter": status_filter,
             },
         )
 
@@ -174,6 +186,7 @@ def service_search_api(request: HttpRequest) -> HttpResponse:
             "services": [],
             "paginator_data": PaginatorData(total_count=0, current_page=1, page_size=20),
             "pagination_params": "",
+            "status_filter": status_filter,
             **error_ctx,
         }
         return render(request, "services/partials/services_table.html", context)

--- a/services/portal/templates/services/partials/services_table.html
+++ b/services/portal/templates/services/partials/services_table.html
@@ -90,18 +90,27 @@
 {% include 'components/pagination.html' with page_obj=paginator_data extra_params=pagination_params %}
 
 {% else %}
-{# Empty State #}
+{# Empty State — status-aware: a filtered tab shows a status-specific message,
+   the unfiltered list keeps the "browse plans to get started" call to action. #}
 <div class="bg-slate-800/50 border border-slate-700 rounded-lg">
   <div class="text-center py-12 px-6">
     <div class="mx-auto h-16 w-16 bg-slate-700 rounded-full flex items-center justify-center mb-4">
       {% icon "server" size="xl" css_class="text-slate-400" %}
     </div>
+    {% if status_filter %}
+    <h3 class="text-lg font-medium text-white mb-2">{% blocktrans with status=status_filter|status_label %}No {{ status }} services{% endblocktrans %}</h3>
+    <p class="text-slate-400 mb-6 max-w-sm mx-auto">
+      {% trans "You have no services with this status." %}
+      <a href="{% url 'services:list' %}" class="text-blue-400 hover:text-blue-300 underline">{% trans "View all services" %}</a>.
+    </p>
+    {% else %}
     <h3 class="text-lg font-medium text-white mb-2">{% trans 'No services found' %}</h3>
     <p class="text-slate-400 mb-6 max-w-sm mx-auto">
       <a href="{% url 'orders:catalog' %}" class="text-blue-400 hover:text-blue-300 underline">{% trans "Browse our hosting plans" %}</a>
       {% trans "to get started, or" %}
       <a href="{% url 'tickets:create' %}" class="text-blue-400 hover:text-blue-300 underline">{% trans "contact our support team" %}</a>.
     </p>
+    {% endif %}
   </div>
 </div>
 {% endif %}

--- a/services/portal/templates/services/partials/services_table.html
+++ b/services/portal/templates/services/partials/services_table.html
@@ -90,14 +90,22 @@
 {% include 'components/pagination.html' with page_obj=paginator_data extra_params=pagination_params %}
 
 {% else %}
-{# Empty State — status-aware: a filtered tab shows a status-specific message,
-   the unfiltered list keeps the "browse plans to get started" call to action. #}
+{# Empty State — three cases, in order:
+   1. a search term that matched nothing → search-empty message (even inside a status tab),
+   2. a filtered tab with no services    → status-specific message,
+   3. the unfiltered list                → "browse plans to get started" call to action. #}
 <div class="bg-slate-800/50 border border-slate-700 rounded-lg">
   <div class="text-center py-12 px-6">
     <div class="mx-auto h-16 w-16 bg-slate-700 rounded-full flex items-center justify-center mb-4">
       {% icon "server" size="xl" css_class="text-slate-400" %}
     </div>
-    {% if status_filter %}
+    {% if search_query %}
+    <h3 class="text-lg font-medium text-white mb-2">{% trans 'No matching services' %}</h3>
+    <p class="text-slate-400 mb-6 max-w-sm mx-auto">
+      {% blocktrans with query=search_query %}No services match "{{ query }}".{% endblocktrans %}
+      <a href="{% url 'services:list' %}" class="text-blue-400 hover:text-blue-300 underline">{% trans "View all services" %}</a>.
+    </p>
+    {% elif status_filter %}
     <h3 class="text-lg font-medium text-white mb-2">{% blocktrans with status=status_filter|status_label %}No {{ status }} services{% endblocktrans %}</h3>
     <p class="text-slate-400 mb-6 max-w-sm mx-auto">
       {% trans "You have no services with this status." %}

--- a/services/portal/tests/services/test_service_status_tabs.py
+++ b/services/portal/tests/services/test_service_status_tabs.py
@@ -33,6 +33,25 @@ class ServiceStatusTabConfigTests(TestCase):
         missing = PLATFORM_SERVICE_STATUSES - tab_values
         self.assertEqual(missing, set(), f"statuses without a filter tab: {missing}")
 
+    def test_tab_set_exactly_mirrors_platform_statuses(self) -> None:
+        """Drift guardrail: the tab list is exactly All + the 7 platform statuses.
+
+        If the platform Service.STATUS_CHOICES gains or loses a status, update
+        BOTH the PLATFORM_SERVICE_STATUSES mirror above and SERVICE_STATUS_TABS —
+        this exact-set + count assertion fails on any one-sided edit, including
+        a re-introduced dead tab (e.g. "cancelled").
+        """
+        tab_values = [t["value"] for t in SERVICE_STATUS_TABS]
+        self.assertEqual(len(tab_values), len(set(tab_values)), "duplicate tab values")
+        self.assertEqual(set(tab_values), PLATFORM_SERVICE_STATUSES | {""})
+        self.assertEqual(len(tab_values), len(PLATFORM_SERVICE_STATUSES) + 1)
+
+    def test_newest_platform_status_has_a_tab(self) -> None:
+        # Canary pinned to the LAST entry of the platform STATUS_CHOICES tuple
+        # (provisioning/service_models.py). If a status is appended there, this
+        # name documents where to look when the mirror set needs updating.
+        self.assertIn("expired", {t["value"] for t in SERVICE_STATUS_TABS})
+
     def test_includes_all_services_default_tab(self) -> None:
         self.assertEqual(SERVICE_STATUS_TABS[0]["value"], "", "first tab must be the 'All' default")
 
@@ -70,3 +89,35 @@ class ServiceSearchStatusEmptyStateTests(TestCase):
         self.assertIn("View all services", body)
         # the API was filtered by the requested status
         self.assertEqual(mock_get.call_args.kwargs.get("status"), "expired")
+
+    @patch("apps.services.views.services_api.get_customer_services")
+    def test_unknown_status_is_not_reflected_in_search_partial(self, mock_get: object) -> None:
+        """?status= is attacker-influenced; unknown values must not be echoed.
+
+        Output is autoescaped, so this is content spoofing rather than XSS —
+        but 'No Visit Evil.Com Now services' in an authenticated page is still
+        a real reflection. Unknown statuses fall back to the All tab.
+        """
+        mock_get.return_value = {"results": [], "count": 0}
+
+        resp = self.client.get(reverse("services:search_api"), {"status": "visit_evil.com_now"})
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertNotIn("Evil", body)
+        self.assertNotIn("visit_evil", body)
+        # the bogus value is not forwarded to the platform API either
+        self.assertEqual(mock_get.call_args.kwargs.get("status"), "")
+
+    @patch("apps.services.views.services_api.get_services_summary")
+    @patch("apps.services.views.services_api.get_customer_services")
+    def test_unknown_status_is_dropped_on_list_view(self, mock_get: object, mock_summary: object) -> None:
+        mock_get.return_value = {"results": [], "count": 0}
+        mock_summary.return_value = {"active_services": 0, "total_services": 0}
+
+        resp = self.client.get(reverse("services:list"), {"status": "<script>alert(1)</script>"})
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertNotIn("alert(1)", body)
+        self.assertEqual(mock_get.call_args.kwargs.get("status"), "")

--- a/services/portal/tests/services/test_service_status_tabs.py
+++ b/services/portal/tests/services/test_service_status_tabs.py
@@ -91,6 +91,45 @@ class ServiceSearchStatusEmptyStateTests(TestCase):
         self.assertEqual(mock_get.call_args.kwargs.get("status"), "expired")
 
     @patch("apps.services.views.services_api.get_customer_services")
+    def test_search_no_match_shows_search_empty_not_status_empty(self, mock_get: object) -> None:
+        """A status tab WITH services + a search term matching none of them must
+        say the search returned nothing — not that the status tab is empty.
+
+        Regression: with status_filter set, an empty *search* result rendered the
+        status-tab-empty heading ('No <Status> services'), which is misleading —
+        the tab does have services, the query just matched none.
+        """
+        # API returns a real service for the "active" tab; the search term below
+        # matches none of its fields, so _filter_services_by_query empties the list.
+        mock_get.return_value = {
+            "results": [{"service_name": "Web Hosting", "status": "active", "domain": "example.com"}],
+            "count": 1,
+        }
+
+        resp = self.client.get(
+            reverse("services:search_api"),
+            {"status": "active", "q": "zzz-no-such-service"},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertNotIn("No Active services", body)
+        self.assertIn("No services match", body)
+        self.assertIn("zzz-no-such-service", body)
+
+    @patch("apps.services.views.services_api.get_customer_services")
+    def test_search_empty_state_escapes_query(self, mock_get: object) -> None:
+        """The echoed search term is user input — it must be autoescaped."""
+        mock_get.return_value = {"results": [], "count": 0}
+
+        resp = self.client.get(reverse("services:search_api"), {"q": "<script>alert(2)</script>"})
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertIn("No services match", body)
+        self.assertNotIn("<script>alert(2)</script>", body)
+
+    @patch("apps.services.views.services_api.get_customer_services")
     def test_unknown_status_is_not_reflected_in_search_partial(self, mock_get: object) -> None:
         """?status= is attacker-influenced; unknown values must not be echoed.
 

--- a/services/portal/tests/services/test_service_status_tabs.py
+++ b/services/portal/tests/services/test_service_status_tabs.py
@@ -1,0 +1,72 @@
+"""Tests for My Services status filter tabs (#101).
+
+Covers:
+- SERVICE_STATUS_TABS exposes a tab for every real Service status and no longer
+  carries the dead "cancelled" tab (no such platform status).
+- The HTMX search/filter endpoint threads status_filter into the partial so the
+  empty state can render a status-specific message.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.services.views import SERVICE_STATUS_TABS
+
+# The platform Service.STATUS_CHOICES (provisioning/service_models.py).
+PLATFORM_SERVICE_STATUSES = {
+    "pending",
+    "provisioning",
+    "active",
+    "suspended",
+    "failed",
+    "terminated",
+    "expired",
+}
+
+
+class ServiceStatusTabConfigTests(TestCase):
+    def test_every_real_status_has_a_tab(self) -> None:
+        tab_values = {t["value"] for t in SERVICE_STATUS_TABS}
+        missing = PLATFORM_SERVICE_STATUSES - tab_values
+        self.assertEqual(missing, set(), f"statuses without a filter tab: {missing}")
+
+    def test_includes_all_services_default_tab(self) -> None:
+        self.assertEqual(SERVICE_STATUS_TABS[0]["value"], "", "first tab must be the 'All' default")
+
+    def test_no_dead_cancelled_tab(self) -> None:
+        # "cancelled" is not a Service status — it would be a permanently-empty tab.
+        tab_values = {t["value"] for t in SERVICE_STATUS_TABS}
+        self.assertNotIn("cancelled", tab_values)
+
+    def test_each_tab_has_styling_keys(self) -> None:
+        for tab in SERVICE_STATUS_TABS:
+            self.assertIn("label", tab)
+            self.assertIn("border_class", tab)
+            self.assertIn("text_class", tab)
+
+
+class ServiceSearchStatusEmptyStateTests(TestCase):
+    """The HTMX filter endpoint renders a status-aware empty state."""
+
+    def setUp(self) -> None:
+        session = self.client.session
+        session["customer_id"] = 1
+        session["user_id"] = 2
+        session.save()
+
+    @patch("apps.services.views.services_api.get_customer_services")
+    def test_filtered_empty_state_names_the_status(self, mock_get: object) -> None:
+        mock_get.return_value = {"results": [], "count": 0}
+
+        resp = self.client.get(reverse("services:search_api"), {"status": "expired"})
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        # status-aware empty state (status_label title-cases "expired" -> "Expired")
+        self.assertIn("No Expired services", body)
+        self.assertIn("View all services", body)
+        # the API was filtered by the requested status
+        self.assertEqual(mock_get.call_args.kwargs.get("status"), "expired")


### PR DESCRIPTION
Integration branch for #193 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus review fixes. Opened against `master` (source PR is from a fork). Portal-only change.

Contributor change (#193 / #101): My Services filter tabs now mirror the platform Service.STATUS_CHOICES (all + active/pending/provisioning/suspended/failed/terminated/expired), dropping the dead `cancelled` tab; status-aware empty state.

Review fixes on top:
- Allowlist the `?status=` filter in both views so an unknown/attacker-controlled status is dropped rather than reflected into the heading/hidden input and forwarded to the API (reflected content spoofing).
- Strengthened the guardrail test to pin the tab set against the platform statuses by count + newest-status canary (the PR's membership-only tests passed a bogus extra tab).

Closes #193. Closes #101.
