### PR TITLE
fix(infrastructure): harden Virtualmin control plane

### DIFF
--- a/.env.example.dev
+++ b/.env.example.dev
@@ -24,6 +24,7 @@ DJANGO_SECRET_KEY=your-secret-key-here-change-in-production
 
 # Debug mode (NEVER set to True in production)
 DEBUG=True
+PRAHO_SSH_KNOWN_HOSTS_PATH=             # Optional verified known_hosts file for infrastructure SSH
 
 # Allowed hosts (comma-separated, no spaces)
 ALLOWED_HOSTS=localhost,127.0.0.1,pragmatichost.com,www.pragmatichost.com

--- a/.env.example.prod
+++ b/.env.example.prod
@@ -48,6 +48,7 @@ DB_SSLMODE=require                      # [OPTIONAL] 'require' for remote DB, 'd
 # --- Application ---------------------------------------------
 DJANGO_SETTINGS_MODULE=config.settings.prod  # [OPTIONAL] Set by Ansible based on praho_env
 DEBUG=false                             # [OPTIONAL] NEVER true in production
+PRAHO_SSH_KNOWN_HOSTS_PATH=             # [RECOMMENDED] Verified known_hosts file for managed-node SSH
 
 # --- Inter-Service Communication -----------------------------
 PLATFORM_API_BASE_URL=http://localhost:8700/api  # [OPTIONAL] Native: localhost, Docker: container name

--- a/.env.example.staging
+++ b/.env.example.staging
@@ -60,6 +60,7 @@ DB_SSLMODE=disable                      # [OPTIONAL] 'disable' OK for localhost 
 # --- Application ---------------------------------------------
 DJANGO_SETTINGS_MODULE=config.settings.staging  # ← This is the key difference from prod
 DEBUG=false                             # [OPTIONAL]
+PRAHO_SSH_KNOWN_HOSTS_PATH=             # [RECOMMENDED] Verified known_hosts file for managed-node SSH
 
 # --- Inter-Service Communication -----------------------------
 PLATFORM_API_BASE_URL=http://localhost:8700/api  # [OPTIONAL]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **e-Factura EN16931/CIUS-RO XML compliance** — completed the UBL 2.1 builder for ANAF Schematron conformance: EU cross-border B2B encoded as reverse charge (AE, VATEX-EU-AE, rate 0, all lines coherent per BR-AE-1) with deterministic tax-category derivation; corrected VATEX exemption codes (S/Z emit neither BT-120 nor BT-121; BT-121 only with a valid VATEX code); per-line and credit-note VAT rate clamped to 0 for non-standard categories; credit-note unit code from the line. Document-level allowance/charge totals reconciled in UBL element order with consistent TaxExclusive/TaxInclusive/Payable and a netted breakdown TaxableAmount (BR-CO-13/15/16/17), and allowance/charge metadata validated against malformed amounts (#158, #160)
 
