### PR TITLE
fix(platform): drop unused unpkg.com/cdn.tailwindcss.com from CSP — #104 [M7] step 3 (#201)

### DIFF
--- a/services/platform/apps/common/middleware.py
+++ b/services/platform/apps/common/middleware.py
@@ -121,9 +121,9 @@ class SecurityHeadersMiddleware:
         if not response.get("Content-Security-Policy"):
             csp = (
                 "default-src 'self'; "
-                "style-src 'self' 'unsafe-inline' fonts.googleapis.com cdn.tailwindcss.com; "
+                "style-src 'self' 'unsafe-inline' fonts.googleapis.com; "
                 "font-src 'self' fonts.gstatic.com; "
-                "script-src 'self' 'unsafe-inline' unpkg.com cdn.tailwindcss.com; "
+                "script-src 'self' 'unsafe-inline'; "
                 "img-src 'self' data: https:; "
                 "connect-src 'self'; "
                 "object-src 'none'; "

--- a/services/platform/tests/common/test_common_security.py
+++ b/services/platform/tests/common/test_common_security.py
@@ -5,16 +5,15 @@ Tests HTTPS enforcement, secure cookies, HSTS configuration,
 and production security settings to ensure robust transport security.
 """
 
-from django.conf import settings
-from django.core.checks import Error, Warning as DjangoWarning
+from django.core.checks import Error
+from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
-from django.http import HttpResponse
 
 from apps.common.checks import (
     check_https_security_configuration,
-    check_session_security_configuration,
     check_security_middleware_configuration,
+    check_session_security_configuration,
 )
 from apps.common.middleware import SecurityHeadersMiddleware
 
@@ -405,8 +404,11 @@ class SecurityMiddlewareTest(TestCase):
         self.assertNotIn('unpkg.com', csp_header)
         self.assertNotIn('cdn.tailwindcss.com', csp_header)
         # Core directives remain intact.
-        self.assertIn("script-src 'self'", csp_header)
-        self.assertIn("style-src 'self'", csp_header)
+        self.assertIn("script-src 'self' 'unsafe-inline'", csp_header)
+        self.assertIn("style-src 'self' 'unsafe-inline'", csp_header)
+        # Still-needed external sources must survive the CDN cleanup.
+        self.assertIn('fonts.googleapis.com', csp_header)
+        self.assertIn('fonts.gstatic.com', csp_header)
 
     def test_security_headers_values(self):
         """Test specific security header values."""

--- a/services/platform/tests/common/test_common_security.py
+++ b/services/platform/tests/common/test_common_security.py
@@ -391,14 +391,22 @@ class SecurityMiddlewareTest(TestCase):
         self.assertIn('X-XSS-Protection', response)
         self.assertIn('Referrer-Policy', response)
 
-    def test_csp_allows_trusted_cdns(self):
-        """Test that CSP allows trusted CDN domains."""
+    def test_csp_omits_unused_cdns(self):
+        """CSP must not allowlist dead CDN domains (#104 [M7] step 3).
+
+        unpkg.com and cdn.tailwindcss.com are not referenced by any template
+        or static asset (platform ships compiled local Tailwind), so they are
+        removed from the CSP to shrink the script/style allowlist.
+        """
         request = self.request_factory.get('/')
         response = self.middleware(request)
 
         csp_header = response.get('Content-Security-Policy', '')
-        self.assertIn('unpkg.com', csp_header)
-        self.assertIn('cdn.tailwindcss.com', csp_header)
+        self.assertNotIn('unpkg.com', csp_header)
+        self.assertNotIn('cdn.tailwindcss.com', csp_header)
+        # Core directives remain intact.
+        self.assertIn("script-src 'self'", csp_header)
+        self.assertIn("style-src 'self'", csp_header)
 
     def test_security_headers_values(self):
         """Test specific security header values."""


### PR DESCRIPTION
Integration branch for #201 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus a test-strengthening fix. Opened against `master` (source PR is from a fork).

Contributor change (#201 / #104 [M7] step 3): remove two dead CDN domains from the platform CSP (`apps/common/middleware.py`) — `cdn.tailwindcss.com` (style-src + script-src) and `unpkg.com` (script-src).

Verified safe: exhaustive repo grep confirms zero usage — every `<script src>` in platform templates resolves to a local vendored file (`js/alpine.min.js`, `js/htmx.min.js`, `js/components/*.js`), the only stylesheet is local compiled Tailwind, and there is no dynamic external-script injection. The named risk (alpine/htmx loaded from unpkg) is decisively cleared.

Review fix on top: strengthened the test to also assert the surviving CSP sources (`'unsafe-inline'`, `fonts.googleapis.com`, `fonts.gstatic.com`) so an over-strip also fails, and fixed pre-existing lint in the touched test file.

Follow-ups (out of scope, harmless): the nginx edge CSP still allowlists both dead CDNs, and a dead `CSP_SCRIPT_SRC` env example + stale docs.

Closes #201.
