### PR TITLE
fix(portal): CSP nonce on inline script/style tags — #104 [M7] step 1 (#199)

### DIFF
--- a/services/portal/templates/base.html
+++ b/services/portal/templates/base.html
@@ -154,7 +154,7 @@
     {% endif %}
 
     <!-- Custom JS - Simplified like platform -->
-    <script>
+    <script nonce="{{ csp_nonce }}">
         // Global HTMX configuration
         document.body.addEventListener('htmx:afterRequest', function(evt) {
             const indicators = document.querySelectorAll('.htmx-indicator');

--- a/services/portal/templates/billing/invoice_detail.html
+++ b/services/portal/templates/billing/invoice_detail.html
@@ -346,7 +346,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function showInvoiceRefundRequestModal() {
     document.getElementById('invoiceRefundRequestModal').classList.remove('hidden');
 }

--- a/services/portal/templates/components/cookie_consent_banner.html
+++ b/services/portal/templates/components/cookie_consent_banner.html
@@ -135,7 +135,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     function cookieConsent() {
         return {
             showBanner: false,
@@ -314,6 +314,6 @@
     }
 </script>
 
-<style>
+<style nonce="{{ csp_nonce }}">
     [x-cloak] { display: none !important; }
 </style>

--- a/services/portal/templates/components/customer_selector.html
+++ b/services/portal/templates/components/customer_selector.html
@@ -100,7 +100,7 @@
 </div>
 
 <!-- JavaScript for Customer Selector -->
-<script>
+<script nonce="{{ csp_nonce }}">
 function toggleCustomerSelector() {
   const dropdown = document.getElementById('customerSelectorDropdown');
   const btn = document.getElementById('customerSelectorBtn');

--- a/services/portal/templates/orders/cart_review.html
+++ b/services/portal/templates/orders/cart_review.html
@@ -173,7 +173,7 @@
 </div>
 
 <!-- Auto-refresh totals when cart changes -->
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('cartUpdated', function() {
   // Refresh totals when cart is updated
   htmx.ajax('POST', '{% url "orders:calculate_totals" %}', {

--- a/services/portal/templates/orders/checkout.html
+++ b/services/portal/templates/orders/checkout.html
@@ -417,7 +417,7 @@
 </div>
 
 {% comment %}DS-6: This script block is intentionally kept inline. It references 6+ Django template constructs (url, trans, if can_submit, escapejs) that would require data-* shims on a container element for every string/URL if extracted. The complexity of that indirection outweighs the static-asset benefit for a single-page script this small. Revisit if the block grows beyond ~120 lines or needs to be shared across templates.{% endcomment %}
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const orderForm = document.querySelector('form[action="{% url 'orders:create_order' %}"]');
     const submitButton = document.getElementById('checkout-submit');

--- a/services/portal/templates/orders/order_confirmation.html
+++ b/services/portal/templates/orders/order_confirmation.html
@@ -386,7 +386,7 @@
 {% if payment_info and stripe_config %}{% if order.status == 'awaiting_payment' %}
 {# nosemgrep: missing-integrity — Stripe does not support SRI on js.stripe.com #}
 <script src="https://js.stripe.com/v3/"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
   // Initialize Stripe
   const stripe = Stripe('{{ stripe_config.publishable_key|escapejs }}');

--- a/services/portal/templates/services/partials/usage_chart.html
+++ b/services/portal/templates/services/partials/usage_chart.html
@@ -208,7 +208,7 @@
 </div>
 
 <!-- Auto-refresh every 5 minutes -->
-<script>
+<script nonce="{{ csp_nonce }}">
 setTimeout(function() {
   // Auto-refresh usage data every 5 minutes
   htmx.ajax('GET', window.location.pathname.replace('/services/', '/services/').replace('/', '/usage/'), {

--- a/services/portal/templates/services/service_detail.html
+++ b/services/portal/templates/services/service_detail.html
@@ -873,7 +873,7 @@
 <!-- Alpine.js for tab functionality -->
 
 
-<style>
+<style nonce="{{ csp_nonce }}">
 [x-cloak] { display: none !important; }
 </style>
 

--- a/services/portal/templates/services/service_request_action.html
+++ b/services/portal/templates/services/service_request_action.html
@@ -298,7 +298,7 @@
 </div>
 
 <!-- JavaScript for dynamic form behavior -->
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
   const actionRadios = document.querySelectorAll('input[name="action"]');
   const reasonField = document.getElementById('reason');

--- a/services/portal/templates/services/service_usage.html
+++ b/services/portal/templates/services/service_usage.html
@@ -175,7 +175,7 @@
     {% endif %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 function loadUsageData(period) {
     // Update active button
     document.querySelectorAll('[onclick*="loadUsageData"]').forEach(btn => {

--- a/services/portal/templates/tickets/ticket_create.html
+++ b/services/portal/templates/tickets/ticket_create.html
@@ -156,7 +156,7 @@
   {% end_section_card %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
   // Auto-populate title placeholder based on category
   document.getElementById('category').addEventListener('change', function () {
     const titleField = document.getElementById('title');

--- a/services/portal/templates/tickets/ticket_detail.html
+++ b/services/portal/templates/tickets/ticket_detail.html
@@ -41,7 +41,7 @@
 </div>
 
 <!-- Enhanced JavaScript for HTMX replies -->
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const textarea = document.querySelector('textarea[name="message"]');
     const charCounter = document.getElementById('char-counter');

--- a/services/portal/templates/users/mfa_backup_codes.html
+++ b/services/portal/templates/users/mfa_backup_codes.html
@@ -132,7 +132,7 @@
 </div>
 
 <!-- JavaScript for copying and printing -->
-<script>
+<script nonce="{{ csp_nonce }}">
 function copyCode(code) {
   navigator.clipboard.writeText(code).then(function() {
     // Could add visual feedback here
@@ -163,7 +163,7 @@ function printCodes() {
     <html>
       <head>
         <title>{% trans "MFA Backup Codes" %}</title>
-        <style>
+        <style nonce="{{ csp_nonce }}">
           body { font-family: monospace; margin: 20px; }
           h1 { color: #333; }
           .code {

--- a/services/portal/templates/users/mfa_setup_totp.html
+++ b/services/portal/templates/users/mfa_setup_totp.html
@@ -195,7 +195,7 @@
 </div>
 
 <!-- Copy Secret Key JavaScript -->
-<script>
+<script nonce="{{ csp_nonce }}">
 function copySecret() {
   const secretElement = document.getElementById('secret-key');
   const textToCopy = secretElement.textContent;

--- a/services/portal/tests/ui/test_csp_nonce_policy.py
+++ b/services/portal/tests/ui/test_csp_nonce_policy.py
@@ -1,0 +1,156 @@
+"""
+CSP nonce policy tests — #104 [M7] step 1.
+
+Three layers of protection for the CSP hardening rollout:
+
+1. Plumbing: CSPNonceMiddleware populates a fresh per-request nonce and the
+   csp_nonce context processor exposes it to templates, so every
+   nonce="{{ csp_nonce }}" attribute renders a non-empty value.
+2. Header state: the portal CSP header still carries 'unsafe-inline' and no
+   nonce-source, so the nonce attributes are inert by spec (browsers ignore
+   nonces until a nonce-source appears in the policy). When [M7] step 3
+   injects the nonce into the header, update these assertions deliberately.
+3. Completeness: every inline <script>/<style> tag in every template the
+   portal can render (service templates + shared UI components) carries a
+   nonce attribute. Once 'unsafe-inline' is dropped ([M7] step 4), any
+   inline tag without a nonce silently stops executing — this scan is the
+   guardrail that keeps that from ever being true.
+
+No database access (portal test isolation).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.template import RequestContext, Template
+from django.test import RequestFactory, SimpleTestCase
+
+from apps.common.context_processors import csp_nonce
+from apps.common.middleware import CSPNonceMiddleware, SecurityHeadersMiddleware
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Every directory the portal template engine can load templates from.
+TEMPLATE_ROOTS = (
+    REPO_ROOT / "services" / "portal" / "templates",
+    REPO_ROOT / "shared" / "ui" / "templates",
+)
+
+# Opening tags, including multi-line attribute lists.
+SCRIPT_TAG_RE = re.compile(r"<script\b[^>]*>", re.IGNORECASE | re.DOTALL)
+STYLE_TAG_RE = re.compile(r"<style\b[^>]*>", re.IGNORECASE | re.DOTALL)
+SRC_ATTR_RE = re.compile(r"\bsrc\s*=", re.IGNORECASE)
+NONCE_ATTR_RE = re.compile(r'\bnonce="\{\{ csp_nonce \}\}"')
+
+
+def _noop_view(_request: HttpRequest) -> HttpResponse:
+    return HttpResponse("ok")
+
+
+class CSPNoncePlumbingTests(SimpleTestCase):
+    """The nonce must be populated per-request and reach template context."""
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    def _request_through_middleware(self) -> HttpRequest:
+        request = self.factory.get("/")
+        CSPNonceMiddleware(_noop_view)(request)
+        return request
+
+    def test_middleware_sets_nonempty_nonce(self) -> None:
+        request = self._request_through_middleware()
+        nonce = getattr(request, "csp_nonce", "")
+        self.assertTrue(nonce, "CSPNonceMiddleware must set request.csp_nonce")
+        self.assertGreaterEqual(len(nonce), 32)
+
+    def test_nonce_is_unique_per_request(self) -> None:
+        first = self._request_through_middleware()
+        second = self._request_through_middleware()
+        self.assertNotEqual(first.csp_nonce, second.csp_nonce)
+
+    def test_context_processor_exposes_nonce(self) -> None:
+        request = self._request_through_middleware()
+        self.assertEqual(csp_nonce(request), {"csp_nonce": request.csp_nonce})
+
+    def test_context_processor_registered_in_settings(self) -> None:
+        processors = settings.TEMPLATES[0]["OPTIONS"]["context_processors"]
+        self.assertIn("apps.common.context_processors.csp_nonce", processors)
+
+    def test_nonce_attribute_renders_nonempty_value(self) -> None:
+        """End-to-end: the exact template pattern renders a non-empty nonce."""
+        request = self._request_through_middleware()
+        request.session = {}  # portal_context reads request.session (no DB)
+        rendered = Template('<script nonce="{{ csp_nonce }}">x()</script>').render(
+            RequestContext(request)
+        )
+        self.assertIn(f'nonce="{request.csp_nonce}"', rendered)
+        self.assertNotIn('nonce=""', rendered)
+
+
+class CSPHeaderStateTests(SimpleTestCase):
+    """Documents [M7] step 1 inertness: unsafe-inline present, no nonce-source.
+
+    When step 3 injects 'nonce-{request.csp_nonce}' into the header, these
+    assertions must be updated in the same change — that is the point at
+    which the nonce attributes stop being inert.
+    """
+
+    def _csp_header(self) -> str:
+        request = RequestFactory().get("/")
+        response = SecurityHeadersMiddleware(_noop_view)(request)
+        return response["Content-Security-Policy"]
+
+    def test_header_still_allows_unsafe_inline(self) -> None:
+        csp = self._csp_header()
+        self.assertIn("'unsafe-inline'", csp)
+
+    def test_header_has_no_nonce_source_yet(self) -> None:
+        csp = self._csp_header()
+        self.assertNotIn("'nonce-", csp)
+
+
+class InlineNonceCompletenessTests(SimpleTestCase):
+    """Every inline <script>/<style> tag the portal can render carries a nonce.
+
+    This is the precondition for dropping 'unsafe-inline' ([M7] step 4):
+    at that point any inline tag without a nonce silently stops executing.
+    """
+
+    def _tags_missing_nonce(self, tag_re: re.Pattern[str], *, skip_src: bool) -> list[str]:
+        missing: list[str] = []
+        for root in TEMPLATE_ROOTS:
+            for template in sorted(root.rglob("*.html")):
+                text = template.read_text(encoding="utf-8")
+                for match in tag_re.finditer(text):
+                    tag = match.group(0)
+                    if skip_src and SRC_ATTR_RE.search(tag):
+                        continue  # external script: covered by 'self'/host sources
+                    if NONCE_ATTR_RE.search(tag):
+                        continue
+                    line = text.count("\n", 0, match.start()) + 1
+                    rel = template.relative_to(REPO_ROOT).as_posix()
+                    missing.append(f"{rel}:{line}")
+        return missing
+
+    def test_every_inline_script_has_nonce(self) -> None:
+        missing = self._tags_missing_nonce(SCRIPT_TAG_RE, skip_src=True)
+        self.assertEqual(
+            missing,
+            [],
+            "Inline <script> tags without nonce=\"{{ csp_nonce }}\" — these will "
+            f"silently stop executing when 'unsafe-inline' is dropped: {missing}",
+        )
+
+    def test_every_style_tag_has_nonce(self) -> None:
+        missing = self._tags_missing_nonce(STYLE_TAG_RE, skip_src=False)
+        self.assertEqual(
+            missing,
+            [],
+            "<style> tags without nonce=\"{{ csp_nonce }}\" — these will silently "
+            f"stop applying when 'unsafe-inline' is dropped: {missing}",
+        )

--- a/shared/ui/templates/components/input.html
+++ b/shared/ui/templates/components/input.html
@@ -79,7 +79,7 @@
 
 {# JavaScript for password toggle #}
 {% if icon_right == "password-toggle" %}
-<script>
+<script nonce="{{ csp_nonce }}">
   function togglePassword(inputId) {
     const input = document.getElementById(inputId);
     const type = input.getAttribute('type') === 'password' ? 'text' : 'password';

--- a/shared/ui/templates/components/list_page_filters.html
+++ b/shared/ui/templates/components/list_page_filters.html
@@ -108,7 +108,7 @@ Optional:
 </div>
 
 {% if filter_tabs %}
-<script>
+<script nonce="{{ csp_nonce }}">
 function switchTab(el) {
   var borderClass = el.dataset.tabBorder;
   var textClass = el.dataset.tabText;


### PR DESCRIPTION
Integration branch for #199 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus a completeness fix. Opened against `master` (source PR is from a fork).

Contributor change (#199 / #104 [M7] step 1): add `nonce="{{ csp_nonce }}"` to the remaining inline `<script>`/`<style>` tags across portal templates. Inert today — the CSP header still carries `'unsafe-inline'` with no nonce-source, so browsers ignore the nonces until a later [M7] step adds a nonce-source — verified end-to-end.

Review fix on top:
- Completeness: the PR covered `services/portal/templates/` but missed two shared UI components the portal also renders (`shared/ui/templates/components/input.html`, `list_page_filters.html`). Added nonces there too (safe for both services — identical nonce wiring). Net: zero inline tags without a nonce across portal + shared.
- Added a repo-scan guardrail test that fails if any inline tag lacks a nonce, locking in the precondition for removing `'unsafe-inline'`.

Deferred (tracked follow-up): 50 inline event handlers that nonces cannot fix — they need addEventListener refactors before [M7] step 4.

Closes #199.
