### PR TITLE
refactor(portal): consolidate toast notifications into one system (#102) (#194)

### DIFF
--- a/services/portal/apps/orders/views.py
+++ b/services/portal/apps/orders/views.py
@@ -651,7 +651,9 @@ def add_to_cart(request: HttpRequest) -> HttpResponse:  # noqa: PLR0911
         # Return updated cart widget
         cart_items = cart.get_items()
         if cart_items:
-            # Item was successfully added — fire cartAdded event so Alpine auto-opens mini-cart
+            # Item was successfully added — cart_updated.html renders the mini-cart open
+            # (server-rendered state; the cartAdded HX-Trigger below fires pre-swap and
+            # cannot open the swapped-in widget, it only informs page-level listeners)
             just_added_slug = product_slug
             # Find the item by slug rather than using cart_items[-1], which is wrong when
             # add_item() updates an existing item in-place instead of appending.

--- a/services/portal/templates/base.html
+++ b/services/portal/templates/base.html
@@ -144,14 +144,17 @@
     {# Polite live region — catches async form validation errors and HTMX messages #}
     <div id="async-error-region" role="status" aria-live="polite" aria-atomic="true" class="sr-only"></div>
 
-    {# Toast Messages (via toast component, auto-dismiss via Alpine.js) #}
-    {% if messages %}
+    {% comment %}
+    Single unified toast container (#102): server-rendered Django messages (via the
+    toast component) AND client-side showToast() (toast.js) both render here, so there
+    is only ever one #toast-container in the DOM. Rendered unconditionally so showToast()
+    appends to this element instead of creating a second container.
+    {% endcomment %}
     <div id="toast-container" class="fixed top-4 lg:top-20 left-1/2 transform -translate-x-1/2 z-50 space-y-2" aria-live="assertive">
         {% for message in messages %}
         {% toast message variant=message.tags dismissible=True auto_dismiss=5000 %}
         {% endfor %}
     </div>
-    {% endif %}
 
     <!-- Custom JS - Simplified like platform -->
     <script>

--- a/services/portal/templates/orders/partials/cart_updated.html
+++ b/services/portal/templates/orders/partials/cart_updated.html
@@ -1,8 +1,13 @@
 {% load i18n ui_components %}
 
 <!-- Updated Cart Widget (HTMX Response) -->
+<!-- miniCartOpen starts TRUE: this partial only renders after a successful cart
+     mutation (add/remove), where the mini-cart should be showing. The open state
+     must be server-rendered — the cartAdded HX-Trigger event fires BEFORE the
+     outerHTML swap, so a window listener could only ever open the old widget that
+     this very response is replacing. -->
 <div id="cart-widget" class="relative"
-     x-data="{ miniCartOpen: false }"
+     x-data="{ miniCartOpen: true }"
      @cart-added.window="miniCartOpen = true"
      @click.outside="miniCartOpen = false">
   <button @click="miniCartOpen = !miniCartOpen"
@@ -39,7 +44,8 @@
      (showToast → single #toast-container) rather than a bespoke inline Alpine box,
      so add-to-cart shows exactly one toast with consistent styling/position. The
      x-init fires on the HTMX-swapped node (Alpine already drives #cart-widget above);
-     the mini-cart dropdown still auto-opens via @cart-added.window for the cart link. -->
+     the mini-cart dropdown opens via the server-rendered miniCartOpen state above,
+     which keeps the View Cart / Checkout links reachable after the add. -->
 {% if success_message %}
 <div x-init="window.showToast && window.showToast('success', '{{ success_message|escapejs }}{% if product_name %} ({{ product_name|escapejs }}){% endif %}')" x-cloak></div>
 {% endif %}

--- a/services/portal/templates/orders/partials/cart_updated.html
+++ b/services/portal/templates/orders/partials/cart_updated.html
@@ -35,25 +35,11 @@
   </div>
 </div>
 
-<!-- Success notification (if provided) -->
+<!-- Success notification (#102): route through the unified toast system
+     (showToast → single #toast-container) rather than a bespoke inline Alpine box,
+     so add-to-cart shows exactly one toast with consistent styling/position. The
+     x-init fires on the HTMX-swapped node (Alpine already drives #cart-widget above);
+     the mini-cart dropdown still auto-opens via @cart-added.window for the cart link. -->
 {% if success_message %}
-<div id="cart-success-message" class="fixed top-4 right-4 bg-green-600 text-white px-4 py-2 rounded-lg shadow-lg z-50 transform transition-transform duration-300"
-     x-data="{ show: true }"
-     x-init="setTimeout(() => show = false, 3000)"
-     x-show="show"
-     x-transition:enter="translate-x-full"
-     x-transition:enter-end="translate-x-0"
-     x-transition:leave="translate-x-0"
-     x-transition:leave-end="translate-x-full">
-  <div class="flex items-center">
-    {% icon "check" size="sm" css_class="mr-2 text-green-400" %}
-    <span>{{ success_message }}</span>
-    {% if product_name %}
-    <div class="text-xs opacity-90 ml-2">({{ product_name }})</div>
-    {% endif %}
-    <a href="{% url 'orders:cart_review' %}" class="text-blue-400 hover:text-blue-300 text-sm font-medium ml-2">
-      {% trans "View Cart" %} →
-    </a>
-  </div>
-</div>
+<div x-init="window.showToast && window.showToast('success', '{{ success_message|escapejs }}{% if product_name %} ({{ product_name|escapejs }}){% endif %}')" x-cloak></div>
 {% endif %}

--- a/services/portal/tests/orders/test_cart_ux_enhancements.py
+++ b/services/portal/tests/orders/test_cart_ux_enhancements.py
@@ -199,15 +199,21 @@ class TestCartUpdatedToastViewCartLink(SimpleTestCase):
     """ENH-1 + #102: after add-to-cart the View-Cart affordance is reachable via the
     auto-opening mini-cart dropdown (the inline toast 'View Cart' link was removed when
     the success notice was consolidated into showToast; the dropdown's cart link is the
-    canonical affordance now and auto-opens via @cart-added.window)."""
+    canonical affordance now).
+
+    The auto-open must be server-rendered state (``miniCartOpen: true``), NOT the
+    ``cartAdded``/``cart-added`` window event: HX-Trigger events are dispatched before
+    the outerHTML swap, so the only listener that could catch them sits on the widget
+    that the swap is about to replace — the swapped-in widget would initialise closed.
+    """
 
     def setUp(self) -> None:
         self.client = Client()
         _auth_client_with_product_mocked(self.client)
 
     def test_cart_updated_response_wires_auto_opening_mini_cart(self) -> None:
-        """The cart_updated response auto-loads the mini-cart dropdown that holds the
-        cart-review/checkout links (it opens on the cartAdded event)."""
+        """The cart_updated response renders the mini-cart dropdown open (it holds the
+        cart-review/checkout links), and the dropdown loads its content on swap."""
         with (
             patch("apps.orders.views.PlatformAPIClient") as mock_cls,
             patch("apps.orders.services.PlatformAPIClient") as svc_mock_cls,
@@ -225,11 +231,11 @@ class TestCartUpdatedToastViewCartLink(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-        # The mini-cart dropdown (which contains the View Cart / Checkout links) is wired
-        # to auto-open and load its content after the add.
+        # The mini-cart dropdown (which contains the View Cart / Checkout links) is
+        # rendered OPEN by the server and loads its content after the add.
         self.assertIn('id="mini-cart"', content)
         self.assertIn("mini-cart/", content)  # hx-get to mini_cart_content
-        self.assertIn("@cart-added.window", content)
+        self.assertIn('x-data="{ miniCartOpen: true }"', content)
 
 
 # ---------------------------------------------------------------------------

--- a/services/portal/tests/orders/test_cart_ux_enhancements.py
+++ b/services/portal/tests/orders/test_cart_ux_enhancements.py
@@ -190,20 +190,24 @@ class TestMiniCartJustAdded(SimpleTestCase):
 
 
 # ---------------------------------------------------------------------------
-# ENH-1: cart_updated template contains "View Cart" link
+# ENH-1: View Cart affordance after add-to-cart
 # ---------------------------------------------------------------------------
 
 
 @override_settings(**_CACHE_SETTINGS)
 class TestCartUpdatedToastViewCartLink(SimpleTestCase):
-    """ENH-1-toast: cart_updated response includes a View Cart link to orders:cart_review."""
+    """ENH-1 + #102: after add-to-cart the View-Cart affordance is reachable via the
+    auto-opening mini-cart dropdown (the inline toast 'View Cart' link was removed when
+    the success notice was consolidated into showToast; the dropdown's cart link is the
+    canonical affordance now and auto-opens via @cart-added.window)."""
 
     def setUp(self) -> None:
         self.client = Client()
         _auth_client_with_product_mocked(self.client)
 
-    def test_cart_updated_response_contains_view_cart_link(self) -> None:
-        """The cart_updated HTMX response contains a link to cart review page."""
+    def test_cart_updated_response_wires_auto_opening_mini_cart(self) -> None:
+        """The cart_updated response auto-loads the mini-cart dropdown that holds the
+        cart-review/checkout links (it opens on the cartAdded event)."""
         with (
             patch("apps.orders.views.PlatformAPIClient") as mock_cls,
             patch("apps.orders.services.PlatformAPIClient") as svc_mock_cls,
@@ -221,5 +225,50 @@ class TestCartUpdatedToastViewCartLink(SimpleTestCase):
 
         self.assertEqual(response.status_code, 200)
         content = response.content.decode()
-        # View Cart link must be present in toast
-        self.assertIn("/order/cart/", content)
+        # The mini-cart dropdown (which contains the View Cart / Checkout links) is wired
+        # to auto-open and load its content after the add.
+        self.assertIn('id="mini-cart"', content)
+        self.assertIn("mini-cart/", content)  # hx-get to mini_cart_content
+        self.assertIn("@cart-added.window", content)
+
+
+# ---------------------------------------------------------------------------
+# #102: Toast system consolidation — add-to-cart uses the unified showToast()
+# ---------------------------------------------------------------------------
+
+
+@override_settings(**_CACHE_SETTINGS)
+class TestCartToastConsolidation(SimpleTestCase):
+    """#102: the add-to-cart success notice routes through the single showToast()
+    system instead of the old bespoke inline Alpine '#cart-success-message' box,
+    so exactly one toast renders (in the shared #toast-container)."""
+
+    def setUp(self) -> None:
+        self.client = Client()
+        _auth_client_with_product_mocked(self.client)
+
+    def _post_add(self, slug: str = "shared-hosting-basic") -> object:
+        with (
+            patch("apps.orders.views.PlatformAPIClient") as mock_cls,
+            patch("apps.orders.services.PlatformAPIClient") as svc_mock_cls,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = _make_product_data(slug=slug)
+            mock_cls.return_value = mock_instance
+            svc_mock_cls.return_value = mock_instance
+            return self.client.post(
+                "/order/cart/add/",
+                {"product_slug": slug, "quantity": "1", "billing_period": "monthly"},
+                HTTP_X_FORWARDED_FOR="127.0.0.1",
+            )
+
+    def test_no_inline_cart_success_message_block(self) -> None:
+        """The old top-right inline Alpine toast block must be gone (it duplicated the toast)."""
+        body = self._post_add().content.decode()
+        self.assertNotIn("cart-success-message", body)
+        self.assertNotIn("fixed top-4 right-4", body)
+
+    def test_success_routes_through_show_toast(self) -> None:
+        """Success is surfaced via the unified showToast('success', …) call."""
+        body = self._post_add().content.decode()
+        self.assertIn("showToast('success'", body)


### PR DESCRIPTION
Integration branch for #194 (Ciprian Radulescu / @b3lz3but), carrying the contributor's commit plus a fix. Opened against `master` (source PR is from a fork).

Contributor change (#194 / #102): consolidate the portal's 3 overlapping toast systems into one — remove the bespoke inline cart-success box so add-to-cart uses the single `#toast-container`; render `#toast-container` unconditionally.

Review fix on top: the mini-cart auto-open was broken (a real affordance regression, since the PR removed the "View Cart" link that relied on it). Root cause was NOT the reviewer-flagged event-name case (htmx 2.0.7 dispatches both `cartAdded` and `cart-added`) but that HX-Trigger fires before the outerHTML swap — the only `@cart-added.window` listener alive belongs to the widget the response replaces. Fixed by rendering the open state server-side in `cart_updated.html`, verified in-browser on both product-detail and catalog pages. Corrected the misleading event-name comments.

Deferred (tracked): dead 422 error-swap path, undefined `toggleMiniCart()` in two partials, swapped `showToast` args in `service_request_action.html`, dead `@cart-added.window` wiring on the catalog widget.

Closes #194. Closes #102.
