### PR TITLE
fix(tickets): filter internal notes server-side in reply HTMX swap (#159) (#187)

### DIFF
--- a/services/platform/apps/tickets/views.py
+++ b/services/platform/apps/tickets/views.py
@@ -456,7 +456,14 @@ def _handle_ticket_reply_post(request: HttpRequest, ticket: Ticket) -> HttpRespo
     if request.headers.get("HX-Request"):
         # Refresh ticket data and comments
         ticket.refresh_from_db()
-        comments = ticket.comments.all().order_by("created_at")
+        # Defense-in-depth: filter internal notes server-side, mirroring
+        # ticket_detail()/ticket_comments_htmx(). The template gate alone is not
+        # sufficient — without this, internal-note content reaches the rendering
+        # context for non-staff users on the reply HTMX swap.
+        if user.is_staff_user:
+            comments = ticket.comments.all().order_by("created_at")
+        else:
+            comments = ticket.comments.filter(comment_type__in=["customer", "support"]).order_by("created_at")
         can_edit = ticket.status != "closed" or user.is_staff_user
         return render(
             request,

--- a/services/platform/templates/tickets/detail.html
+++ b/services/platform/templates/tickets/detail.html
@@ -10,7 +10,8 @@
 
     <!-- Dynamic content that updates after replies -->
     <div id="ticket-status-and-comments">
-        {% include 'tickets/partials/status_and_comments.html' with can_edit=can_edit comments=ticket.comments.all %}
+        {# comments comes from ticket_detail() already filtered by staff permissions — never re-derive it from ticket.comments here #}
+        {% include 'tickets/partials/status_and_comments.html' with can_edit=can_edit comments=comments %}
     </div>
     <!-- End dynamic content -->
 

--- a/services/platform/templates/tickets/partials/status_and_comments.html
+++ b/services/platform/templates/tickets/partials/status_and_comments.html
@@ -87,7 +87,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-3.582 8-8 8a8.955 8.955 0 01-1.946-.228A18.89 18.89 0 0111 22l-1-1 1-1c.636-.636 1-1.5 1-2.4 0-1.778 1.44-3.22 3.22-3.22M21 12c0-4.418-3.582-8-8-8s-8 3.582-8 8"></path>
             </svg>
             {% trans 'Conversation' %}
-            <span class="ml-2 text-sm font-normal text-slate-400">({{ ticket.comments.count }} {% trans 'replies' %})</span>
+            <span class="ml-2 text-sm font-normal text-slate-400">({{ comments|length }} {% trans 'replies' %})</span>
         </h3>
     </div>
 

--- a/services/platform/tests/tickets/test_tickets_comments.py
+++ b/services/platform/tests/tickets/test_tickets_comments.py
@@ -182,6 +182,37 @@ class TicketInternalCommentsSecurityTest(TestCase):
         self.assertNotContains(response, 'Internal staff note - CONFIDENTIAL')
         self.assertNotContains(response, 'STAFF INTERNAL NOTE')
 
+    def test_reply_htmx_response_filters_internal_notes_for_customer(self):
+        """Reply POST (HX-Request) must not leak internal notes to non-staff.
+
+        Regression: the reply HTMX branch refreshed comments with comments.all(),
+        relying solely on the template gate. A customer posting a reply received
+        the internal-note content in the rendered swap.
+        """
+        self.client.login(email='customer@example.com', password='testpass123')
+        response = self.client.post(
+            reverse('tickets:reply', kwargs={'pk': self.ticket.pk}),
+            {'reply': 'Customer follow-up reply'},
+            HTTP_HX_REQUEST='true',
+        )
+        self.assertEqual(response.status_code, 200)
+        # Customer-visible comments are present...
+        self.assertContains(response, 'Customer comment - visible to all')
+        self.assertContains(response, 'Support comment - visible to all')
+        # ...but the internal note is not in the rendered swap.
+        self.assertNotContains(response, 'Internal staff note - CONFIDENTIAL')
+
+    def test_reply_htmx_response_includes_internal_notes_for_staff(self):
+        """Staff posting a reply via HX-Request still see internal notes."""
+        self.client.login(email='admin@example.com', password='testpass123')
+        response = self.client.post(
+            reverse('tickets:reply', kwargs={'pk': self.ticket.pk}),
+            {'reply': 'Staff follow-up reply'},
+            HTTP_HX_REQUEST='true',
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Internal staff note - CONFIDENTIAL')
+
     def test_comment_filtering_in_views(self):
         """Test that view-level comment filtering works correctly"""
         # Test with staff user - should see all comments

--- a/services/platform/tests/tickets/test_tickets_comments.py
+++ b/services/platform/tests/tickets/test_tickets_comments.py
@@ -256,6 +256,10 @@ class TicketInternalCommentsSecurityTest(TestCase):
         self.assertContains(response, 'Support comment - visible to all')
         # ...but the internal note is not in the rendered swap.
         self.assertNotContains(response, 'Internal staff note - CONFIDENTIAL')
+        # Lock in the server-side filter: the internal note must not even reach
+        # the rendering context. The template gate alone hides the content, so a
+        # body-only assertion would still pass if the queryset filter regressed.
+        self.assertNotIn(self.internal_comment, list(response.context['comments']))
 
     def test_reply_htmx_response_includes_internal_notes_for_staff(self):
         """Staff posting a reply via HX-Request still see internal notes."""
@@ -267,6 +271,58 @@ class TicketInternalCommentsSecurityTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Internal staff note - CONFIDENTIAL')
+        self.assertIn(self.internal_comment, list(response.context['comments']))
+
+    def test_detail_page_shows_empty_state_when_only_internal_notes_exist(self):
+        """The detail page must render the filtered queryset, not ticket.comments.all.
+
+        Regression: detail.html included the comments partial with
+        comments=ticket.comments.all, discarding the server-side filter from
+        ticket_detail(). For a ticket whose only comment is an internal note,
+        a customer must get the empty state instead of a loop over hidden rows.
+        """
+        internal_only_ticket = Ticket.objects.create(
+            customer=self.customer,
+            title='Internal-only Ticket',
+            description='Ticket with only an internal note',
+            priority='normal',
+            status='open',
+            created_by=self.customer_user,
+        )
+        TicketComment.objects.create(
+            ticket=internal_only_ticket,
+            content='Internal-only staff note - CONFIDENTIAL',
+            comment_type='internal',
+            author=self.staff_user,
+            author_name=self.staff_user.get_full_name(),
+            author_email=self.staff_user.email,
+            is_public=False,
+        )
+
+        self.client.login(email='customer@example.com', password='testpass123')
+        response = self.client.get(reverse('tickets:detail', kwargs={'pk': internal_only_ticket.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'Internal-only staff note - CONFIDENTIAL')
+        self.assertContains(response, 'No replies yet. Be the first to respond!')
+
+    def test_conversation_count_excludes_hidden_comments_for_customer(self):
+        """The conversation header count must not disclose hidden internal notes.
+
+        A customer seeing "(3 replies)" with only 2 rendered comments leaks the
+        existence of internal notes. The count must come from the filtered
+        queryset, not ticket.comments.count.
+        """
+        self.client.login(email='customer@example.com', password='testpass123')
+        response = self.client.get(reverse('tickets:detail', kwargs={'pk': self.ticket.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '(2 replies)')
+        self.assertNotContains(response, '(3 replies)')
+
+        # Staff still see the full count including the internal note.
+        self.client.login(email='admin@example.com', password='testpass123')
+        response = self.client.get(reverse('tickets:detail', kwargs={'pk': self.ticket.pk}))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '(3 replies)')
 
     def test_comment_filtering_in_views(self):
         """Test that view-level comment filtering works correctly"""


### PR DESCRIPTION
Integration branch for #187 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus review fixes. Opened against `master` (source PR is from a fork).

Contributor change (#187 / #159): the ticket reply view's HX-Request branch refreshed comments with `ticket.comments.all()`, relying on the template gate to hide internal notes. Apply the same `is_staff_user`-gated queryset the GET paths use, so non-staff never get internal-note content in the reply swap.

Review fixes on top:
- Cascade instance the PR missed: `templates/tickets/detail.html` passed `comments=ticket.comments.all` into the partial, discarding the filtered queryset from `ticket_detail()` — the server-side filter on the full-page render was dead code. Now passes the filtered comments.
- Count metadata leak: the reply count showed customers a total that included hidden internal notes; now counts the filtered list.
- Strengthened the leak tests to assert the rendering context (they previously passed even with the view fix reverted, because the template gate masked the leak).

Closes #187. Closes #159.