+### Security
+
+- **Virtualmin and infrastructure control plane** — Virtualmin credentials now require HTTPS and either CA verification or a SHA-256 certificate pin enforced during the TLS handshake; all SSH and Ansible paths reject unknown host keys from a shared operator-provisioned trust file; root maintenance accepts only fixed semantic actions and elevated deploy permission; authentication fallbacks escalate only on typed authentication failures; rate limiting uses atomic fixed-window slot claims; and SSH key generation and revocation are audited and fail closed during node destruction (#327)
+
 ---
 
 ## [0.28.0] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Virtualmin and infrastructure control plane** — Virtualmin credentials now require HTTPS and either CA verification or a SHA-256 certificate pin enforced during the TLS handshake; all SSH and Ansible paths reject unknown host keys from a shared operator-provisioned trust file; root maintenance accepts only fixed semantic actions and elevated deploy permission; authentication fallbacks escalate only on typed authentication failures; rate limiting uses atomic fixed-window slot claims; and SSH key generation and revocation are audited and fail closed during node destruction (#327)
+- **Virtualmin and infrastructure control plane** — Virtualmin credentials now require HTTPS and either CA verification or a SHA-256 certificate pin enforced during the TLS handshake; auto-registered and existing self-signed nodes obtain their pins through verified SSH rather than network trust-on-first-use; all SSH and Ansible paths reject unknown host keys from a shared operator-provisioned trust file; root maintenance accepts only fixed semantic actions and elevated deploy permission; authentication fallbacks escalate only on typed authentication failures and preserve retry-safety metadata; rate limiting uses atomic fixed-window slot claims; and SSH key generation and revocation are audited and fail closed during node destruction (#327)
 
 ---
 

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -33,6 +33,15 @@ PRAHO_SSH_KNOWN_HOSTS_PATH=/etc/praho/known_hosts
 
 The file must be readable by the Platform and worker processes. Container deployments must mount the same file read-only into the container at the configured path. A missing file, unknown host, or changed key intentionally blocks the operation; verify rotations out of band and update the trust file before retrying.
 
+Newly deployed self-signed Virtualmin nodes have the certificate actually served on port 10000 measured through this trusted SSH channel and pinned automatically. Before enabling provisioning after upgrading an installation with existing unpinned self-signed nodes, run:
+
+```bash
+python manage.py pin_virtualmin_certificates --dry-run
+python manage.py pin_virtualmin_certificates
+```
+
+The command fails closed for records without a linked deployment or without verified SSH host-key trust. Resolve those records and rerun the command; do not obtain their initial certificate pin over an unverified network connection.
+
 ---
 
 ## Choosing a Deployment Method

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -5,6 +5,7 @@ This guide covers all deployment scenarios for PRAHO, from native single-server 
 ## Table of Contents
 
 - [Choosing a Deployment Method](#choosing-a-deployment-method)
+- [Managed-node SSH Trust](#managed-node-ssh-trust)
 - [Deployment Options](#deployment-options)
   - [Option 1: Native Single Server](#option-1-native-single-server)
   - [Option 2: Docker Single Server](#option-2-docker-single-server)
@@ -17,6 +18,20 @@ This guide covers all deployment scenarios for PRAHO, from native single-server 
 - [Makefile Commands](#makefile-commands)
 - [Environment Variables](#environment-variables)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## Managed-node SSH Trust
+
+PRAHO rejects unknown SSH host keys for node validation, Virtualmin fallback access, pooled SSH connections, and Ansible maintenance. Before enabling infrastructure automation, provision a `known_hosts` file for the operating-system account that runs Platform and its Django-Q workers.
+
+Obtain each host key or fingerprint through a trusted out-of-band channel, such as the cloud-provider console. Do not trust an unverified `ssh-keyscan` result by itself. Add entries for every address PRAHO uses to connect (normally both the node hostname and its public IP), then set:
+
+```dotenv
+PRAHO_SSH_KNOWN_HOSTS_PATH=/etc/praho/known_hosts
+```
+
+The file must be readable by the Platform and worker processes. Container deployments must mount the same file read-only into the container at the configured path. A missing file, unknown host, or changed key intentionally blocks the operation; verify rotations out of band and update the trust file before retrying.
 
 ---
 

--- a/services/platform/apps/common/outbound_http.py
+++ b/services/platform/apps/common/outbound_http.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import http.client
 import ipaddress
 import logging
+import re
 import socket
 import ssl
 import urllib.parse
@@ -72,6 +73,20 @@ class OutboundSecurityError(Exception):
     """
 
 
+def normalize_tls_cert_fingerprint(fingerprint: str) -> str:
+    """Return a normalized SHA-256 certificate fingerprint or fail closed."""
+    if not fingerprint:
+        return ""
+
+    normalized = fingerprint.strip().lower()
+    if normalized.startswith("sha256:"):
+        normalized = normalized.removeprefix("sha256:")
+    normalized = normalized.replace(":", "")
+    if not re.fullmatch(r"[0-9a-f]{64}", normalized):
+        raise OutboundSecurityError("TLS certificate fingerprint must be a SHA-256 hex digest")
+    return normalized
+
+
 # ---------------------------------------------------------------------------
 # Policy dataclass
 # ---------------------------------------------------------------------------
@@ -90,6 +105,7 @@ class OutboundPolicy:
     blocked_ports: frozenset[int] = DANGEROUS_PORTS
     allowed_domains: frozenset[str] | None = None  # None = any domain
     verify_tls: bool = True
+    tls_cert_fingerprint: str = ""
     max_retries: int = 0
     check_dns: bool = True
 
@@ -416,14 +432,23 @@ class PinnedIPAdapter(HTTPAdapter):
     _hostname: str
     _port: int
 
-    def __init__(self, pinned_ip: str, hostname: str, port: int = 443) -> None:
+    def __init__(
+        self,
+        pinned_ip: str,
+        hostname: str,
+        port: int = 443,
+        tls_cert_fingerprint: str = "",
+    ) -> None:
         self._pinned_ip = pinned_ip
         self._hostname = hostname
         self._port = port
+        self._tls_cert_fingerprint = normalize_tls_cert_fingerprint(tls_cert_fingerprint)
         super().__init__()
 
     def init_poolmanager(self, *args: object, **kwargs: object) -> None:
         kwargs["server_hostname"] = self._hostname
+        if self._tls_cert_fingerprint:
+            kwargs["assert_fingerprint"] = self._tls_cert_fingerprint
         super().init_poolmanager(*args, **kwargs)
 
     def _rewrite_url_to_ip(self, request: requests.PreparedRequest, ip: str) -> None:
@@ -492,7 +517,15 @@ def _follow_redirects(
 
         pinned_ip = target.pinned_ips[0] if target.pinned_ips else target.hostname
         prefix = f"{target.scheme}://{target.hostname}"
-        session.mount(prefix, PinnedIPAdapter(pinned_ip=pinned_ip, hostname=target.hostname, port=target.port))
+        session.mount(
+            prefix,
+            PinnedIPAdapter(
+                pinned_ip=pinned_ip,
+                hostname=target.hostname,
+                port=target.port,
+                tls_cert_fingerprint=policy.tls_cert_fingerprint,
+            ),
+        )
 
         if response.status_code == HTTP_STATUS_SEE_OTHER:
             method = "GET"
@@ -534,6 +567,7 @@ def safe_request(
         OutboundSecurityError: If the URL violates the security policy
         requests.RequestException: For transport errors
     """
+    normalize_tls_cert_fingerprint(policy.tls_cert_fingerprint)
     try:
         target = validate_and_resolve(url, policy)
     except OutboundSecurityError:
@@ -557,10 +591,17 @@ def _execute_pinned_request(
     **kwargs: object,
 ) -> requests.Response:
     """Mount pinned adapter, send request, handle redirects."""
-    if target.pinned_ips:
+    if target.pinned_ips or policy.tls_cert_fingerprint:
         prefix = f"{target.scheme}://"
+        pinned_ip = target.pinned_ips[0] if target.pinned_ips else target.hostname
         session.mount(
-            prefix, PinnedIPAdapter(pinned_ip=target.pinned_ips[0], hostname=target.hostname, port=target.port)
+            prefix,
+            PinnedIPAdapter(
+                pinned_ip=pinned_ip,
+                hostname=target.hostname,
+                port=target.port,
+                tls_cert_fingerprint=policy.tls_cert_fingerprint,
+            ),
         )
 
     # Strip transport kwargs from Request constructor kwargs
@@ -609,6 +650,9 @@ def safe_urlopen(
     Returns:
         http.client.HTTPResponse
     """
+    if policy.tls_cert_fingerprint:
+        raise OutboundSecurityError("safe_urlopen cannot enforce TLS certificate fingerprints; use safe_request")
+
     target = validate_and_resolve(url, policy)
     effective_timeout = timeout if timeout is not None else policy.timeout_seconds
 

--- a/services/platform/apps/common/performance/connection_pool.py
+++ b/services/platform/apps/common/performance/connection_pool.py
@@ -405,6 +405,8 @@ class SSHConnectionPool:
             known_hosts_path = str(getattr(settings, "PRAHO_SSH_KNOWN_HOSTS_PATH", "")).strip()
             if known_hosts_path:
                 client.load_host_keys(known_hosts_path)
+            # Host-key rejection mirrors apps/common/ssh.py (kept inline to avoid an
+            # import cycle through the pool); keep the two in sync if either changes.
             client.set_missing_host_key_policy(self._paramiko.RejectPolicy())
 
             connect_kwargs: dict[str, Any] = {

--- a/services/platform/apps/common/performance/connection_pool.py
+++ b/services/platform/apps/common/performance/connection_pool.py
@@ -18,6 +18,8 @@ from contextlib import contextmanager
 from typing import Any, ClassVar
 from urllib.parse import urlparse
 
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
 
 # Try to import requests with urllib3 for connection pooling
@@ -399,7 +401,11 @@ class SSHConnectionPool:
 
             # Create new connection
             client = self._paramiko.SSHClient()
-            client.set_missing_host_key_policy(self._paramiko.AutoAddPolicy())
+            client.load_system_host_keys()
+            known_hosts_path = str(getattr(settings, "PRAHO_SSH_KNOWN_HOSTS_PATH", "")).strip()
+            if known_hosts_path:
+                client.load_host_keys(known_hosts_path)
+            client.set_missing_host_key_policy(self._paramiko.RejectPolicy())
 
             connect_kwargs: dict[str, Any] = {
                 "hostname": hostname,

--- a/services/platform/apps/common/ssh.py
+++ b/services/platform/apps/common/ssh.py
@@ -1,0 +1,15 @@
+"""Shared fail-closed SSH host-key trust configuration."""
+
+from __future__ import annotations
+
+import paramiko
+from django.conf import settings
+
+
+def configure_strict_host_key_checking(client: paramiko.SSHClient) -> None:
+    """Load pre-provisioned known hosts and reject every unknown host key."""
+    client.load_system_host_keys()
+    known_hosts_path = str(getattr(settings, "PRAHO_SSH_KNOWN_HOSTS_PATH", "")).strip()
+    if known_hosts_path:
+        client.load_host_keys(known_hosts_path)
+    client.set_missing_host_key_policy(paramiko.RejectPolicy())

--- a/services/platform/apps/infrastructure/ansible_service.py
+++ b/services/platform/apps/infrastructure/ansible_service.py
@@ -273,14 +273,14 @@ class AnsibleService:
         ansible_env = {
             **os.environ,
             "ANSIBLE_HOST_KEY_CHECKING": "True",
+            "ANSIBLE_SSH_COMMON_ARGS": "-o StrictHostKeyChecking=yes",
             "ANSIBLE_STDOUT_CALLBACK": "yaml",
             "ANSIBLE_FORCE_COLOR": "0",
         }
         known_hosts_path = str(getattr(settings, "PRAHO_SSH_KNOWN_HOSTS_PATH", "")).strip()
         if known_hosts_path:
-            existing_ssh_args = ansible_env.get("ANSIBLE_SSH_COMMON_ARGS", "")
             known_hosts_arg = f"-o UserKnownHostsFile={shlex.quote(known_hosts_path)}"
-            ansible_env["ANSIBLE_SSH_COMMON_ARGS"] = f"{existing_ssh_args} {known_hosts_arg}".strip()
+            ansible_env["ANSIBLE_SSH_COMMON_ARGS"] = f"{ansible_env['ANSIBLE_SSH_COMMON_ARGS']} {known_hosts_arg}"
         return ansible_env
 
     def _generate_inventory(self, deployment: NodeDeployment) -> Path:

--- a/services/platform/apps/infrastructure/ansible_service.py
+++ b/services/platform/apps/infrastructure/ansible_service.py
@@ -11,12 +11,15 @@ import json
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
+
+from django.conf import settings
 
 from apps.common.types import Err, Ok, Result
 from apps.infrastructure.ssh_key_manager import get_ssh_key_manager
@@ -73,6 +76,17 @@ class AnsibleService:
 
     # Default playbook order (backwards compatibility)
     PLAYBOOK_ORDER = PANEL_PLAYBOOKS["virtualmin"]
+    ALLOWED_PLAYBOOKS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "common_base.yml",
+            "virtualmin.yml",
+            "virtualmin_harden.yml",
+            "virtualmin_backup.yml",
+            "blesta.yml",
+            "blesta_harden.yml",
+            "blesta_backup.yml",
+        }
+    )
 
     def __init__(self, timeout: int = 1800) -> None:
         """Initialize Ansible service"""
@@ -132,7 +146,7 @@ class AnsibleService:
         logger.info(f"📜 [Ansible] All {len(results)} playbooks completed successfully")
         return Ok(results)
 
-    def run_playbook(
+    def run_playbook(  # noqa: PLR0911, PLR0912  # Explicit fail-closed boundary checks
         self,
         deployment: NodeDeployment,
         playbook: str,
@@ -152,12 +166,17 @@ class AnsibleService:
         if not deployment.ipv4_address:
             return Err("Deployment has no IP address")
 
-        playbook_path = PLAYBOOKS_PATH / playbook
+        if playbook not in self.ALLOWED_PLAYBOOKS:
+            return Err(f"Playbook not allowed: {playbook}")
+
+        playbook_path = (PLAYBOOKS_PATH / playbook).resolve()
+        if playbook_path.parent != PLAYBOOKS_PATH.resolve():
+            return Err(f"Playbook not allowed: {playbook}")
         if not playbook_path.exists():
             return Err(f"Playbook not found: {playbook_path}")
 
         # Get SSH key
-        key_result = self._ssh_manager.get_private_key_file(  # type: ignore[call-arg]
+        key_result = self._ssh_manager.get_private_key_file(
             deployment,
             reason=f"Ansible playbook: {playbook}",
         )
@@ -193,6 +212,8 @@ class AnsibleService:
 
             logger.info(f"📜 [Ansible] Running: {playbook} on {deployment.ipv4_address}")
 
+            ansible_env = self._build_ansible_env()
+
             # Execute
             result = subprocess.run(  # Safe: shell=False  # noqa: S603  # Safe: shell=False
                 cmd,
@@ -201,12 +222,7 @@ class AnsibleService:
                 text=True,
                 timeout=self.timeout,
                 check=False,
-                env={
-                    **os.environ,
-                    "ANSIBLE_HOST_KEY_CHECKING": "False",
-                    "ANSIBLE_STDOUT_CALLBACK": "yaml",
-                    "ANSIBLE_FORCE_COLOR": "0",
-                },
+                env=ansible_env,
             )
 
             success = result.returncode == 0
@@ -250,6 +266,22 @@ class AnsibleService:
                 key_file.unlink()
             if "inventory_file" in locals() and inventory_file.exists():
                 inventory_file.unlink()
+
+    @staticmethod
+    def _build_ansible_env() -> dict[str, str]:
+        """Build an environment that always enforces managed SSH host-key trust."""
+        ansible_env = {
+            **os.environ,
+            "ANSIBLE_HOST_KEY_CHECKING": "True",
+            "ANSIBLE_STDOUT_CALLBACK": "yaml",
+            "ANSIBLE_FORCE_COLOR": "0",
+        }
+        known_hosts_path = str(getattr(settings, "PRAHO_SSH_KNOWN_HOSTS_PATH", "")).strip()
+        if known_hosts_path:
+            existing_ssh_args = ansible_env.get("ANSIBLE_SSH_COMMON_ARGS", "")
+            known_hosts_arg = f"-o UserKnownHostsFile={shlex.quote(known_hosts_path)}"
+            ansible_env["ANSIBLE_SSH_COMMON_ARGS"] = f"{existing_ssh_args} {known_hosts_arg}".strip()
+        return ansible_env
 
     def _generate_inventory(self, deployment: NodeDeployment) -> Path:
         """Generate dynamic inventory file for deployment"""

--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -614,6 +614,12 @@ class NodeDeploymentService:
                     )
                     return Err(f"Server deletion failed: {delete_result.unwrap_err()}")
 
+                # Cloud VM is gone. Clear external_node_id NOW so that if a later
+                # step (vault-key revocation) fails and the destroy is retried, the
+                # retry does not re-invoke delete_server against an already-deleted VM.
+                deployment.external_node_id = ""
+                deployment.save(update_fields=["external_node_id", "updated_at"])
+
                 # Clean up SSH key from provider
                 ssh_key_name = f"praho-{deployment.hostname}"
                 ssh_delete_result = gateway.delete_ssh_key(ssh_key_name)

--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -33,6 +33,7 @@ from apps.infrastructure.cloud_gateway import (
     ServerCreateResult,
     get_cloud_gateway,
 )
+from apps.infrastructure.maintenance import resolve_maintenance_playbooks
 from apps.infrastructure.provider_config import (
     run_provider_command,
 )
@@ -660,7 +661,11 @@ class NodeDeploymentService:
                 logger.warning(f"No external_node_id for {deployment.hostname}, skipping cloud deletion")
 
             # Clean up SSH key from vault
-            self._ssh_manager.revoke_deployment_key(deployment, user=user)
+            key_delete_result = self._ssh_manager.delete_deployment_key(deployment, user=user)
+            if key_delete_result.is_err():
+                error_msg = f"SSH key revocation failed: {key_delete_result.unwrap_err()}"
+                self._mark_failed(deployment, error_msg, stage="destroying", audit_ctx=audit_ctx)
+                return Err(error_msg)
 
             # Mark as destroyed
             deployment.destroyed_at = timezone.now()
@@ -868,7 +873,7 @@ class NodeDeploymentService:
                 logger.warning(f"[Upgrade:{deployment.hostname}] Failed to log audit: upgrade failed")
             return Err(f"Upgrade failed: {e}")
 
-    def run_maintenance(  # Complexity: deployment orchestration  # noqa: C901  # Complexity: multi-step business logic
+    def run_maintenance(  # Complexity: deployment orchestration  # noqa: C901, PLR0911  # Complexity: multi-step business logic
         self,
         deployment: NodeDeployment,
         playbooks: list[str] | None = None,
@@ -897,9 +902,11 @@ class NodeDeploymentService:
         if not deployment.ipv4_address:
             return Err("Deployment has no IP address")
 
-        # Default to hardening playbook
-        if not playbooks:
-            playbooks = ["virtualmin_harden.yml"]
+        actions = playbooks or ["security"]
+        try:
+            playbooks = resolve_maintenance_playbooks(deployment.panel_type.panel_type, actions)
+        except ValueError as exc:
+            return Err(str(exc))
 
         logger.info(f"[Maintenance:{deployment.hostname}] Running playbooks: {playbooks}")
 

--- a/services/platform/apps/infrastructure/maintenance.py
+++ b/services/platform/apps/infrastructure/maintenance.py
@@ -1,0 +1,26 @@
+"""Semantic maintenance actions mapped to repository-owned playbooks."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+MAINTENANCE_ACTION_PLAYBOOKS: dict[str, dict[str, str]] = {
+    "security": {
+        "virtualmin": "virtualmin_harden.yml",
+        "blesta": "blesta_harden.yml",
+    },
+}
+
+
+def resolve_maintenance_playbooks(panel_type: str, actions: Iterable[str]) -> list[str]:
+    """Resolve semantic action IDs to fixed panel-aware playbook filenames."""
+    resolved: list[str] = []
+    for action in actions:
+        panel_playbooks = MAINTENANCE_ACTION_PLAYBOOKS.get(action)
+        if panel_playbooks is None:
+            raise ValueError(f"Unsupported maintenance action: {action}")
+        playbook = panel_playbooks.get(panel_type)
+        if playbook is None:
+            raise ValueError(f"Maintenance action '{action}' is unsupported for panel '{panel_type}'")
+        resolved.append(playbook)
+    return resolved

--- a/services/platform/apps/infrastructure/management/commands/pin_virtualmin_certificates.py
+++ b/services/platform/apps/infrastructure/management/commands/pin_virtualmin_certificates.py
@@ -1,0 +1,68 @@
+"""Backfill trusted SHA-256 pins for self-signed Virtualmin node certificates."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.management.base import BaseCommand, CommandError, CommandParser
+
+from apps.infrastructure.validation_service import get_validation_service
+from apps.provisioning.virtualmin_models import VirtualminServer
+
+
+class Command(BaseCommand):
+    """Pin certificates through the deployment SSH trust path, never network TOFU."""
+
+    help = "Pin self-signed Virtualmin certificates over trusted deployment SSH"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("--server-id", type=int, help="Limit the backfill to one VirtualminServer ID")
+        parser.add_argument("--dry-run", action="store_true", help="List candidate servers without changing them")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        candidates = VirtualminServer.objects.filter(
+            use_ssl=True,
+            ssl_verify=False,
+            ssl_cert_fingerprint="",
+        )
+        if options["server_id"] is not None:
+            candidates = candidates.filter(pk=options["server_id"])
+        servers = list(candidates)
+
+        if options["dry_run"]:
+            self.stdout.write(f"Would pin {len(servers)} Virtualmin certificate(s)")
+            return
+
+        validation = get_validation_service()
+        pinned = 0
+        failed = 0
+        for server in servers:
+            try:
+                deployment = server.node_deployment
+            except ObjectDoesNotExist:
+                failed += 1
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"Skipped VirtualminServer {server.id} ({server.hostname}): no linked node deployment"
+                    )
+                )
+                continue
+
+            result = validation.get_webmin_certificate_fingerprint(deployment)
+            if result.is_err():
+                failed += 1
+                self.stderr.write(
+                    self.style.WARNING(
+                        f"Could not pin VirtualminServer {server.id} ({server.hostname}): {result.unwrap_err()}"
+                    )
+                )
+                continue
+
+            server.ssl_cert_fingerprint = result.unwrap()
+            server.save(update_fields=["ssl_cert_fingerprint", "updated_at"])
+            pinned += 1
+
+        self.stdout.write(self.style.SUCCESS(f"Pinned {pinned} Virtualmin certificate(s)"))
+        if failed:
+            raise CommandError(f"Failed to pin {failed} Virtualmin certificate(s)")

--- a/services/platform/apps/infrastructure/registration_service.py
+++ b/services/platform/apps/infrastructure/registration_service.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from django.db import transaction
 
+from apps.common.outbound_http import OutboundSecurityError, normalize_tls_cert_fingerprint
 from apps.common.types import Err, Ok, Result
 
 if TYPE_CHECKING:
@@ -31,6 +32,35 @@ class NodeRegistrationService:
     Creates VirtualminServer records that integrate with the existing
     provisioning system.
     """
+
+    @staticmethod
+    def _registration_validation_error(deployment: NodeDeployment) -> str | None:
+        """Return a preflight error without opening a database transaction or SSH session."""
+        if deployment.status not in {"completed", "registering"}:
+            return f"Cannot register node in status '{deployment.status}'"
+        if not deployment.ipv4_address:
+            return "Deployment has no IP address assigned"
+        if deployment.virtualmin_server:
+            return f"Node already registered as: {deployment.virtualmin_server}"
+
+        from apps.provisioning.virtualmin_models import VirtualminServer  # noqa: PLC0415
+
+        if VirtualminServer.objects.filter(hostname=deployment.fqdn).exists():
+            return f"VirtualminServer with hostname '{deployment.fqdn}' already exists"
+        return None
+
+    @staticmethod
+    def _trusted_certificate_fingerprint(deployment: NodeDeployment) -> Result[str, str]:
+        """Obtain and validate the Webmin pin through the trusted SSH channel."""
+        from apps.infrastructure.validation_service import get_validation_service  # noqa: PLC0415
+
+        fingerprint_result = get_validation_service().get_webmin_certificate_fingerprint(deployment)
+        if fingerprint_result.is_err():
+            return Err(f"Could not verify Webmin certificate fingerprint: {fingerprint_result.unwrap_err()}")
+        try:
+            return Ok(normalize_tls_cert_fingerprint(fingerprint_result.unwrap()))
+        except OutboundSecurityError as exc:
+            return Err(f"Could not verify Webmin certificate fingerprint: {exc}")
 
     def register_node(
         self,
@@ -60,17 +90,16 @@ class NodeRegistrationService:
             VirtualminServer,
         )
 
-        # Validate deployment status
-        if deployment.status not in {"completed", "registering"}:
-            return Err(f"Cannot register node in status '{deployment.status}'")
-
-        if not deployment.ipv4_address:
-            return Err("Deployment has no IP address assigned")
-
-        if deployment.virtualmin_server:
-            return Err(f"Node already registered as: {deployment.virtualmin_server}")
+        validation_error = self._registration_validation_error(deployment)
+        if validation_error:
+            return Err(validation_error)
 
         logger.info(f"📝 [Registration] Registering node: {deployment.hostname}")
+
+        fingerprint_result = self._trusted_certificate_fingerprint(deployment)
+        if fingerprint_result.is_err():
+            return Err(fingerprint_result.unwrap_err())
+        ssl_cert_fingerprint = fingerprint_result.unwrap()
 
         try:
             with transaction.atomic():
@@ -85,6 +114,7 @@ class NodeRegistrationService:
                     api_port=10000,
                     use_ssl=True,
                     ssl_verify=False,  # Self-signed initially
+                    ssl_cert_fingerprint=ssl_cert_fingerprint,
                     status="active",
                     api_username=admin_username,
                     encrypted_api_password=b"",  # Stored in CredentialVault instead

--- a/services/platform/apps/infrastructure/ssh_key_manager.py
+++ b/services/platform/apps/infrastructure/ssh_key_manager.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
+from django.db import transaction
 
 from apps.common.credential_vault import (
     CredentialData,
@@ -182,6 +183,20 @@ class SSHKeyManager:
             deployment.ssh_key_credential_id = str(credential.id)
             deployment.save(update_fields=["ssh_key_credential_id", "updated_at"])
 
+            try:
+                from apps.infrastructure.audit_service import (  # noqa: PLC0415
+                    InfrastructureAuditContext,
+                    InfrastructureAuditService,
+                )
+
+                InfrastructureAuditService.log_ssh_key_generated(
+                    deployment,
+                    key_pair.fingerprint,
+                    InfrastructureAuditContext(user=user),
+                )
+            except Exception:
+                logger.exception("Failed to audit SSH key generation for %s", deployment.hostname)
+
             logger.info(
                 f"🔑 [SSH Manager] Generated and stored SSH key for deployment: "
                 f"{deployment.hostname}, fingerprint: {key_pair.fingerprint}"
@@ -272,6 +287,7 @@ class SSHKeyManager:
         self,
         deployment: NodeDeployment,
         user: User | None = None,
+        reason: str = "Private key for Ansible",
     ) -> Result[Path, str]:
         """
         Get private key written to a temporary file (for Ansible).
@@ -281,11 +297,12 @@ class SSHKeyManager:
         Args:
             deployment: NodeDeployment instance
             user: User requesting access
+            reason: Audit reason recorded for private-key access
 
         Returns:
             Result with Path to temporary key file or error
         """
-        result = self.get_deployment_key(deployment, user, "Private key for Ansible")
+        result = self.get_deployment_key(deployment, user, reason)
 
         if result.is_err():
             return Err(result.unwrap_err())
@@ -331,22 +348,34 @@ class SSHKeyManager:
             return Ok(True)
 
         try:
-            # Deactivate the credential (soft delete)
-            credential = EncryptedCredential.objects.get(id=deployment.ssh_key_credential_id)
-            credential.is_active = False
-            credential.save(update_fields=["is_active", "updated_at"])
+            with transaction.atomic():
+                try:
+                    credential = EncryptedCredential.objects.get(id=deployment.ssh_key_credential_id)
+                except EncryptedCredential.DoesNotExist:
+                    logger.warning(f"🔑 [SSH Manager] SSH key credential not found: {deployment.ssh_key_credential_id}")
+                else:
+                    credential.is_active = False
+                    credential.save(update_fields=["is_active", "updated_at"])
 
-            # Clear the reference on deployment
-            deployment.ssh_key_credential_id = ""
-            deployment.save(update_fields=["ssh_key_credential_id", "updated_at"])
+                deployment.ssh_key_credential_id = ""
+                deployment.save(update_fields=["ssh_key_credential_id", "updated_at"])
+
+            try:
+                from apps.infrastructure.audit_service import (  # noqa: PLC0415
+                    InfrastructureAuditContext,
+                    InfrastructureAuditService,
+                )
+
+                InfrastructureAuditService.log_ssh_key_revoked(
+                    deployment,
+                    InfrastructureAuditContext(user=user),
+                )
+            except Exception:
+                logger.exception("Failed to audit SSH key revocation for %s", deployment.hostname)
 
             logger.info(f"🔑 [SSH Manager] Deleted SSH key for: {deployment.hostname}")
 
             return Ok(True)
-
-        except EncryptedCredential.DoesNotExist:
-            logger.warning(f"🔑 [SSH Manager] SSH key credential not found: {deployment.ssh_key_credential_id}")
-            return Ok(True)  # Already deleted
 
         except Exception as e:
             logger.error(f"🚨 [SSH Manager] Failed to delete SSH key: {e}")

--- a/services/platform/apps/infrastructure/tasks.py
+++ b/services/platform/apps/infrastructure/tasks.py
@@ -736,7 +736,7 @@ def maintenance_task(
         }
 
     ansible_results = result.unwrap()
-    playbook_names = playbooks or ["update"]
+    playbook_names = playbooks or ["security"]
 
     NodeDeploymentLog.objects.create(
         deployment=deployment,

--- a/services/platform/apps/infrastructure/validation_service.py
+++ b/services/platform/apps/infrastructure/validation_service.py
@@ -189,6 +189,10 @@ class NodeValidationService:
 
             if key_result.is_err():
                 # Try master key as fallback
+                logger.warning(
+                    "🔑 [Validation] Deployment SSH key unavailable for %s — falling back to master key",
+                    getattr(deployment, "hostname", "unknown"),
+                )
                 master_result = self._ssh_manager.get_master_key()
                 if master_result.is_err():
                     return ValidationResult(
@@ -257,7 +261,9 @@ class NodeValidationService:
                 message=f"SSH check failed: {e}",
             )
 
-    def get_webmin_certificate_fingerprint(self, deployment: NodeDeployment) -> Result[str, str]:
+    def get_webmin_certificate_fingerprint(  # noqa: PLR0911  # Explicit fail-closed exits per error class
+        self, deployment: NodeDeployment
+    ) -> Result[str, str]:
         """Read the certificate actually served by Webmin over the trusted SSH channel."""
         if not deployment.ipv4_address:
             return Err("Node has no IP address assigned")
@@ -267,6 +273,11 @@ class NodeValidationService:
             reason="Node registration - verify Webmin TLS certificate",
         )
         if key_result.is_err():
+            logger.warning(
+                "🔑 [Validation] Deployment SSH key unavailable for %s (%s) — falling back to master key",
+                deployment.hostname,
+                key_result.unwrap_err(),
+            )
             master_result = self._ssh_manager.get_master_key()
             if master_result.is_err():
                 return Err(f"Could not get SSH key: {key_result.unwrap_err()}")
@@ -304,7 +315,23 @@ class NodeValidationService:
                 return Err("Could not parse Webmin SHA-256 certificate fingerprint")
             fingerprint = normalize_tls_cert_fingerprint(raw_fingerprint)
             return Ok(fingerprint)
+        except paramiko.BadHostKeyException as exc:
+            # The node's SSH host key does not match the pinned known_hosts entry.
+            # This is the MITM signal this verified-SSH path exists to catch — never
+            # flatten it into generic connection friction.
+            logger.error(
+                "🚨 [Security] SSH host-key mismatch reading Webmin certificate for %s — "
+                "possible man-in-the-middle; refusing to trust the served certificate: %s",
+                deployment.ipv4_address,
+                exc,
+            )
+            return Err(f"SSH host-key mismatch for {deployment.hostname} — possible MITM, certificate not trusted")
         except Exception as exc:
+            logger.warning(
+                "⚠️ [Validation] Could not read Webmin certificate over SSH for %s: %s",
+                deployment.hostname,
+                exc,
+            )
             return Err(f"Could not verify Webmin certificate fingerprint over SSH: {exc}")
         finally:
             if client is not None:

--- a/services/platform/apps/infrastructure/validation_service.py
+++ b/services/platform/apps/infrastructure/validation_service.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 import paramiko
 
 from apps.common.outbound_http import OutboundPolicy, OutboundSecurityError, safe_urlopen
+from apps.common.ssh import configure_strict_host_key_checking
 from apps.common.types import Err, Ok, Result
 from apps.infrastructure.ssh_key_manager import get_ssh_key_manager
 
@@ -196,9 +197,7 @@ class NodeValidationService:
 
             # Create SSH client
             client = paramiko.SSHClient()
-            client.set_missing_host_key_policy(
-                paramiko.AutoAddPolicy()  # noqa: S507  # Intentional: auto-trust for infra validation
-            )  # Intentional: auto-trust for infra validation  # Intentional: auto-trust for infra validation
+            configure_strict_host_key_checking(client)
 
             # Load private key
 

--- a/services/platform/apps/infrastructure/validation_service.py
+++ b/services/platform/apps/infrastructure/validation_service.py
@@ -22,7 +22,12 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import paramiko
 
-from apps.common.outbound_http import OutboundPolicy, OutboundSecurityError, safe_urlopen
+from apps.common.outbound_http import (
+    OutboundPolicy,
+    OutboundSecurityError,
+    normalize_tls_cert_fingerprint,
+    safe_urlopen,
+)
 from apps.common.ssh import configure_strict_host_key_checking
 from apps.common.types import Err, Ok, Result
 from apps.infrastructure.ssh_key_manager import get_ssh_key_manager
@@ -251,6 +256,59 @@ class NodeValidationService:
                 passed=False,
                 message=f"SSH check failed: {e}",
             )
+
+    def get_webmin_certificate_fingerprint(self, deployment: NodeDeployment) -> Result[str, str]:
+        """Read the certificate actually served by Webmin over the trusted SSH channel."""
+        if not deployment.ipv4_address:
+            return Err("Node has no IP address assigned")
+
+        key_result = self._ssh_manager.get_deployment_key(
+            deployment,
+            reason="Node registration - verify Webmin TLS certificate",
+        )
+        if key_result.is_err():
+            master_result = self._ssh_manager.get_master_key()
+            if master_result.is_err():
+                return Err(f"Could not get SSH key: {key_result.unwrap_err()}")
+            private_key_content = master_result.unwrap()
+        else:
+            private_key_content = key_result.unwrap().private_key
+
+        client: paramiko.SSHClient | None = None
+        try:
+            client = paramiko.SSHClient()
+            configure_strict_host_key_checking(client)
+            pkey = paramiko.Ed25519Key.from_private_key(io.StringIO(private_key_content))
+            client.connect(
+                hostname=deployment.ipv4_address,
+                port=22,
+                username="root",
+                pkey=pkey,
+                timeout=self.timeout,
+                allow_agent=False,
+                look_for_keys=False,
+            )
+
+            command = (
+                "openssl s_client -connect 127.0.0.1:10000 </dev/null 2>/dev/null "
+                "| openssl x509 -noout -fingerprint -sha256"
+            )
+            _stdin, stdout, stderr = client.exec_command(command, timeout=self.timeout)
+            output = stdout.read().decode().strip()
+            if stdout.channel.recv_exit_status() != 0:
+                error_output = stderr.read().decode().strip()
+                return Err(f"Could not read Webmin certificate: {error_output or 'openssl failed'}")
+
+            _label, separator, raw_fingerprint = output.partition("=")
+            if not separator or not raw_fingerprint.strip():
+                return Err("Could not parse Webmin SHA-256 certificate fingerprint")
+            fingerprint = normalize_tls_cert_fingerprint(raw_fingerprint)
+            return Ok(fingerprint)
+        except Exception as exc:
+            return Err(f"Could not verify Webmin certificate fingerprint over SSH: {exc}")
+        finally:
+            if client is not None:
+                client.close()
 
     def _check_ports(self, deployment: NodeDeployment) -> ValidationResult:
         """Check required ports are open"""

--- a/services/platform/apps/infrastructure/views.py
+++ b/services/platform/apps/infrastructure/views.py
@@ -37,6 +37,7 @@ from .forms import (
     NodeDeploymentForm,
     NodeSizeForm,
 )
+from .maintenance import MAINTENANCE_ACTION_PLAYBOOKS
 from .models import (
     CloudProvider,
     DriftCheck,
@@ -48,6 +49,7 @@ from .models import (
     NodeSize,
 )
 from .permissions import (
+    can_deploy_nodes,
     can_manage_deployments,
     require_deploy_permission,
     require_deployment_management,
@@ -419,6 +421,7 @@ def deployment_detail(request: HttpRequest, pk: int) -> HttpResponse:
         "status_icon": _get_status_icon(deployment.status),
         "can_retry": deployment.status == "failed",
         "can_destroy": deployment.status in ("completed", "failed", "stopped"),
+        "can_deploy": can_deploy_nodes(cast("User", request.user)),
         "can_manage": can_manage_deployments(cast("User", request.user)),
         "is_in_progress": deployment.status
         in (
@@ -723,7 +726,7 @@ def deployment_reboot(request: HttpRequest, pk: int) -> HttpResponse:
 
 
 @login_required
-@require_deployment_management
+@require_deploy_permission
 @require_http_methods(["GET", "POST"])
 def deployment_maintenance(request: HttpRequest, pk: int) -> HttpResponse:
     """Run maintenance tasks on a deployment."""
@@ -736,21 +739,15 @@ def deployment_maintenance(request: HttpRequest, pk: int) -> HttpResponse:
 
     # Available maintenance playbooks
     playbook_options = [
-        {"id": "update", "name": "System Update", "description": "Update system packages and security patches"},
-        {"id": "security", "name": "Security Hardening", "description": "Apply security hardening configurations"},
-        {
-            "id": "ssl_renew",
-            "name": "SSL Certificate Renewal",
-            "description": "Renew SSL certificates via Let's Encrypt",
-        },
-        {"id": "backup", "name": "Backup Now", "description": "Trigger immediate backup"},
-        {"id": "cleanup", "name": "Disk Cleanup", "description": "Clean up temporary files and logs"},
+        {"id": "security", "name": "Security Hardening", "description": "Apply security hardening configurations"}
     ]
 
     if request.method == "POST":
         selected_playbooks = request.POST.getlist("playbooks")
         if not selected_playbooks:
             messages.error(request, _("Please select at least one maintenance task."))
+        elif any(action not in MAINTENANCE_ACTION_PLAYBOOKS for action in selected_playbooks):
+            messages.error(request, _("One or more maintenance tasks are unsupported."))
         else:
             # Queue maintenance task
             task_id = queue_maintenance(

--- a/services/platform/apps/provisioning/virtualmin_auth_manager.py
+++ b/services/platform/apps/provisioning/virtualmin_auth_manager.py
@@ -8,6 +8,7 @@ ACL authentication potentially being "fixed" by Virtualmin updates.
 from __future__ import annotations
 
 import logging
+import shlex
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -19,10 +20,12 @@ from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
+from apps.common.ssh import configure_strict_host_key_checking
 from apps.common.types import Err, Ok, Result
 
-from .virtualmin_gateway import VirtualminConfig, VirtualminGateway
+from .virtualmin_gateway import VirtualminAPIError, VirtualminAuthError, VirtualminConfig, VirtualminGateway
 from .virtualmin_models import VirtualminServer
+from .virtualmin_validators import VirtualminValidator
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +83,13 @@ class AuthMethod(Enum):
     SSH_SUDO = "ssh_sudo"
 
 
+class AuthMethodUnavailableError(Exception):
+    """An explicitly configured fallback method is unavailable on this installation."""
+
+
+AuthFailure = str | VirtualminAPIError | AuthMethodUnavailableError
+
+
 @dataclass
 class AuthResult:
     """Result of authentication attempt"""
@@ -132,6 +142,11 @@ class VirtualminAuthenticationManager:
             Result with command output or error
         """
         start_time = timezone.now()
+        try:
+            program = VirtualminValidator.validate_virtualmin_program(program)
+            parameters = VirtualminValidator.validate_virtualmin_params(parameters)
+        except Exception as exc:
+            return Err(f"Virtualmin command validation failed: {exc}")
 
         # Determine authentication method to try
         methods_to_try = [force_method] if force_method else self._get_auth_method_priority()
@@ -153,27 +168,34 @@ class VirtualminAuthenticationManager:
                         f"✅ [Virtualmin Auth] {method.value} succeeded for {program} in {execution_time:.0f}ms"
                     )
 
-                    return result
+                    return Ok(result.unwrap())
                 else:
-                    error_msg = result.unwrap_err()
+                    error = result.unwrap_err()
+                    error_msg = str(error)
                     last_error = f"{method.value}: {error_msg}"
                     logger.warning(f"❌ [Virtualmin Auth] {method.value} failed: {error_msg}")
 
-                    # Mark this method as failed
-                    self._cache_failed_auth_method(method, error_msg)
+                    if isinstance(error, VirtualminAuthError):
+                        self._cache_failed_auth_method(method, error_msg)
+                        continue
+                    if isinstance(error, AuthMethodUnavailableError):
+                        continue
+                    return Err(last_error)
 
             except Exception as e:
                 last_error = f"{method.value}: {e!s}"
                 logger.error(f"🔥 [Virtualmin Auth] {method.value} exception: {e}")
-                self._cache_failed_auth_method(method, str(e))
+                return Err(last_error)
 
         # All methods failed
         logger.error(f"🚨 [Virtualmin Auth] ALL methods failed for {program}: {last_error}")
         return Err(f"All authentication methods failed. Last error: {last_error}")
 
-    def _execute_with_method(self, method: AuthMethod, program: str, parameters: dict[str, Any]) -> Result[Any, str]:
+    def _execute_with_method(
+        self, method: AuthMethod, program: str, parameters: dict[str, Any]
+    ) -> Result[Any, AuthFailure]:
         """Execute command with specific authentication method."""
-        handlers: dict[AuthMethod, Callable[[str, dict[str, Any]], Result[Any, str]]] = {
+        handlers: dict[AuthMethod, Callable[[str, dict[str, Any]], Result[Any, AuthFailure]]] = {
             AuthMethod.ACL: self._execute_acl_auth,
             AuthMethod.MASTER_PROXY: self._execute_master_proxy,
             AuthMethod.SSH_SUDO: self._execute_ssh_sudo,
@@ -183,7 +205,7 @@ class VirtualminAuthenticationManager:
             return Err(f"Unknown auth method: {method}")
         return handler(program, parameters)
 
-    def _execute_acl_auth(self, program: str, parameters: dict[str, Any]) -> Result[Any, str]:
+    def _execute_acl_auth(self, program: str, parameters: dict[str, Any]) -> Result[Any, AuthFailure]:
         """Execute using current ACL user authentication"""
         try:
             # Use existing gateway with ACL credentials
@@ -194,18 +216,21 @@ class VirtualminAuthenticationManager:
                 port=self.server.api_port,
                 use_ssl=self.server.use_ssl,
                 verify_ssl=self.server.ssl_verify,
+                cert_fingerprint=self.server.ssl_cert_fingerprint,
                 timeout=30,
             )
 
             gateway = VirtualminGateway(config)
             result = gateway.call(program, parameters)
             if result.is_err():
-                return Err(str(result.unwrap_err()))
+                return Err(result.unwrap_err())
             return Ok(result.unwrap())
+        except VirtualminAPIError as e:
+            return Err(e)
         except Exception as e:
-            return Err(f"ACL authentication failed: {e!s}")
+            return Err(VirtualminAPIError(f"ACL request failed: {e!s}", self.server.hostname, program))
 
-    def _execute_master_proxy(self, program: str, parameters: dict[str, Any]) -> Result[Any, str]:
+    def _execute_master_proxy(self, program: str, parameters: dict[str, Any]) -> Result[Any, AuthFailure]:
         """Execute using master admin credentials via proxy service"""
         try:
             # Get master admin credentials from environment
@@ -213,7 +238,7 @@ class VirtualminAuthenticationManager:
             master_password = getattr(settings, "VIRTUALMIN_MASTER_PASSWORD", None)
 
             if not master_username or not master_password:
-                return Err("Master admin credentials not configured")
+                return Err(AuthMethodUnavailableError("Master admin credentials not configured"))
 
             # Use master credentials with same gateway
             config = VirtualminConfig.from_credentials(
@@ -223,6 +248,7 @@ class VirtualminAuthenticationManager:
                 port=self.server.api_port,
                 use_ssl=self.server.use_ssl,
                 verify_ssl=self.server.ssl_verify,
+                cert_fingerprint=self.server.ssl_cert_fingerprint,
                 timeout=30,
             )
 
@@ -236,11 +262,13 @@ class VirtualminAuthenticationManager:
                 )
                 return Ok(result.unwrap())
 
-            return Err(str(result.unwrap_err()))
+            return Err(result.unwrap_err())
+        except VirtualminAPIError as e:
+            return Err(e)
         except Exception as e:
-            return Err(f"Master proxy authentication failed: {e!s}")
+            return Err(VirtualminAPIError(f"Master proxy request failed: {e!s}", self.server.hostname, program))
 
-    def _execute_ssh_sudo(self, program: str, parameters: dict[str, Any]) -> Result[Any, str]:
+    def _execute_ssh_sudo(self, program: str, parameters: dict[str, Any]) -> Result[Any, AuthFailure]:
         """Execute using SSH + sudo to virtualmin CLI"""
         try:
             # Build virtualmin CLI command
@@ -253,13 +281,13 @@ class VirtualminAuthenticationManager:
                 elif value is not None and value is not False:
                     cmd_parts.extend([f"--{key}", str(value)])
 
-            command = " ".join(cmd_parts)
+            command = shlex.join(["sudo", *cmd_parts])
 
             # Execute via SSH
-            ssh_result = self._execute_ssh_command(f"sudo {command}")
+            ssh_result = self._execute_ssh_command(command)
 
             if ssh_result.is_err():
-                return ssh_result
+                return Err(ssh_result.unwrap_err())
 
             output = ssh_result.unwrap()
 
@@ -305,7 +333,7 @@ class VirtualminAuthenticationManager:
 
         try:
             self._ssh_client = paramiko.SSHClient()
-            self._ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            configure_strict_host_key_checking(self._ssh_client)
 
             # Get SSH credentials from settings
             ssh_username = getattr(settings, "VIRTUALMIN_SSH_USERNAME", "virtualmin-praho")
@@ -401,7 +429,7 @@ class VirtualminAuthenticationManager:
                         success=True, method=method, response_time_ms=int(execution_time)
                     )
                 else:
-                    results[method.value] = AuthResult(success=False, method=method, error=result.unwrap_err())
+                    results[method.value] = AuthResult(success=False, method=method, error=str(result.unwrap_err()))
 
             except Exception as e:
                 results[method.value] = AuthResult(success=False, method=method, error=str(e))

--- a/services/platform/apps/provisioning/virtualmin_auth_manager.py
+++ b/services/platform/apps/provisioning/virtualmin_auth_manager.py
@@ -23,7 +23,15 @@ from django.utils import timezone
 from apps.common.ssh import configure_strict_host_key_checking
 from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 
-from .virtualmin_gateway import VirtualminAPIError, VirtualminAuthError, VirtualminConfig, VirtualminGateway
+from .virtualmin_gateway import (
+    VirtualminAPIError,
+    VirtualminAuthError,
+    VirtualminAuthorizationError,
+    VirtualminConfig,
+    VirtualminGateway,
+    VirtualminRateLimitedError,
+    VirtualminTransientError,
+)
 from .virtualmin_models import VirtualminServer
 from .virtualmin_validators import VirtualminValidator
 
@@ -111,6 +119,19 @@ class SSHCredentials:
     password: str | None = None
 
 
+def _retriability_of_exception(error: VirtualminAPIError) -> Retriability:
+    """Preserve retry-safety when a typed gateway exception is converted to Err.
+
+    gateway.call() RAISES rate-limit/transient errors (HTTP 429/5xx are not
+    RequestExceptions, so its retry loop does not catch them). Converting them
+    to a bare Err would drop RETRIABLE and make a caller treat a transient
+    failure as terminal.
+    """
+    if isinstance(error, (VirtualminRateLimitedError, VirtualminTransientError)):
+        return Retriability.RETRIABLE
+    return Retriability.UNKNOWN
+
+
 class VirtualminAuthenticationManager:
     """
     🚨 CRITICAL: Multi-path authentication manager for ACL risk mitigation.
@@ -177,6 +198,11 @@ class VirtualminAuthenticationManager:
                     last_error = f"{method.value}: {error_msg}"
                     logger.warning(f"❌ [Virtualmin Auth] {method.value} failed: {error_msg}")
 
+                    if isinstance(error, VirtualminAuthorizationError):
+                        # 403: the account authenticated but is not permitted.
+                        # Escalating to a higher-privilege method would bypass the
+                        # ACL the server enforced — terminal, never fall through.
+                        return Err(last_error, retriability=last_retriability)
                     if isinstance(error, VirtualminAuthError):
                         self._cache_failed_auth_method(method, error_msg)
                         continue
@@ -229,7 +255,7 @@ class VirtualminAuthenticationManager:
             result = gateway.call(program, parameters)
             return cast(Result[Any, AuthFailure], result)
         except VirtualminAPIError as e:
-            return Err(e)
+            return Err(e, retriability=_retriability_of_exception(e))
         except Exception as e:
             return Err(VirtualminAPIError(f"ACL request failed: {e!s}", self.server.hostname, program))
 
@@ -266,7 +292,7 @@ class VirtualminAuthenticationManager:
 
             return cast(Result[Any, AuthFailure], result)
         except VirtualminAPIError as e:
-            return Err(e)
+            return Err(e, retriability=_retriability_of_exception(e))
         except Exception as e:
             return Err(VirtualminAPIError(f"Master proxy request failed: {e!s}", self.server.hostname, program))
 

--- a/services/platform/apps/provisioning/virtualmin_auth_manager.py
+++ b/services/platform/apps/provisioning/virtualmin_auth_manager.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from types import TracebackType
-from typing import Any
+from typing import Any, cast
 
 import paramiko
 from django.conf import settings
@@ -21,7 +21,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from apps.common.ssh import configure_strict_host_key_checking
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 
 from .virtualmin_gateway import VirtualminAPIError, VirtualminAuthError, VirtualminConfig, VirtualminGateway
 from .virtualmin_models import VirtualminServer
@@ -152,6 +152,7 @@ class VirtualminAuthenticationManager:
         methods_to_try = [force_method] if force_method else self._get_auth_method_priority()
 
         last_error = ""
+        last_retriability = Retriability.UNKNOWN
 
         for method in methods_to_try:
             logger.info(f"🔐 [Virtualmin Auth] Trying {method.value} for {program} on {self.server.hostname}")
@@ -172,6 +173,7 @@ class VirtualminAuthenticationManager:
                 else:
                     error = result.unwrap_err()
                     error_msg = str(error)
+                    last_retriability = retriability_of(result)
                     last_error = f"{method.value}: {error_msg}"
                     logger.warning(f"❌ [Virtualmin Auth] {method.value} failed: {error_msg}")
 
@@ -180,7 +182,7 @@ class VirtualminAuthenticationManager:
                         continue
                     if isinstance(error, AuthMethodUnavailableError):
                         continue
-                    return Err(last_error)
+                    return Err(last_error, retriability=last_retriability)
 
             except Exception as e:
                 last_error = f"{method.value}: {e!s}"
@@ -189,7 +191,10 @@ class VirtualminAuthenticationManager:
 
         # All methods failed
         logger.error(f"🚨 [Virtualmin Auth] ALL methods failed for {program}: {last_error}")
-        return Err(f"All authentication methods failed. Last error: {last_error}")
+        return Err(
+            f"All authentication methods failed. Last error: {last_error}",
+            retriability=last_retriability,
+        )
 
     def _execute_with_method(
         self, method: AuthMethod, program: str, parameters: dict[str, Any]
@@ -222,9 +227,7 @@ class VirtualminAuthenticationManager:
 
             gateway = VirtualminGateway(config)
             result = gateway.call(program, parameters)
-            if result.is_err():
-                return Err(result.unwrap_err())
-            return Ok(result.unwrap())
+            return cast(Result[Any, AuthFailure], result)
         except VirtualminAPIError as e:
             return Err(e)
         except Exception as e:
@@ -260,9 +263,8 @@ class VirtualminAuthenticationManager:
                     f"🚨 [Security] Using master admin credentials for {program} "
                     f"on {self.server.hostname} - ACL auth appears broken!"
                 )
-                return Ok(result.unwrap())
 
-            return Err(result.unwrap_err())
+            return cast(Result[Any, AuthFailure], result)
         except VirtualminAPIError as e:
             return Err(e)
         except Exception as e:

--- a/services/platform/apps/provisioning/virtualmin_forms.py
+++ b/services/platform/apps/provisioning/virtualmin_forms.py
@@ -10,6 +10,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from apps.common.outbound_http import OutboundSecurityError, normalize_tls_cert_fingerprint
 from apps.ui.widgets import (
     PRAHOCheckboxWidget,
     PRAHOPasswordWidget,
@@ -43,6 +44,7 @@ class VirtualminServerForm(forms.ModelForm):  # type: ignore[type-arg]
             "api_username",
             "use_ssl",
             "ssl_verify",
+            "ssl_cert_fingerprint",
             "status",
             "max_domains",
             "max_disk_gb",
@@ -55,6 +57,9 @@ class VirtualminServerForm(forms.ModelForm):  # type: ignore[type-arg]
             "api_username": PRAHOTextWidget(attrs={"placeholder": "webmin_api_user"}),
             "use_ssl": PRAHOCheckboxWidget(),
             "ssl_verify": PRAHOCheckboxWidget(),
+            "ssl_cert_fingerprint": PRAHOTextWidget(
+                attrs={"placeholder": "SHA-256 certificate fingerprint (required for private CAs)"}
+            ),
             "status": PRAHOSelectWidget(),
             "max_domains": PRAHOTextWidget(attrs={"placeholder": "100", "type": "number"}),
             "max_disk_gb": PRAHOTextWidget(attrs={"placeholder": "1000", "type": "number"}),
@@ -102,6 +107,29 @@ class VirtualminServerForm(forms.ModelForm):  # type: ignore[type-arg]
                 raise ValidationError(_("Password validation failed: %(error)s") % {"error": e.message}) from e
 
         return password
+
+    def clean(self) -> dict[str, Any]:
+        """Require HTTPS and a certificate pin whenever CA verification is disabled."""
+        cleaned_data = super().clean() or {}
+        use_ssl = bool(cleaned_data.get("use_ssl"))
+        ssl_verify = bool(cleaned_data.get("ssl_verify"))
+        fingerprint = cast(str, cleaned_data.get("ssl_cert_fingerprint", ""))
+
+        if not use_ssl:
+            self.add_error("use_ssl", _("Virtualmin API connections require HTTPS."))
+
+        if not ssl_verify and not fingerprint:
+            self.add_error(
+                "ssl_cert_fingerprint",
+                _("A SHA-256 certificate fingerprint is required when CA verification is disabled."),
+            )
+        elif fingerprint:
+            try:
+                cleaned_data["ssl_cert_fingerprint"] = normalize_tls_cert_fingerprint(fingerprint)
+            except OutboundSecurityError as exc:
+                self.add_error("ssl_cert_fingerprint", ValidationError(str(exc)))
+
+        return cleaned_data
 
     def save(self, commit: bool = True) -> VirtualminServer:
         """Save server and handle password encryption."""

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -348,9 +348,18 @@ class VirtualminConfig:
 
     server: VirtualminServer
     timeout: int = VIRTUALMIN_API_TIMEOUT
-    verify_ssl: bool = True
+    verify_ssl: bool | None = None
     cert_fingerprint: str = ""
     use_credential_vault: bool = True
+
+    def __post_init__(self) -> None:
+        """Default TLS settings from the persisted server when callers omit them."""
+        if self.verify_ssl is None:
+            object.__setattr__(self, "verify_ssl", bool(getattr(self.server, "ssl_verify", True)))
+        if not self.cert_fingerprint:
+            server_fingerprint = getattr(self.server, "ssl_cert_fingerprint", "")
+            if isinstance(server_fingerprint, str):
+                object.__setattr__(self, "cert_fingerprint", server_fingerprint)
 
     @classmethod
     def from_credentials(  # Virtualmin API parameters  # noqa: PLR0913  # Business logic parameters
@@ -386,13 +395,16 @@ class VirtualminConfig:
         """
         # Create a temporary VirtualminServer-like object for the config
         # We can't create a real VirtualminServer because it requires database access
-        temp_server = SimpleNamespace()
+        temp_server = SimpleNamespace(status="active")
         temp_server.hostname = hostname
         temp_server.api_username = username
         temp_server.api_port = port
+        temp_server.api_path = "/virtual-server/remote.cgi"
         temp_server.use_ssl = use_ssl
         temp_server.ssl_verify = verify_ssl
         temp_server.ssl_cert_fingerprint = cert_fingerprint
+        protocol = "https" if use_ssl else "http"
+        temp_server.api_url = f"{protocol}://{hostname}:{port}{temp_server.api_path}"
 
         # Store the password directly (bypass get_api_password method)
         temp_server._api_password = password
@@ -661,20 +673,25 @@ class VirtualminGateway:
     # _create_session removed — safe_request() handles sessions with DNS-pinned adapters
 
     def _check_rate_limit(self, operation: str) -> bool:
-        """Check if server is within rate limits"""
-        cache_key = f"virtualmin_rate_limit:{self.server.hostname}:{operation}"
-        current_calls = cache.get(cache_key, 0)
-
-        if current_calls >= VIRTUALMIN_RATE_LIMIT_MAX_CALLS:
-            logger.warning(
-                f"Rate limit exceeded for {self.server.hostname} operation {operation}: "
-                f"{current_calls}/{VIRTUALMIN_RATE_LIMIT_MAX_CALLS}"
-            )
+        """Atomically reserve a request slot, failing closed on cache errors."""
+        window = int(time.time() // VIRTUALMIN_RATE_LIMIT_WINDOW)
+        scope = hashlib.sha256(f"{self.server.hostname}\0{operation}".encode()).hexdigest()[:24]
+        cache_key_prefix = f"virtualmin_rate_limit:{scope}:{window}"
+        try:
+            for slot in range(VIRTUALMIN_RATE_LIMIT_MAX_CALLS):
+                if cache.add(f"{cache_key_prefix}:{slot}", 1, VIRTUALMIN_RATE_LIMIT_WINDOW):
+                    return True
+        except Exception:
+            logger.exception("Virtualmin rate-limit counter failed for %s", self.server.hostname)
             return False
 
-        # Increment counter
-        cache.set(cache_key, current_calls + 1, VIRTUALMIN_RATE_LIMIT_WINDOW)
-        return True
+        logger.warning(
+            "Rate limit exceeded for %s operation %s: %s slots claimed",
+            self.server.hostname,
+            operation,
+            VIRTUALMIN_RATE_LIMIT_MAX_CALLS,
+        )
+        return False
 
     def _validate_server_health(self) -> Result[bool, str]:
         """Validate server health before making requests"""
@@ -684,31 +701,6 @@ class VirtualminGateway:
             return Err(f"Server {self.server.hostname} is not active (status: {self.server.status})")
 
         return Ok(True)
-
-    def _validate_ssl_certificate(self, response: requests.Response) -> bool:
-        """Validate SSL certificate if fingerprint is configured"""
-        if not self.config.cert_fingerprint:
-            return True
-
-        try:
-            # Get certificate from response
-            cert_der = response.raw.connection.sock.getpeercert(binary_form=True)  # type: ignore[union-attr]
-            cert_sha256 = hashlib.sha256(cert_der).hexdigest()
-
-            expected = self.config.cert_fingerprint.replace("sha256:", "").lower()
-            actual = cert_sha256.lower()
-
-            if expected != actual:
-                logger.error(
-                    f"SSL certificate mismatch for {self.server.hostname}. Expected: {expected}, Got: {actual}"
-                )
-                return False
-
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to validate SSL certificate: {e}")
-            return False
 
     def call(
         self,
@@ -835,7 +827,6 @@ class VirtualminGateway:
         try:
             response = self._execute_http_request(params)
             self._validate_response_size(response)
-            self._validate_ssl_if_configured(response)
             self._validate_http_status(response)
             return response
 
@@ -853,7 +844,15 @@ class VirtualminGateway:
             ) from e
 
     def _execute_http_request(self, params: dict[str, Any]) -> requests.Response:
-        """Execute the HTTP request via safe_request() with DNS pinning."""
+        """Execute HTTPS with DNS pinning and optional handshake-time certificate pinning."""
+        if not self.server.use_ssl or not self.server.api_url.lower().startswith("https://"):
+            raise VirtualminAPIError("Virtualmin API requires HTTPS", self.server.hostname)
+        if not self.config.verify_ssl and not self.config.cert_fingerprint:
+            raise VirtualminAPIError(
+                "Disabling CA verification requires a pinned SHA-256 certificate fingerprint",
+                self.server.hostname,
+            )
+
         # Get current timeout configuration (supports hot-reloading)
         timeout_config = get_virtualmin_timeouts()
         request_timeout = timeout_config.get("API_REQUEST_TIMEOUT", self.config.timeout)
@@ -861,9 +860,10 @@ class VirtualminGateway:
         # Build per-server policy — Virtualmin uses self-signed certs on some nodes
         virtualmin_policy = OutboundPolicy(
             name="virtualmin",
-            require_https=False,
-            verify_tls=self.config.verify_ssl,
-            allowed_schemes=frozenset({"https", "http"}),
+            require_https=True,
+            verify_tls=bool(self.config.verify_ssl),
+            tls_cert_fingerprint=self.config.cert_fingerprint,
+            allowed_schemes=frozenset({"https"}),
             timeout_seconds=float(request_timeout),
             blocked_ports=frozenset(),  # Virtualmin runs on non-standard ports
         )
@@ -892,11 +892,6 @@ class VirtualminGateway:
 
         # Replace response content
         response._content = content
-
-    def _validate_ssl_if_configured(self, response: requests.Response) -> None:
-        """Validate SSL certificate if configured."""
-        if self.server.use_ssl and self.config.cert_fingerprint and not self._validate_ssl_certificate(response):
-            raise VirtualminAPIError("SSL certificate validation failed", self.server.hostname)
 
     def _validate_http_status(self, response: requests.Response) -> None:
         """Validate HTTP status codes and raise appropriate errors."""

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -16,6 +16,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from functools import lru_cache, wraps
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -419,6 +420,14 @@ class VirtualminConfig:
         )
 
 
+class RateLimitOutcome(Enum):
+    """Outcome of a rate-limit slot claim (distinguishes exhaustion from backend failure)."""
+
+    ALLOWED = "allowed"
+    EXHAUSTED = "exhausted"
+    BACKEND_ERROR = "backend_error"
+
+
 class VirtualminAPIError(Exception):
     """Base exception for Virtualmin API errors"""
 
@@ -682,18 +691,24 @@ class VirtualminGateway:
 
     # _create_session removed — safe_request() handles sessions with DNS-pinned adapters
 
-    def _check_rate_limit(self, operation: str) -> bool:
-        """Atomically reserve a request slot, failing closed on cache errors."""
+    def _check_rate_limit(self, operation: str) -> RateLimitOutcome:
+        """Atomically reserve a request slot, failing closed on cache errors.
+
+        Returns ALLOWED (slot claimed), EXHAUSTED (all slots taken this window),
+        or BACKEND_ERROR (the cache raised). The caller must NOT report a
+        BACKEND_ERROR as a retriable rate-limit hit — during a cache outage that
+        would make every call fleet-wide fail with a misleading "just wait".
+        """
         window = int(time.time() // VIRTUALMIN_RATE_LIMIT_WINDOW)
         scope = hashlib.sha256(f"{self.server.hostname}\0{operation}".encode()).hexdigest()[:24]
         cache_key_prefix = f"virtualmin_rate_limit:{scope}:{window}"
         try:
             for slot in range(VIRTUALMIN_RATE_LIMIT_MAX_CALLS):
                 if cache.add(f"{cache_key_prefix}:{slot}", 1, VIRTUALMIN_RATE_LIMIT_WINDOW):
-                    return True
+                    return RateLimitOutcome.ALLOWED
         except Exception:
             logger.exception("Virtualmin rate-limit counter failed for %s", self.server.hostname)
-            return False
+            return RateLimitOutcome.BACKEND_ERROR
 
         logger.warning(
             "Rate limit exceeded for %s operation %s: %s slots claimed",
@@ -701,7 +716,7 @@ class VirtualminGateway:
             operation,
             VIRTUALMIN_RATE_LIMIT_MAX_CALLS,
         )
-        return False
+        return RateLimitOutcome.EXHAUSTED
 
     def _validate_server_health(self) -> Result[bool, str]:
         """Validate server health before making requests"""
@@ -749,10 +764,22 @@ class VirtualminGateway:
             return Err(VirtualminAPIError(health_result.unwrap_err(), self.server.hostname, program))
 
         # Rate limiting check
-        if not self._check_rate_limit(program):
+        rate_limit_outcome = self._check_rate_limit(program)
+        if rate_limit_outcome is RateLimitOutcome.EXHAUSTED:
             return Err(
                 VirtualminRateLimitedError(f"Rate limit exceeded for {program}", self.server.hostname, program),
                 retriability=Retriability.RETRIABLE,
+            )
+        if rate_limit_outcome is RateLimitOutcome.BACKEND_ERROR:
+            # The limiter could not be consulted — fail closed, but NOT as a
+            # retriable rate-limit: retrying hammers a backend that will not
+            # self-heal, and the operator needs the real cause.
+            return Err(
+                VirtualminAPIError(
+                    f"Rate-limit backend unavailable for {program} — refusing to proceed unmetered",
+                    self.server.hostname,
+                    program,
+                )
             )
 
         # Prepare request parameters

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -433,6 +433,16 @@ class VirtualminAuthError(VirtualminAPIError):
     """Authentication failed - check credentials or ACL permissions"""
 
 
+class VirtualminAuthorizationError(VirtualminAuthError):
+    """HTTP 403 — authenticated but not permitted (ACL denial).
+
+    Distinct from VirtualminAuthError (401, authentication failure): an
+    authorization denial must NOT trigger privilege-escalating auth fallback,
+    or a forbidden operation would succeed as master/root and a compromised
+    node returning 403 could coax PRAHO into sending it master credentials.
+    """
+
+
 class VirtualminRateLimitedError(VirtualminAPIError):
     """Rate limit exceeded - implement exponential backoff"""
 
@@ -898,7 +908,7 @@ class VirtualminGateway:
         if response.status_code == HTTP_UNAUTHORIZED:
             raise VirtualminAuthError("Authentication failed - check API credentials", self.server.hostname)
         elif response.status_code == HTTP_FORBIDDEN:
-            raise VirtualminAuthError("Access forbidden - check ACL permissions", self.server.hostname)
+            raise VirtualminAuthorizationError("Access forbidden - check ACL permissions", self.server.hostname)
         elif response.status_code == HTTP_TOO_MANY_REQUESTS:
             raise VirtualminRateLimitedError("Server rate limit exceeded", self.server.hostname)
         elif response.status_code >= HTTP_INTERNAL_SERVER_ERROR:

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -95,7 +95,7 @@ class VirtualminProvisioningService:
             config = VirtualminConfig(
                 server=target_server,
                 timeout=config_data["timeout"],
-                verify_ssl=config_data.get("ssl_verify", target_server.ssl_verify),
+                verify_ssl=target_server.ssl_verify,
                 cert_fingerprint=target_server.ssl_cert_fingerprint or config_data.get("pinned_cert_sha256", ""),
             )
 

--- a/services/platform/apps/provisioning/virtualmin_views.py
+++ b/services/platform/apps/provisioning/virtualmin_views.py
@@ -778,6 +778,7 @@ def virtualmin_server_test_connection(request: HttpRequest) -> HttpResponse:
         api_password = request.POST.get("api_password", "").strip()
         use_ssl = request.POST.get("use_ssl") == "on"
         ssl_verify = request.POST.get("ssl_verify") == "on"
+        ssl_cert_fingerprint = request.POST.get("ssl_cert_fingerprint", "").strip()
 
         # Validate required fields
         if not all([hostname, api_username, api_password]):
@@ -799,7 +800,12 @@ def virtualmin_server_test_connection(request: HttpRequest) -> HttpResponse:
 
         # Create a temporary server instance for testing
         temp_server = VirtualminServer(
-            hostname=hostname, api_port=int(api_port), api_username=api_username, use_ssl=use_ssl, ssl_verify=ssl_verify
+            hostname=hostname,
+            api_port=int(api_port),
+            api_username=api_username,
+            use_ssl=use_ssl,
+            ssl_verify=ssl_verify,
+            ssl_cert_fingerprint=ssl_cert_fingerprint,
         )
         # Set the password using the proper method (handles encryption)
         temp_server.set_api_password(api_password)

--- a/services/platform/config/settings/base.py
+++ b/services/platform/config/settings/base.py
@@ -406,6 +406,7 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET")
 # ✅ Virtualmin settings migrated to Settings UI!
 # Visit: /app/settings/dashboard/ → Provisioning & Infrastructure
 # Credentials are stored in the encrypted credential vault.
+PRAHO_SSH_KNOWN_HOSTS_PATH = os.environ.get("PRAHO_SSH_KNOWN_HOSTS_PATH", "")
 
 # e-Factura API settings
 EFACTURA_API_URL = os.environ.get("EFACTURA_API_URL")

--- a/services/platform/infrastructure/ansible/ansible.cfg
+++ b/services/platform/infrastructure/ansible/ansible.cfg
@@ -3,7 +3,7 @@
 
 [defaults]
 inventory = inventory/
-host_key_checking = False
+host_key_checking = True
 retry_files_enabled = False
 gathering = smart
 fact_caching = jsonfile
@@ -24,7 +24,7 @@ timeout = 30
 remote_user = root
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 pipelining = True
 

--- a/services/platform/templates/infrastructure/deployment_detail.html
+++ b/services/platform/templates/infrastructure/deployment_detail.html
@@ -25,11 +25,13 @@
                         {% icon "arrow-up" css_class="inline mr-1" %}
                         {% trans "Upgrade" %}
                     </a>
-                    <a href="{% url 'infrastructure:deployment_maintenance' deployment.id %}"
-                       class="px-4 py-2 bg-slate-600 hover:bg-slate-500 text-white rounded-lg transition-colors">
-                        {% icon "settings" css_class="inline mr-1" %}
-                        {% trans "Maintenance" %}
-                    </a>
+                    {% if can_deploy %}
+                        <a href="{% url 'infrastructure:deployment_maintenance' deployment.id %}"
+                           class="px-4 py-2 bg-slate-600 hover:bg-slate-500 text-white rounded-lg transition-colors">
+                            {% icon "settings" css_class="inline mr-1" %}
+                            {% trans "Maintenance" %}
+                        </a>
+                    {% endif %}
                     <form method="post" action="{% url 'infrastructure:deployment_reboot' deployment.id %}" class="inline"
                           onsubmit="return confirm('{% trans "Reboot this node? Active connections will be interrupted." %}')">
                         {% csrf_token %}

--- a/services/platform/templates/provisioning/virtualmin/server_form.html
+++ b/services/platform/templates/provisioning/virtualmin/server_form.html
@@ -206,6 +206,16 @@
                                                 {{ form.ssl_verify.label }}
                                             </label>
                                         </div>
+
+                                        <div>
+                                            <label for="{{ form.ssl_cert_fingerprint.id_for_label }}" class="block text-sm font-medium text-slate-300 mb-2">
+                                                {{ form.ssl_cert_fingerprint.label }}
+                                            </label>
+                                            {{ form.ssl_cert_fingerprint }}
+                                            {% if form.ssl_cert_fingerprint.errors %}
+                                            <p class="mt-1 text-sm text-red-400">{{ form.ssl_cert_fingerprint.errors.0 }}</p>
+                                            {% endif %}
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/services/platform/tests/common/test_outbound_http.py
+++ b/services/platform/tests/common/test_outbound_http.py
@@ -21,6 +21,8 @@ from apps.common.outbound_http import (
     _log_dns_fallback,
     clear_internal_service_policy_cache,
     get_internal_service_policy,
+    safe_request,
+    safe_urlopen,
     validate_and_resolve,
 )
 
@@ -457,6 +459,66 @@ class TestDNSFallback(TestCase):
         mock_logger.error.assert_called_once()
         call_args = mock_logger.error.call_args
         self.assertIn("Audit logging failed", call_args[0][0])
+
+
+class TestTLSFingerprintPinning(TestCase):
+    """Certificate pins must be enforced by urllib3 before HTTP bytes are sent."""
+
+    def test_pinned_adapter_passes_sha256_fingerprint_to_connection_pool(self):
+        fingerprint = "ab" * 32
+
+        adapter = PinnedIPAdapter(
+            pinned_ip=MOCK_PUBLIC_IP,
+            hostname="virtualmin.example.com",
+            port=10000,
+            tls_cert_fingerprint=fingerprint,
+        )
+
+        self.assertEqual(adapter.poolmanager.connection_pool_kw["assert_fingerprint"], fingerprint)
+
+    @patch("apps.common.outbound_http.requests.Session.send")
+    @patch("apps.common.outbound_http.validate_and_resolve")
+    def test_invalid_sha256_fingerprint_is_rejected_before_send(
+        self,
+        mock_validate: MagicMock,
+        mock_send: MagicMock,
+    ) -> None:
+        mock_validate.return_value = ResolvedTarget(
+            original_url="https://virtualmin.example.com:10000/remote.cgi",
+            scheme="https",
+            hostname="virtualmin.example.com",
+            port=10000,
+            path="/remote.cgi",
+            pinned_ips=[MOCK_PUBLIC_IP],
+        )
+        policy = OutboundPolicy(name="virtualmin", tls_cert_fingerprint="not-a-sha256-fingerprint")
+
+        with self.assertRaises(OutboundSecurityError):
+            safe_request("GET", mock_validate.return_value.original_url, policy=policy)
+
+        mock_send.assert_not_called()
+
+    @patch("apps.common.outbound_http.urllib.request.urlopen")
+    @patch("apps.common.outbound_http.validate_and_resolve")
+    def test_urlopen_rejects_fingerprint_policy_it_cannot_enforce(
+        self,
+        mock_validate: MagicMock,
+        mock_urlopen: MagicMock,
+    ) -> None:
+        mock_validate.return_value = ResolvedTarget(
+            original_url="https://virtualmin.example.com:10000/",
+            scheme="https",
+            hostname="virtualmin.example.com",
+            port=10000,
+            path="/",
+            pinned_ips=[MOCK_PUBLIC_IP],
+        )
+        policy = OutboundPolicy(name="fingerprinted", tls_cert_fingerprint="ab" * 32)
+
+        with self.assertRaises(OutboundSecurityError):
+            safe_urlopen(mock_validate.return_value.original_url, policy=policy)
+
+        mock_urlopen.assert_not_called()
 
 
 class TestInternalServicePolicy(TestCase):

--- a/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
+++ b/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
@@ -379,7 +379,7 @@ class TestDestroyNodeAtomicTransition(TestCase):
         self.assertTrue(result.is_err())
         self.assertIn("Cannot destroy", result.unwrap_err())
 
-    def test_destroy_revokes_vault_key_through_real_manager_contract(self) -> None:
+    def test_destroy_pins_renamed_vault_key_deletion_method_signature(self) -> None:
         deployment = _create_deployment("completed")
         service = _make_service()
 
@@ -632,3 +632,27 @@ class TestMaintenanceStatusCheck(TestCase):
         self.assertTrue(result.is_err())
         self.assertIn("Unsupported maintenance action", result.unwrap_err())
         service._ansible.run_playbook.assert_not_called()
+
+
+class TestDestroyClearsExternalIdForRetryIdempotency(TestCase):
+    """MEDIUM-4: after the cloud VM is deleted, external_node_id must be cleared
+    so a destroy retry (triggered by a later vault-revocation failure) does not
+    re-invoke delete_server against an already-deleted VM."""
+
+    def test_destroy_clears_external_node_id_after_cloud_deletion(self) -> None:
+        deployment = _create_deployment("completed", external_node_id="srv-123")
+        service = _make_service()
+        # Vault revocation FAILS after cloud deletion succeeds -> destroy returns Err.
+        service._ssh_manager.delete_deployment_key.return_value = Err("vault unavailable")
+
+        mock_gateway = MagicMock()
+        mock_gateway.delete_server.return_value = Ok(True)
+        mock_gateway.delete_ssh_key.return_value = Ok(True)
+
+        with patch("apps.infrastructure.deployment_service.get_cloud_gateway", return_value=mock_gateway):
+            result = service.destroy_node(deployment, credentials={"api_token": "tok"})
+
+        self.assertTrue(result.is_err())
+        mock_gateway.delete_server.assert_called_once_with("srv-123")
+        deployment.refresh_from_db()
+        self.assertEqual(deployment.external_node_id, "")

--- a/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
+++ b/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from apps.common.types import Err, Ok
@@ -111,6 +110,7 @@ def _make_service() -> NodeDeploymentService:
     with patch("apps.infrastructure.deployment_service.get_ansible_service", return_value=MagicMock()):
         service = NodeDeploymentService()
     service._ssh_manager = MagicMock()
+    service._ssh_manager.delete_deployment_key.return_value = Ok(True)
     service._ansible = MagicMock()
     service._validation = MagicMock()
     service._registration = MagicMock()
@@ -171,7 +171,7 @@ class TestTransientErrorPreservesExternalId(TestCase):
             patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True),
             patch("apps.infrastructure.deployment_service.get_cloud_gateway", return_value=mock_gateway),
         ):
-            result = service.deploy_node(
+            service.deploy_node(
                 deployment=deployment,
                 credentials={"api_token": "test-token"},
             )
@@ -378,6 +378,27 @@ class TestDestroyNodeAtomicTransition(TestCase):
 
         self.assertTrue(result.is_err())
         self.assertIn("Cannot destroy", result.unwrap_err())
+
+    def test_destroy_revokes_vault_key_through_real_manager_contract(self) -> None:
+        deployment = _create_deployment("completed")
+        service = _make_service()
+
+        result = service.destroy_node(deployment=deployment, credentials={})
+
+        self.assertTrue(result.is_ok())
+        service._ssh_manager.delete_deployment_key.assert_called_once_with(deployment, user=None)
+
+    def test_destroy_fails_closed_when_vault_key_revocation_fails(self) -> None:
+        deployment = _create_deployment("completed")
+        service = _make_service()
+        service._ssh_manager.delete_deployment_key.return_value = Err("vault unavailable")
+
+        result = service.destroy_node(deployment=deployment, credentials={})
+
+        self.assertTrue(result.is_err())
+        self.assertIn("vault unavailable", result.unwrap_err())
+        deployment.refresh_from_db()
+        self.assertNotEqual(deployment.status, "destroyed")
 
 
 # ===========================================================================
@@ -587,3 +608,27 @@ class TestMaintenanceStatusCheck(TestCase):
 
         self.assertTrue(result.is_err())
         self.assertIn("Can only run maintenance on completed", result.unwrap_err())
+
+    def test_security_action_maps_to_panel_owned_playbook(self) -> None:
+        deployment = _create_deployment("completed")
+        service = _make_service()
+        service._ansible.run_playbook.return_value = Ok(MagicMock(success=True))
+
+        result = service.run_maintenance(deployment=deployment, playbooks=["security"])
+
+        self.assertTrue(result.is_ok())
+        service._ansible.run_playbook.assert_called_once_with(
+            deployment=deployment,
+            playbook="virtualmin_harden.yml",
+            extra_vars=None,
+        )
+
+    def test_unknown_maintenance_action_is_rejected_before_ansible(self) -> None:
+        deployment = _create_deployment("completed")
+        service = _make_service()
+
+        result = service.run_maintenance(deployment=deployment, playbooks=["../ansible.cfg"])
+
+        self.assertTrue(result.is_err())
+        self.assertIn("Unsupported maintenance action", result.unwrap_err())
+        service._ansible.run_playbook.assert_not_called()

--- a/services/platform/tests/infrastructure/test_provider_views.py
+++ b/services/platform/tests/infrastructure/test_provider_views.py
@@ -10,7 +10,7 @@ remediation approval transactional safety.
 from __future__ import annotations
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
@@ -254,6 +254,41 @@ class TestDeploymentDetailProgress(_DeploymentTestMixin, TestCase):
         self.assertIsInstance(response.context["stages"], list)
         # progress_percentage=15, 15//16=0 → progress_step=0
         self.assertEqual(response.context["progress_step"], 0)
+
+
+class TestDeploymentMaintenanceSecurity(_DeploymentTestMixin, TestCase):
+    """Root-level maintenance requires deploy permission and semantic action IDs."""
+
+    def setUp(self) -> None:
+        self.deployment = self._create_deployment(status="completed")
+        self.url = reverse("infrastructure:deployment_maintenance", args=[self.deployment.pk])
+
+    def test_staff_without_deploy_permission_is_forbidden(self) -> None:
+        staff = User.objects.create_user(email="staff@test.com", password="testpass123", is_staff=True)
+        self.client.force_login(staff)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_only_implemented_security_action_is_exposed(self) -> None:
+        superuser = User.objects.create_superuser(email="admin@test.com", password="testpass123")
+        self.client.force_login(superuser)
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([option["id"] for option in response.context["playbook_options"]], ["security"])
+
+    @patch("apps.infrastructure.views.queue_maintenance")
+    def test_unknown_action_is_rejected_before_queueing(self, mock_queue: MagicMock) -> None:
+        superuser = User.objects.create_superuser(email="admin@test.com", password="testpass123")
+        self.client.force_login(superuser)
+
+        response = self.client.post(self.url, {"playbooks": ["../ansible.cfg"]})
+
+        self.assertEqual(response.status_code, 200)
+        mock_queue.assert_not_called()
 
 
 class TestDriftDashboardCounts(_DeploymentTestMixin, TestCase):

--- a/services/platform/tests/infrastructure/test_registration_tls_pin.py
+++ b/services/platform/tests/infrastructure/test_registration_tls_pin.py
@@ -1,0 +1,87 @@
+"""Regression tests for trusted Virtualmin certificate pin registration."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from apps.common.types import Err, Ok
+from apps.infrastructure.registration_service import NodeRegistrationService
+
+
+class NodeRegistrationTLSPinTests(TestCase):
+    """Auto-registered self-signed nodes must remain reachable without trusting TOFU."""
+
+    def _deployment(self) -> MagicMock:
+        deployment = MagicMock()
+        deployment.status = "registering"
+        deployment.ipv4_address = "203.0.113.10"
+        deployment.virtualmin_server = None
+        deployment.hostname = "prd-sha-tst-de-tst1-001"
+        deployment.fqdn = "prd-sha-tst-de-tst1-001.example.com"
+        deployment.id = 1
+        deployment.node_size.max_domains = 50
+        deployment.node_size.max_bandwidth_gb = 1000
+        return deployment
+
+    @patch("apps.provisioning.virtualmin_models.VirtualminServer")
+    @patch("apps.infrastructure.validation_service.get_validation_service")
+    def test_registration_persists_certificate_pin_read_over_trusted_ssh(
+        self,
+        mock_get_validation: MagicMock,
+        mock_server_model: MagicMock,
+    ) -> None:
+        fingerprint = "ab" * 32
+        mock_get_validation.return_value.get_webmin_certificate_fingerprint.return_value = Ok(fingerprint)
+        mock_server_model.objects.filter.return_value.exists.return_value = False
+        mock_server_model.objects.create.return_value = MagicMock(id=7)
+
+        result = NodeRegistrationService().register_node(self._deployment())
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        self.assertEqual(
+            mock_server_model.objects.create.call_args.kwargs["ssl_cert_fingerprint"],
+            fingerprint,
+        )
+
+    @patch("apps.provisioning.virtualmin_models.VirtualminServer")
+    @patch("apps.infrastructure.validation_service.get_validation_service")
+    def test_registration_fails_closed_when_certificate_pin_cannot_be_verified(
+        self,
+        mock_get_validation: MagicMock,
+        mock_server_model: MagicMock,
+    ) -> None:
+        mock_server_model.objects.filter.return_value.exists.return_value = False
+        mock_get_validation.return_value.get_webmin_certificate_fingerprint.return_value = Err("SSH trust failed")
+
+        result = NodeRegistrationService().register_node(self._deployment())
+
+        self.assertTrue(result.is_err())
+        self.assertIn("certificate fingerprint", result.unwrap_err())
+        mock_server_model.objects.create.assert_not_called()
+
+
+class VirtualminCertificatePinCommandTests(TestCase):
+    """Existing self-signed node records have an explicit trusted migration path."""
+
+    @patch("apps.infrastructure.management.commands.pin_virtualmin_certificates.get_validation_service")
+    @patch("apps.infrastructure.management.commands.pin_virtualmin_certificates.VirtualminServer.objects.filter")
+    def test_command_pins_existing_server_from_trusted_deployment(
+        self,
+        mock_filter: MagicMock,
+        mock_get_validation: MagicMock,
+    ) -> None:
+        server = MagicMock(id=7, hostname="node.example.com", node_deployment=MagicMock())
+        mock_filter.return_value = [server]
+        fingerprint = "cd" * 32
+        mock_get_validation.return_value.get_webmin_certificate_fingerprint.return_value = Ok(fingerprint)
+        stdout = StringIO()
+
+        call_command("pin_virtualmin_certificates", stdout=stdout)
+
+        self.assertEqual(server.ssl_cert_fingerprint, fingerprint)
+        server.save.assert_called_once_with(update_fields=["ssl_cert_fingerprint", "updated_at"])
+        self.assertIn("Pinned 1 Virtualmin certificate", stdout.getvalue())

--- a/services/platform/tests/infrastructure/test_security_hardening.py
+++ b/services/platform/tests/infrastructure/test_security_hardening.py
@@ -1,0 +1,156 @@
+"""Regression tests for infrastructure trust-boundary hardening."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import paramiko
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from apps.common.performance.connection_pool import SSHConnectionPool
+from apps.common.types import Ok
+from apps.infrastructure.ansible_service import ANSIBLE_BASE_PATH, AnsibleService
+from apps.infrastructure.ssh_key_manager import SSHKeyManager, SSHKeyPair
+from apps.infrastructure.validation_service import NodeValidationService
+
+
+class AnsiblePlaybookBoundaryTests(SimpleTestCase):
+    """Only repository-owned playbooks may reach root-level Ansible execution."""
+
+    def _service(self) -> AnsibleService:
+        service = object.__new__(AnsibleService)
+        service.timeout = 30
+        service._ansible_path = "/usr/bin/ansible-playbook"
+        service._ssh_manager = MagicMock()
+        return service
+
+    def test_path_traversal_is_rejected_before_ssh_key_access(self) -> None:
+        service = self._service()
+        deployment = MagicMock(ipv4_address="203.0.113.10")
+
+        result = service.run_playbook(deployment, "../ansible.cfg")
+
+        self.assertTrue(result.is_err())
+        self.assertIn("not allowed", result.unwrap_err().lower())
+        service._ssh_manager.get_private_key_file.assert_not_called()
+
+    @patch("apps.infrastructure.ansible_service.subprocess.run")
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_ansible_host_key_checking_is_enabled(self, mock_run: MagicMock) -> None:
+        service = self._service()
+        service._ssh_manager.get_private_key_file.return_value = Ok(Path("nonexistent-praho-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10", hostname="node.example.com")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch.object(service, "_generate_inventory", return_value=Path("nonexistent-praho-inventory")),
+            patch.object(service, "_build_vars", return_value={}),
+        ):
+            result = service.run_playbook(deployment, "virtualmin_harden.yml")
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(mock_run.call_args.kwargs["env"]["ANSIBLE_HOST_KEY_CHECKING"], "True")
+        self.assertIn(
+            "UserKnownHostsFile=/etc/praho/known_hosts",
+            mock_run.call_args.kwargs["env"]["ANSIBLE_SSH_COMMON_ARGS"],
+        )
+
+    def test_repository_ansible_config_does_not_disable_host_key_checking(self) -> None:
+        config = (ANSIBLE_BASE_PATH / "ansible.cfg").read_text()
+
+        self.assertIn("host_key_checking = True", config)
+        self.assertNotIn("StrictHostKeyChecking=no", config)
+
+
+class InfrastructureSSHTrustTests(SimpleTestCase):
+    """Validation SSH connections must use pre-provisioned known-host trust."""
+
+    @patch("apps.infrastructure.validation_service.paramiko.Ed25519Key.from_private_key")
+    @patch("apps.infrastructure.validation_service.paramiko.SSHClient")
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_validation_rejects_unknown_host_keys(
+        self,
+        mock_client_class: MagicMock,
+        _mock_private_key: MagicMock,
+    ) -> None:
+        service = object.__new__(NodeValidationService)
+        service.timeout = 10
+        service._ssh_manager = MagicMock()
+        service._ssh_manager.get_deployment_key.return_value = Ok(MagicMock(private_key="private-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10")
+        client = mock_client_class.return_value
+        stdout = MagicMock()
+        stdout.read.return_value = b"node.example.com"
+        client.exec_command.return_value = (MagicMock(), stdout, MagicMock())
+
+        result = service._check_ssh(deployment)
+
+        self.assertTrue(result.passed)
+        client.load_system_host_keys.assert_called_once_with()
+        client.load_host_keys.assert_called_once_with("/etc/praho/known_hosts")
+        policy = client.set_missing_host_key_policy.call_args.args[0]
+        self.assertIsInstance(policy, paramiko.RejectPolicy)
+
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_shared_ssh_pool_rejects_unknown_host_keys(self) -> None:
+        pool = object.__new__(SSHConnectionPool)
+        pool._paramiko = MagicMock()
+        pool.max_connections = 1
+        pool.idle_timeout = 30
+        pool._connections = {}
+        import threading  # noqa: PLC0415
+
+        pool._lock = threading.Lock()
+        client = pool._paramiko.SSHClient.return_value
+
+        pool.get_connection("node.example.com", "root", password="secret")
+
+        client.load_system_host_keys.assert_called_once_with()
+        client.load_host_keys.assert_called_once_with("/etc/praho/known_hosts")
+        client.set_missing_host_key_policy.assert_called_once_with(pool._paramiko.RejectPolicy.return_value)
+
+
+class SSHKeyLifecycleAuditTests(TestCase):
+    """Key creation and revocation must leave sensitive audit evidence."""
+
+    @patch("apps.infrastructure.audit_service.InfrastructureAuditService.log_ssh_key_generated")
+    def test_generation_is_audited(self, mock_audit: MagicMock) -> None:
+        manager = SSHKeyManager()
+        manager._vault = MagicMock()
+        manager._vault.store_credential.return_value = Ok(MagicMock(id="credential-id"))
+        deployment = MagicMock(hostname="node.example.com", id=42)
+        key_pair = SSHKeyPair(public_key="ssh-ed25519 AAAA", private_key="private", fingerprint="SHA256:test")
+
+        with patch.object(manager, "generate_key_pair", return_value=key_pair):
+            result = manager.generate_deployment_key(deployment)
+
+        self.assertTrue(result.is_ok())
+        mock_audit.assert_called_once()
+        self.assertEqual(mock_audit.call_args.args[:2], (deployment, "SHA256:test"))
+
+    @patch("apps.infrastructure.audit_service.InfrastructureAuditService.log_ssh_key_revoked")
+    @patch("apps.infrastructure.ssh_key_manager.EncryptedCredential.objects.get")
+    def test_revocation_is_audited(self, mock_get: MagicMock, mock_audit: MagicMock) -> None:
+        manager = SSHKeyManager()
+        deployment = MagicMock(hostname="node.example.com", ssh_key_credential_id="credential-id")
+        mock_get.return_value = MagicMock()
+
+        result = manager.delete_deployment_key(deployment)
+
+        self.assertTrue(result.is_ok())
+        mock_audit.assert_called_once()
+        self.assertEqual(mock_audit.call_args.args[0], deployment)
+
+    def test_private_key_file_preserves_ansible_access_reason(self) -> None:
+        manager = SSHKeyManager()
+        deployment = MagicMock(hostname="node.example.com")
+        key_pair = SSHKeyPair(public_key="ssh-ed25519 AAAA", private_key="private", fingerprint="SHA256:test")
+
+        with patch.object(manager, "get_deployment_key", return_value=Ok(key_pair)) as mock_get_key:
+            result = manager.get_private_key_file(deployment, reason="Ansible playbook: virtualmin_harden.yml")
+
+        self.assertTrue(result.is_ok())
+        key_file = result.unwrap()
+        self.addCleanup(key_file.unlink, missing_ok=True)
+        mock_get_key.assert_called_once_with(deployment, None, "Ansible playbook: virtualmin_harden.yml")

--- a/services/platform/tests/infrastructure/test_security_hardening.py
+++ b/services/platform/tests/infrastructure/test_security_hardening.py
@@ -9,7 +9,7 @@ import paramiko
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from apps.common.performance.connection_pool import SSHConnectionPool
-from apps.common.types import Ok
+from apps.common.types import Err, Ok
 from apps.infrastructure.ansible_service import ANSIBLE_BASE_PATH, AnsibleService
 from apps.infrastructure.ssh_key_manager import SSHKeyManager, SSHKeyPair
 from apps.infrastructure.validation_service import NodeValidationService
@@ -55,6 +55,23 @@ class AnsiblePlaybookBoundaryTests(SimpleTestCase):
             "UserKnownHostsFile=/etc/praho/known_hosts",
             mock_run.call_args.kwargs["env"]["ANSIBLE_SSH_COMMON_ARGS"],
         )
+
+    @patch.dict(
+        "os.environ",
+        {
+            "ANSIBLE_SSH_COMMON_ARGS": (
+                "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/var/lib/praho/untrusted-known-hosts"
+            )
+        },
+    )
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_ansible_environment_cannot_weaken_host_key_checking(self) -> None:
+        ansible_env = AnsibleService._build_ansible_env()
+
+        self.assertNotIn("StrictHostKeyChecking=no", ansible_env["ANSIBLE_SSH_COMMON_ARGS"])
+        self.assertNotIn("/var/lib/praho/untrusted-known-hosts", ansible_env["ANSIBLE_SSH_COMMON_ARGS"])
+        self.assertIn("StrictHostKeyChecking=yes", ansible_env["ANSIBLE_SSH_COMMON_ARGS"])
+        self.assertIn("UserKnownHostsFile=/etc/praho/known_hosts", ansible_env["ANSIBLE_SSH_COMMON_ARGS"])
 
     def test_repository_ansible_config_does_not_disable_host_key_checking(self) -> None:
         config = (ANSIBLE_BASE_PATH / "ansible.cfg").read_text()
@@ -109,6 +126,44 @@ class InfrastructureSSHTrustTests(SimpleTestCase):
         client.load_system_host_keys.assert_called_once_with()
         client.load_host_keys.assert_called_once_with("/etc/praho/known_hosts")
         client.set_missing_host_key_policy.assert_called_once_with(pool._paramiko.RejectPolicy.return_value)
+
+    @patch("apps.infrastructure.validation_service.paramiko.Ed25519Key.from_private_key")
+    @patch("apps.infrastructure.validation_service.paramiko.SSHClient")
+    def test_webmin_certificate_pin_is_read_over_trusted_ssh(
+        self,
+        mock_client_class: MagicMock,
+        _mock_private_key: MagicMock,
+    ) -> None:
+        service = object.__new__(NodeValidationService)
+        service.timeout = 10
+        service._ssh_manager = MagicMock()
+        service._ssh_manager.get_deployment_key.return_value = Ok(MagicMock(private_key="private-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10")
+        client = mock_client_class.return_value
+        stdout = MagicMock()
+        stdout.read.return_value = b"sha256 Fingerprint=" + b"AA:" * 31 + b"BB\n"
+        stdout.channel.recv_exit_status.return_value = 0
+        client.exec_command.return_value = (MagicMock(), stdout, MagicMock())
+
+        result = service.get_webmin_certificate_fingerprint(deployment)
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        self.assertEqual(result.unwrap(), "aa" * 31 + "bb")
+        client.exec_command.assert_called_once_with(
+            "openssl s_client -connect 127.0.0.1:10000 </dev/null 2>/dev/null "
+            "| openssl x509 -noout -fingerprint -sha256",
+            timeout=10,
+        )
+        client.close.assert_called_once_with()
+
+    def test_webmin_certificate_pin_fails_closed_without_node_address(self) -> None:
+        service = object.__new__(NodeValidationService)
+        service.timeout = 10
+        service._ssh_manager = MagicMock()
+
+        result = service.get_webmin_certificate_fingerprint(MagicMock(ipv4_address=None))
+
+        self.assertEqual(result, Err("Node has no IP address assigned"))
 
 
 class SSHKeyLifecycleAuditTests(TestCase):

--- a/services/platform/tests/infrastructure/test_security_hardening.py
+++ b/services/platform/tests/infrastructure/test_security_hardening.py
@@ -109,6 +109,32 @@ class InfrastructureSSHTrustTests(SimpleTestCase):
         policy = client.set_missing_host_key_policy.call_args.args[0]
         self.assertIsInstance(policy, paramiko.RejectPolicy)
 
+    @patch("apps.infrastructure.validation_service.paramiko.Ed25519Key.from_private_key")
+    @patch("apps.infrastructure.validation_service.paramiko.SSHClient")
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_host_key_mismatch_reading_webmin_cert_surfaces_as_mitm(
+        self,
+        mock_client_class: MagicMock,
+        _mock_private_key: MagicMock,
+    ) -> None:
+        """HIGH-1: a changed SSH host key while reading the Webmin cert is the
+        MITM signal this verified-SSH path exists to catch — it must return a
+        distinct, MITM-scoped error, not generic connection friction."""
+        service = object.__new__(NodeValidationService)
+        service.timeout = 10
+        service._ssh_manager = MagicMock()
+        service._ssh_manager.get_deployment_key.return_value = Ok(MagicMock(private_key="private-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10", hostname="node.example.com")
+        client = mock_client_class.return_value
+        client.connect.side_effect = paramiko.BadHostKeyException(
+            "203.0.113.10", MagicMock(), MagicMock()
+        )
+
+        result = service.get_webmin_certificate_fingerprint(deployment)
+
+        self.assertTrue(result.is_err())
+        self.assertIn("MITM", result.unwrap_err())
+
     @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
     def test_shared_ssh_pool_rejects_unknown_host_keys(self) -> None:
         pool = object.__new__(SSHConnectionPool)

--- a/services/platform/tests/provisioning/test_auth_manager_regressions.py
+++ b/services/platform/tests/provisioning/test_auth_manager_regressions.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, call, patch
 import paramiko
 from django.test import TestCase, override_settings
 
-from apps.common.types import Err, Ok
+from apps.common.types import Err, Ok, Retriability, retriability_of
 from apps.provisioning.virtualmin_auth_manager import (
     AuthMethod,
     VirtualminAuthenticationManager,
@@ -99,6 +99,24 @@ class ExecuteWithMethodDispatchTests(TestCase):
         self.assertTrue(result.is_err())
         mock_execute.assert_called_once_with(AuthMethod.ACL, "create-domain", {})
 
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_non_authentication_error_preserves_retriability(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+    ) -> None:
+        mock_priority.return_value = [AuthMethod.ACL]
+        mock_execute.return_value = Err(
+            VirtualminAPIError("rate limited"),
+            retriability=Retriability.RETRIABLE,
+        )
+
+        result = self.manager.execute_virtualmin_command("create-domain", {})
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(retriability_of(result), Retriability.RETRIABLE)
+
     @patch.object(VirtualminAuthenticationManager, "_cache_working_auth_method")
     @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
     @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
@@ -132,6 +150,29 @@ class ExecuteWithMethodDispatchTests(TestCase):
 
         self.assertTrue(result.is_err())
         self.assertIsInstance(result.unwrap_err(), VirtualminAuthError)
+
+    @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
+    def test_acl_preserves_gateway_retriability(self, mock_call: MagicMock) -> None:
+        mock_call.return_value = Err(
+            VirtualminAPIError("rate limited"),
+            retriability=Retriability.RETRIABLE,
+        )
+
+        result = self.manager._execute_acl_auth("list-domains", {})
+
+        self.assertEqual(retriability_of(result), Retriability.RETRIABLE)
+
+    @override_settings(VIRTUALMIN_MASTER_USERNAME="root", VIRTUALMIN_MASTER_PASSWORD="secret")
+    @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
+    def test_master_proxy_preserves_gateway_retriability(self, mock_call: MagicMock) -> None:
+        mock_call.return_value = Err(
+            VirtualminAPIError("rate limited"),
+            retriability=Retriability.RETRIABLE,
+        )
+
+        result = self.manager._execute_master_proxy("list-domains", {})
+
+        self.assertEqual(retriability_of(result), Retriability.RETRIABLE)
 
     @override_settings(VIRTUALMIN_SSH_PASSWORD="test-password")
     @patch("apps.provisioning.virtualmin_auth_manager.paramiko.SSHClient")

--- a/services/platform/tests/provisioning/test_auth_manager_regressions.py
+++ b/services/platform/tests/provisioning/test_auth_manager_regressions.py
@@ -19,7 +19,13 @@ from apps.provisioning.virtualmin_auth_manager import (
     AuthMethod,
     VirtualminAuthenticationManager,
 )
-from apps.provisioning.virtualmin_gateway import VirtualminAPIError, VirtualminAuthError
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminAPIError,
+    VirtualminAuthError,
+    VirtualminAuthorizationError,
+    VirtualminGateway,
+    VirtualminRateLimitedError,
+)
 
 
 class ExecuteWithMethodDispatchTests(TestCase):
@@ -152,6 +158,28 @@ class ExecuteWithMethodDispatchTests(TestCase):
         self.assertIsInstance(result.unwrap_err(), VirtualminAuthError)
 
     @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
+    def test_acl_preserves_retriability_of_raised_rate_limit(self, mock_call: MagicMock) -> None:
+        # gateway.call RAISES the rate-limit error (429 is not a RequestException,
+        # so the gateway retry loop does not catch it). The conversion to Err must
+        # keep it RETRIABLE, or a rate-limited request is treated as terminal.
+        mock_call.side_effect = VirtualminRateLimitedError("429", "host", "list-domains")
+
+        result = self.manager._execute_acl_auth("list-domains", {})
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(retriability_of(result), Retriability.RETRIABLE)
+
+    @override_settings(VIRTUALMIN_MASTER_USERNAME="root", VIRTUALMIN_MASTER_PASSWORD="secret")
+    @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
+    def test_master_proxy_preserves_retriability_of_raised_rate_limit(self, mock_call: MagicMock) -> None:
+        mock_call.side_effect = VirtualminRateLimitedError("429", "host", "list-domains")
+
+        result = self.manager._execute_master_proxy("list-domains", {})
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(retriability_of(result), Retriability.RETRIABLE)
+
+    @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
     def test_acl_preserves_gateway_retriability(self, mock_call: MagicMock) -> None:
         mock_call.return_value = Err(
             VirtualminAPIError("rate limited"),
@@ -194,3 +222,62 @@ class ExecuteWithMethodDispatchTests(TestCase):
         mock_execute.assert_called_once_with(
             "sudo /usr/sbin/virtualmin create-domain --domain 'example.com; touch /tmp/pwned'"
         )
+
+
+class AuthorizationDenialDoesNotEscalateTests(TestCase):
+    """403 ACL authorization denial must be terminal. Escalating to master/root
+    would bypass the ACL the node deliberately enforced — and, against a
+    compromised node returning 403, would hand it master credentials."""
+
+    def setUp(self) -> None:
+        self.mock_server = MagicMock()
+        self.mock_server.hostname = "node.example.com"
+        self.mock_server.id = 7
+        self.manager = VirtualminAuthenticationManager(self.mock_server)
+
+    @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_authorization_denial_never_escalates(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+        _cache_failed: MagicMock,
+    ) -> None:
+        mock_priority.return_value = [AuthMethod.ACL, AuthMethod.MASTER_PROXY, AuthMethod.SSH_SUDO]
+        # ACL account authenticated but is forbidden (403); master would succeed
+        # but must never be reached.
+        mock_execute.side_effect = [
+            Err(VirtualminAuthorizationError("Access forbidden - check ACL permissions")),
+            Ok({"success": True}),
+        ]
+
+        result = self.manager.execute_virtualmin_command("delete-domain", {})
+
+        self.assertTrue(result.is_err())
+        mock_execute.assert_called_once_with(AuthMethod.ACL, "delete-domain", {})
+
+
+class GatewayHttpStatusClassificationTests(TestCase):
+    """401 (authentication) and 403 (authorization) must be distinct types so the
+    auth manager can escalate on the former but never the latter."""
+
+    @staticmethod
+    def _gateway_and_response(status_code: int) -> tuple[VirtualminGateway, MagicMock]:
+        gateway = object.__new__(VirtualminGateway)
+        gateway.server = MagicMock()
+        gateway.server.hostname = "node.example.com"
+        response = MagicMock()
+        response.status_code = status_code
+        return gateway, response
+
+    def test_401_maps_to_authentication_error_not_authorization(self) -> None:
+        gateway, response = self._gateway_and_response(401)
+        with self.assertRaises(VirtualminAuthError) as ctx:
+            gateway._validate_http_status(response)
+        self.assertNotIsInstance(ctx.exception, VirtualminAuthorizationError)
+
+    def test_403_maps_to_authorization_error(self) -> None:
+        gateway, response = self._gateway_and_response(403)
+        with self.assertRaises(VirtualminAuthorizationError):
+            gateway._validate_http_status(response)

--- a/services/platform/tests/provisioning/test_auth_manager_regressions.py
+++ b/services/platform/tests/provisioning/test_auth_manager_regressions.py
@@ -9,15 +9,17 @@ Covers:
 from __future__ import annotations
 
 from enum import Enum
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from django.test import TestCase
+import paramiko
+from django.test import TestCase, override_settings
 
-from apps.common.types import Ok
+from apps.common.types import Err, Ok
 from apps.provisioning.virtualmin_auth_manager import (
     AuthMethod,
     VirtualminAuthenticationManager,
 )
+from apps.provisioning.virtualmin_gateway import VirtualminAPIError, VirtualminAuthError
 
 
 class ExecuteWithMethodDispatchTests(TestCase):
@@ -78,3 +80,76 @@ class ExecuteWithMethodDispatchTests(TestCase):
 
         mock_ssh.assert_called_once_with("create-domain", {"domain": "test.com"})
         self.assertEqual(result, expected)
+
+    @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_non_authentication_error_never_escalates_privileges(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+        _mock_cache_failed: MagicMock,
+    ) -> None:
+        mock_priority.return_value = [AuthMethod.ACL, AuthMethod.MASTER_PROXY, AuthMethod.SSH_SUDO]
+        error = VirtualminAPIError("validation failed")
+        mock_execute.return_value = Err(error)
+
+        result = self.manager.execute_virtualmin_command("create-domain", {})
+
+        self.assertTrue(result.is_err())
+        mock_execute.assert_called_once_with(AuthMethod.ACL, "create-domain", {})
+
+    @patch.object(VirtualminAuthenticationManager, "_cache_working_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_authentication_error_may_use_next_configured_method(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+        _mock_cache_failed: MagicMock,
+        _mock_cache_working: MagicMock,
+    ) -> None:
+        mock_priority.return_value = [AuthMethod.ACL, AuthMethod.MASTER_PROXY]
+        mock_execute.side_effect = [Err(VirtualminAuthError("unauthorized")), Ok({"success": True})]
+
+        result = self.manager.execute_virtualmin_command("list-domains", {})
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(
+            mock_execute.call_args_list,
+            [
+                call(AuthMethod.ACL, "list-domains", {}),
+                call(AuthMethod.MASTER_PROXY, "list-domains", {}),
+            ],
+        )
+
+    @patch("apps.provisioning.virtualmin_auth_manager.VirtualminGateway.call")
+    def test_acl_preserves_raised_typed_authentication_error(self, mock_call: MagicMock) -> None:
+        mock_call.side_effect = VirtualminAuthError("unauthorized")
+
+        result = self.manager._execute_acl_auth("list-domains", {})
+
+        self.assertTrue(result.is_err())
+        self.assertIsInstance(result.unwrap_err(), VirtualminAuthError)
+
+    @override_settings(VIRTUALMIN_SSH_PASSWORD="test-password")
+    @patch("apps.provisioning.virtualmin_auth_manager.paramiko.SSHClient")
+    def test_ssh_rejects_unknown_host_keys(self, mock_client_class: MagicMock) -> None:
+        client = mock_client_class.return_value
+
+        self.manager._connect_ssh()
+
+        client.load_system_host_keys.assert_called_once_with()
+        policy = client.set_missing_host_key_policy.call_args.args[0]
+        self.assertIsInstance(policy, paramiko.RejectPolicy)
+
+    @patch.object(VirtualminAuthenticationManager, "_execute_ssh_command")
+    def test_ssh_command_quotes_untrusted_parameter_values(self, mock_execute: MagicMock) -> None:
+        mock_execute.return_value = Ok("created successfully")
+
+        self.manager._execute_ssh_sudo("create-domain", {"domain": "example.com; touch /tmp/pwned"})
+
+        mock_execute.assert_called_once_with(
+            "sudo /usr/sbin/virtualmin create-domain --domain 'example.com; touch /tmp/pwned'"
+        )

--- a/services/platform/tests/provisioning/test_virtualmin_credentials.py
+++ b/services/platform/tests/provisioning/test_virtualmin_credentials.py
@@ -16,6 +16,7 @@ from django.test import TestCase
 from apps.common.credential_vault import CredentialData, CredentialVault
 from apps.common.types import Err, Ok
 from apps.provisioning.models import Server
+from apps.provisioning.virtualmin_forms import VirtualminServerForm
 from apps.provisioning.virtualmin_gateway import VirtualminConfig, VirtualminGateway, get_virtualmin_config
 from apps.provisioning.virtualmin_models import VirtualminServer
 
@@ -176,6 +177,45 @@ class GetCredentialsNoEnvFallbackTest(TestCase):
         username, password = result.unwrap()
         self.assertEqual(username, "fallback_user")
         self.assertEqual(password, "fallback_pass")
+
+
+class VirtualminServerTLSFormTest(TestCase):
+    """The staff form must not persist credential-bearing insecure transports."""
+
+    def _data(self, **overrides: object) -> dict[str, object]:
+        data: dict[str, object] = {
+            "name": "secure-vmin",
+            "hostname": "vmin.example.com",
+            "api_port": 10000,
+            "api_username": "praho_api",
+            "api_password": "StrongPassword1!",
+            "use_ssl": "on",
+            "ssl_verify": "on",
+            "ssl_cert_fingerprint": "",
+            "status": "active",
+            "max_domains": 100,
+            "max_disk_gb": "",
+            "max_bandwidth_gb": "",
+        }
+        data.update(overrides)
+        return data
+
+    def test_plain_http_configuration_is_rejected(self) -> None:
+        form = VirtualminServerForm(data=self._data(use_ssl=""))
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("use_ssl", form.errors)
+
+    def test_disabling_ca_verification_requires_valid_sha256_pin(self) -> None:
+        form = VirtualminServerForm(data=self._data(ssl_verify="", ssl_cert_fingerprint=""))
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("ssl_cert_fingerprint", form.errors)
+
+    def test_valid_sha256_pin_allows_private_ca_configuration(self) -> None:
+        form = VirtualminServerForm(data=self._data(ssl_verify="", ssl_cert_fingerprint="sha256:" + "ab" * 32))
+
+        self.assertTrue(form.is_valid(), form.errors.as_json())
 
 
 class ConfigDictNoEnvCredentialsTest(TestCase):

--- a/services/platform/tests/provisioning/test_virtualmin_outbound.py
+++ b/services/platform/tests/provisioning/test_virtualmin_outbound.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.core.cache import cache as django_cache
+from django.test import TestCase, override_settings
 
 from apps.provisioning.virtualmin_gateway import (
+    RateLimitOutcome,
     VirtualminAPIError,
     VirtualminConfig,
     VirtualminGateway,
@@ -17,25 +20,25 @@ class VirtualminOutboundTests(TestCase):
     """Verify Virtualmin gateway uses safe_request() with DNS pinning."""
 
     @patch("apps.provisioning.virtualmin_gateway.safe_request")
-    def test_execute_http_request_uses_safe_request(self, mock_safe_request: MagicMock) -> None:
-        """_execute_http_request() must use safe_request()."""
+    def test_execute_http_request_routes_through_safe_request_with_pinning_policy(
+        self, mock_safe_request: MagicMock
+    ) -> None:
+        """_execute_http_request must actually call safe_request with an
+        https-only, pin-carrying policy — not merely exist."""
         mock_response = MagicMock()
         mock_response.status_code = 200
-        mock_response.headers = {"content-length": "100"}
+        mock_response.headers = {"content-length": "20"}
         mock_response.iter_content.return_value = iter([b'{"status":"success"}'])
         mock_safe_request.return_value = mock_response
 
-        # We test the method indirectly through the gateway
-        # The import itself validates the module structure
-        from apps.provisioning.virtualmin_gateway import VirtualminGateway  # noqa: PLC0415
+        gateway = self._gateway(fingerprint="a" * 64)
+        gateway._execute_http_request({"program": "list-domains"})
 
-        self.assertTrue(hasattr(VirtualminGateway, "_execute_http_request"))
-
-    def test_safe_request_import_available(self) -> None:
-        """safe_request must be importable from the gateway module."""
-        import apps.provisioning.virtualmin_gateway as gw  # noqa: PLC0415
-
-        self.assertTrue(hasattr(gw, "safe_request"))
+        self.assertEqual(mock_safe_request.call_count, 1)
+        policy = mock_safe_request.call_args.kwargs["policy"]
+        self.assertTrue(policy.require_https)
+        self.assertEqual(policy.allowed_schemes, frozenset({"https"}))
+        self.assertEqual(policy.tls_cert_fingerprint, "a" * 64)
 
     def _gateway(
         self,
@@ -98,9 +101,9 @@ class VirtualminOutboundTests(TestCase):
         gateway = self._gateway()
         mock_cache.add.side_effect = [False, False, True]
 
-        allowed = gateway._check_rate_limit("create-domain")
+        outcome = gateway._check_rate_limit("create-domain")
 
-        self.assertTrue(allowed)
+        self.assertEqual(outcome, RateLimitOutcome.ALLOWED)
         self.assertEqual(mock_cache.add.call_count, 3)
         mock_cache.get.assert_not_called()
         mock_cache.set.assert_not_called()
@@ -113,7 +116,7 @@ class VirtualminOutboundTests(TestCase):
         gateway = self._gateway()
         mock_cache.add.return_value = False
 
-        self.assertFalse(gateway._check_rate_limit("create-domain"))
+        self.assertEqual(gateway._check_rate_limit("create-domain"), RateLimitOutcome.EXHAUSTED)
         self.assertEqual(mock_cache.add.call_count, VIRTUALMIN_RATE_LIMIT_MAX_CALLS)
         mock_cache.incr.assert_not_called()
 
@@ -122,4 +125,54 @@ class VirtualminOutboundTests(TestCase):
         gateway = self._gateway()
         mock_cache.add.side_effect = RuntimeError("cache unavailable")
 
-        self.assertFalse(gateway._check_rate_limit("create-domain"))
+        # HIGH-2: a backend failure is distinct from genuine exhaustion so the
+        # caller can avoid reporting it as a retriable rate-limit hit.
+        self.assertEqual(gateway._check_rate_limit("create-domain"), RateLimitOutcome.BACKEND_ERROR)
+
+    _LOCMEM: ClassVar[dict[str, Any]] = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "virtualmin-ratelimit-test",
+        }
+    }
+
+    @override_settings(CACHES=_LOCMEM)
+    def test_rate_limit_allows_exactly_max_then_denies_against_live_cache(self) -> None:
+        """MEDIUM-5: prove the atomic slot claim against a REAL cache backend,
+        not a mock — exactly MAX allowed, the next denied, and a fresh window
+        resets."""
+        from apps.provisioning.virtualmin_gateway import (  # noqa: PLC0415
+            VIRTUALMIN_RATE_LIMIT_MAX_CALLS,
+        )
+
+        django_cache.clear()
+        gateway = self._gateway()
+
+        allowed = sum(
+            1
+            for _ in range(VIRTUALMIN_RATE_LIMIT_MAX_CALLS)
+            if gateway._check_rate_limit("create-domain") is RateLimitOutcome.ALLOWED
+        )
+        self.assertEqual(allowed, VIRTUALMIN_RATE_LIMIT_MAX_CALLS)
+        self.assertIs(gateway._check_rate_limit("create-domain"), RateLimitOutcome.EXHAUSTED)
+        # A different operation has its own slot namespace.
+        self.assertIs(gateway._check_rate_limit("other-op"), RateLimitOutcome.ALLOWED)
+
+    @patch.object(VirtualminGateway, "_check_rate_limit", return_value=RateLimitOutcome.BACKEND_ERROR)
+    @patch.object(VirtualminGateway, "_validate_server_health")
+    def test_call_reports_cache_backend_failure_as_non_retriable(
+        self, mock_health: MagicMock, _mock_rl: MagicMock
+    ) -> None:
+        """HIGH-2: a rate-limit BACKEND failure must not surface as a retriable
+        'rate limit exceeded' — that invites retry loops against a dead cache."""
+        from apps.common.types import Ok, Retriability, retriability_of  # noqa: PLC0415
+        from apps.provisioning.virtualmin_gateway import VirtualminRateLimitedError  # noqa: PLC0415
+
+        mock_health.return_value = Ok(True)
+        gateway = self._gateway()
+
+        result = gateway.call("list-domains", {})
+
+        self.assertTrue(result.is_err())
+        self.assertNotIsInstance(result.unwrap_err(), VirtualminRateLimitedError)
+        self.assertNotEqual(retriability_of(result), Retriability.RETRIABLE)

--- a/services/platform/tests/provisioning/test_virtualmin_outbound.py
+++ b/services/platform/tests/provisioning/test_virtualmin_outbound.py
@@ -6,6 +6,12 @@ from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminAPIError,
+    VirtualminConfig,
+    VirtualminGateway,
+)
+
 
 class VirtualminOutboundTests(TestCase):
     """Verify Virtualmin gateway uses safe_request() with DNS pinning."""
@@ -30,3 +36,90 @@ class VirtualminOutboundTests(TestCase):
         import apps.provisioning.virtualmin_gateway as gw  # noqa: PLC0415
 
         self.assertTrue(hasattr(gw, "safe_request"))
+
+    def _gateway(
+        self,
+        *,
+        api_url: str = "https://virtualmin.example.com:10000/remote.cgi",
+        use_ssl: bool = True,
+        verify_ssl: bool = True,
+        fingerprint: str = "",
+    ) -> VirtualminGateway:
+        server = MagicMock()
+        server.hostname = "virtualmin.example.com"
+        server.api_url = api_url
+        server.api_username = "praho-api"
+        server.use_ssl = use_ssl
+        server.ssl_cert_fingerprint = fingerprint
+        server.get_api_password.return_value = "secret"
+        return VirtualminGateway(
+            VirtualminConfig(
+                server=server,
+                verify_ssl=verify_ssl,
+                cert_fingerprint=fingerprint,
+                use_credential_vault=False,
+            )
+        )
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    def test_http_is_rejected_before_credentials_are_read(self, mock_safe_request: MagicMock) -> None:
+        gateway = self._gateway(api_url="http://virtualmin.example.com:10000/remote.cgi", use_ssl=False)
+        gateway.server.get_api_password.side_effect = AssertionError("credentials must not be read")
+
+        with self.assertRaises(VirtualminAPIError):
+            gateway._execute_http_request({"program": "info"})
+
+        mock_safe_request.assert_not_called()
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    def test_disabled_ca_verification_requires_certificate_fingerprint(self, mock_safe_request: MagicMock) -> None:
+        gateway = self._gateway(verify_ssl=False)
+
+        with self.assertRaises(VirtualminAPIError):
+            gateway._execute_http_request({"program": "info"})
+
+        mock_safe_request.assert_not_called()
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    def test_fingerprint_is_enforced_by_outbound_transport(self, mock_safe_request: MagicMock) -> None:
+        fingerprint = "ab" * 32
+        gateway = self._gateway(verify_ssl=False, fingerprint=fingerprint)
+        mock_safe_request.return_value = MagicMock()
+
+        gateway._execute_http_request({"program": "info"})
+
+        policy = mock_safe_request.call_args.kwargs["policy"]
+        self.assertTrue(policy.require_https)
+        self.assertEqual(policy.allowed_schemes, frozenset({"https"}))
+        self.assertEqual(policy.tls_cert_fingerprint, fingerprint)
+
+    @patch("apps.provisioning.virtualmin_gateway.cache")
+    def test_rate_limit_claims_slots_with_atomic_cache_add(self, mock_cache: MagicMock) -> None:
+        gateway = self._gateway()
+        mock_cache.add.side_effect = [False, False, True]
+
+        allowed = gateway._check_rate_limit("create-domain")
+
+        self.assertTrue(allowed)
+        self.assertEqual(mock_cache.add.call_count, 3)
+        mock_cache.get.assert_not_called()
+        mock_cache.set.assert_not_called()
+        mock_cache.incr.assert_not_called()
+
+    @patch("apps.provisioning.virtualmin_gateway.cache")
+    def test_rate_limit_rejects_when_all_atomic_slots_are_claimed(self, mock_cache: MagicMock) -> None:
+        from apps.provisioning.virtualmin_gateway import VIRTUALMIN_RATE_LIMIT_MAX_CALLS  # noqa: PLC0415
+
+        gateway = self._gateway()
+        mock_cache.add.return_value = False
+
+        self.assertFalse(gateway._check_rate_limit("create-domain"))
+        self.assertEqual(mock_cache.add.call_count, VIRTUALMIN_RATE_LIMIT_MAX_CALLS)
+        mock_cache.incr.assert_not_called()
+
+    @patch("apps.provisioning.virtualmin_gateway.cache")
+    def test_rate_limit_fails_closed_when_counter_backend_fails(self, mock_cache: MagicMock) -> None:
+        gateway = self._gateway()
+        mock_cache.add.side_effect = RuntimeError("cache unavailable")
+
+        self.assertFalse(gateway._check_rate_limit("create-domain"))


### PR DESCRIPTION
## Summary

- require HTTPS for Virtualmin API credentials and enforce SHA-256 certificate pins during the TLS handshake when CA verification is disabled
- reject unknown SSH host keys across Virtualmin fallback, node validation, pooled SSH, and Ansible execution using one operator-managed trust path
- restrict root-level maintenance to deploy-authorized users, semantic maintenance actions, and repository-owned allowlisted playbooks
- prevent auth fallback from escalating on validation, network, rate-limit, conflict, or other non-authentication failures
- replace the non-atomic rate counter with fail-closed atomic fixed-window slot claims
- audit deployment SSH key creation and revocation, and prevent a node from being recorded as destroyed when vault revocation fails
- preserve retry-safety metadata across Virtualmin authentication boundaries and prevent inherited Ansible SSH arguments from weakening host-key checks
- pin auto-registered self-signed nodes from the certificate actually served on port 10000, measured through verified SSH rather than network trust-on-first-use

Closes #327
Closes #213
Partially addresses #328 (Ansible key-access signature and maintenance playbook boundary).

## Operational and migration notes

No database schema migration is required.

Before using managed-node SSH automation, provision a verified `known_hosts` file out of band and set `PRAHO_SSH_KNOWN_HOSTS_PATH` for both Platform and Django-Q workers. Container deployments must mount the same file read-only. Unknown, missing, or changed keys intentionally block operations.

Existing Virtualmin rows using plaintext HTTP now fail closed. Rows with CA verification disabled must provide a valid SHA-256 certificate fingerprint before credentials can be sent.

New auto-registered self-signed nodes obtain their certificate pin through the verified SSH channel. For existing unpinned self-signed records, run:

```bash
python manage.py pin_virtualmin_certificates --dry-run
python manage.py pin_virtualmin_certificates
```

The command fails closed for records without a linked deployment or verified SSH trust. It never bootstraps trust from an unverified TLS connection.

The maintenance UI now exposes only the implemented security-hardening action. Unsupported dormant actions are removed rather than mapped to arbitrary root playbooks.

## Test plan

- TDD review regression gate: 8 expected failures/errors before implementation; 26 passed after implementation
- `make test-file FILE='tests.common.test_outbound_http tests.provisioning tests.infrastructure'` — 765 passed
- `make lint` — passed, including no-new-Ruff-debt, MyPy (414 platform source files), Django checks, audit/settings/i18n scans, code health, and FSM guardrails
- `make test` on commit `ff99d980` — all phases passed; platform discovered 7,013 tests, portal suite passed, 79 integration tests passed, database-cache and security-isolation phases passed
- pre-commit hooks — passed
