### PR TITLE
fix(security): bind encrypted payment data to immutable rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Row-bound encrypted payment data** — bank details now use v2 AES-256-GCM with exact immutable per-row AAD on first insert and every ORM projection; cross-row ciphertext transplants, downgrade/plaintext values, malformed base64, empty AAD, and decryption failures fail loudly without replacing forensic ciphertext with NULL. Existing rows are re-encrypted by a reversible fail-closed migration, Stripe-only paths defer unrelated bank data, and the key-rotation cipher cache is bounded (#205, #267, #268; ADR-0040)
+
 - **Domain webhook HMAC-SHA256 verification** — implemented signature verification for domain registrar webhooks with timing-safe comparison
 
 - **Order idempotency hardening** — DB-backed unique constraint per customer with atomic `cache.add` and stuck-lock recovery; `IntegrityError` catch narrowed to only handle idempotency race conditions, not financial check constraints

--- a/docs/ADRs/ADR-0040-row-bound-encrypted-json-fields.md
+++ b/docs/ADRs/ADR-0040-row-bound-encrypted-json-fields.md
@@ -105,6 +105,11 @@ primary-key AAD before removing the UUID.
   use database backups or sanitized fixtures instead.
 - The migration is intentionally fail-closed and can block deployment until
   unexpected historical data is investigated.
+- The migration runs atomically, so its safe all-or-nothing rollback is bought
+  with a table-level lock: PostgreSQL's `ADD COLUMN` takes `ACCESS EXCLUSIVE` and
+  holds it through the entire row-by-row re-encryption. Plan a maintenance window
+  proportional to the size of `customer_payment_methods`; a very large table
+  warrants a staged online migration instead.
 
 ## Threat Boundary
 

--- a/docs/ADRs/ADR-0040-row-bound-encrypted-json-fields.md
+++ b/docs/ADRs/ADR-0040-row-bound-encrypted-json-fields.md
@@ -1,0 +1,131 @@
+# ADR-0040: Row-Bound Encrypted JSON Fields
+
+## Status
+
+**Accepted** - July 2026
+
+## Context
+
+EncryptedJSONField used AES-256-GCM v2 ciphertext with associated authenticated
+data (AAD), but its row component was not verified on reads. Auto-increment
+primary keys were also unavailable during the first INSERT, so new ciphertext
+was commonly bound only to table:field:. A database writer could therefore
+copy ciphertext between rows of the same field.
+
+Three related weaknesses made that gap more dangerous:
+
+- decryption, AAD, and downgrade failures returned None, allowing a later
+  model save to replace forensic ciphertext with SQL NULL;
+- callers could supply an expected AAD to the primitive, but v2 decryption
+  ignored it;
+- malformed base64 and empty AAD were accepted, and the per-key AES-GCM cache
+  retained an unbounded number of rotation keys.
+
+Customer payment bank details are the only production EncryptedJSONField.
+They need row-level integrity without changing the public integer
+payment-method identifier used by billing APIs and foreign keys.
+
+## Decision
+
+### Stable row identity
+
+CustomerPaymentMethod has a random encryption_context_id UUID generated before
+its first INSERT. Bank-details AAD is exactly:
+
+customer_payment_methods:bank_details:<encryption_context_id>
+
+The UUID is unique and non-editable. PostgreSQL and SQLite triggers reject
+every attempt to change it after insertion. This prevents an attacker from
+moving the context UUID together with copied ciphertext.
+
+The UUID is cryptographic storage identity, not a customer-facing or billing
+identifier. Existing integer primary and foreign keys remain unchanged.
+
+### Exact read-time verification
+
+The encrypted column's SQL select expression returns an internal JSON envelope
+containing both the immutable context and ciphertext.
+EncryptedJSONField.from_db_value() removes that envelope, constructs the exact
+expected AAD, and supplies it to AES-GCM decryption. The behavior is identical
+for model loads, values(), and values_list(); callers continue to receive the
+original dictionary.
+
+The field uses require_v2=True. Plaintext, v1 ciphertext, missing context,
+malformed ciphertext, invalid decrypted JSON, and exact-AAD mismatches raise
+DecryptionError. They never become a plausible None value.
+
+Queries that need only Stripe card metadata explicitly defer bank details.
+Direct bank-detail access and compliance auditing still fail loudly on
+corruption.
+
+### Primitive and maintenance hardening
+
+- v2 decryption compares supplied and embedded AAD with hmac.compare_digest();
+- empty AAD is rejected for new and existing v2 payloads;
+- ciphertext uses strict RFC 4648 URL-safe base64 decoding;
+- the AES-GCM instance cache is a locked, eight-entry LRU;
+- reencrypt_with_aad validates exact row AAD, includes soft-deleted rows, uses
+  compare-and-swap updates, and reports corrupt or changing rows instead of
+  skipping them as healthy.
+
+### Migration
+
+Migration customers.0019:
+
+1. adds a nullable context UUID;
+2. assigns a unique UUID to every payment-method row, including soft-deleted
+   rows;
+3. accepts only the two known prior v2 contexts (primary-key-bound and the
+   historical empty first-INSERT context), plus v1/plaintext compatibility
+   inputs;
+4. re-encrypts non-null bank details under the exact UUID context;
+5. makes the UUID required and unique, enables v2-only field behavior, and
+   installs the immutability trigger.
+
+Unexpected AAD, unreadable ciphertext, invalid JSON, or concurrent row changes
+abort the migration. Rollback re-encrypts each value under its prior
+primary-key AAD before removing the UUID.
+
+## Consequences
+
+### Positive
+
+- Same-field, cross-row ciphertext transplants fail on every ORM read.
+- First INSERTs are fully row-bound without changing public identifiers.
+- Corrupt ciphertext remains available for investigation.
+- Key rotation cannot grow an unbounded in-process cipher cache.
+- Existing Stripe-only workflows do not decrypt unrelated bank data.
+
+### Negative
+
+- Context-bound encrypted fields support only PostgreSQL and SQLite.
+- Selecting the field requires a small JSON envelope expression in SQL.
+- A corrupt protected value now raises and must be repaired explicitly.
+- Plaintext dumpdata fixtures containing a context-bound field cannot be loaded;
+  use database backups or sanitized fixtures instead.
+- The migration is intentionally fail-closed and can block deployment until
+  unexpected historical data is investigated.
+
+## Threat Boundary
+
+The design protects against ciphertext copying by a database writer that
+cannot alter triggers or encrypt new values. It does not protect against a
+database superuser that can disable DDL protections, or compromise of the
+application encryption key.
+
+## Rejected Alternatives
+
+1. **Bind only to the integer primary key** - it is unavailable during the
+   first auto-increment INSERT and would require an unsafe two-write window.
+2. **Change payment methods to UUID primary keys** - unnecessary API and
+   foreign-key migration blast radius.
+3. **Store a mutable context UUID without a trigger** - an attacker could copy
+   the UUID and ciphertext together.
+4. **Return None on failure** - makes corruption indistinguishable from a
+   legitimate null and enables destructive resaves.
+
+## Related
+
+- [ADR-0033](ADR-0033-encryption-architecture-consolidation.md) - AES-256-GCM
+  architecture and key ownership
+- GitHub issues #205, #267, and #268

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -13,7 +13,7 @@ providing a historical record of why the system is built the way it is.
 ## How to Create a New ADR
 
 1. Create a new file: `ADR-XXXX-short-descriptive-title.md`
-2. Use the next available number (currently: **ADR-0040**)
+2. Use the next available number (currently: **ADR-0041**)
 3. Follow the standard format: Status, Date, Authors, Context, Decision, Consequences
 4. Set status to **Proposed** initially, then update to **Accepted** after team review
 
@@ -68,6 +68,7 @@ providing a historical record of why the system is built the way it is.
 | [ADR-0037](ADR-0037-psycopg-v3-migration.md) | psycopg v3 Migration | Active | 2026-03-20 |
 | [ADR-0038](ADR-0038-proforma-payment-convergence.md) | Proforma Payment Convergence Architecture | Accepted | 2026-03 |
 | [ADR-0039](ADR-0039-praho-owned-recurring-billing.md) | PRAHO-Owned Recurring Billing | Accepted | 2026-07 |
+| [ADR-0040](ADR-0040-row-bound-encrypted-json-fields.md) | Row-Bound Encrypted JSON Fields | Accepted | 2026-07 |
 
 ### 🟡 Partially Superseded
 
@@ -120,6 +121,9 @@ Token & Inter-Service Auth
   ADR-0031 (API token auth) ──related──▶ ADR-0017, ADR-0024
   ADR-0032 (dual HMAC) ──related──▶ ADR-0017, ADR-0031
 
+Encryption Architecture
+  ADR-0033 (AES-256-GCM consolidation) ──extended by──▶ ADR-0040 (row-bound encrypted JSON)
+
 Billing Ownership
   ADR-0025 (amounts in cents) ──related──▶ ADR-0038 (proforma convergence)
   ADR-0038 ──extended by──▶ ADR-0039 (PRAHO-owned recurring billing)
@@ -143,6 +147,7 @@ Billing Ownership
 - [ADR-0017](ADR-0017-portal-auth-fail-open-strategy.md) — Portal fail-open auth
 - [ADR-0018](ADR-0018-django-encryption-key-management.md) — Encryption key management (superseded by ADR-0033)
 - [ADR-0033](ADR-0033-encryption-architecture-consolidation.md) — Encryption architecture consolidation
+- [ADR-0040](ADR-0040-row-bound-encrypted-json-fields.md) — Exact row binding and fail-loud encrypted JSON reads
 - [ADR-0021](ADR-0021-email-enumeration-prevention.md) — Email enumeration prevention
 - [ADR-0030](ADR-0030-rate-limiting-architecture.md) — Throttle architecture and startup validation
 - [ADR-0031](ADR-0031-api-token-authentication-strategy.md) — Token auth gaps and roadmap
@@ -178,8 +183,8 @@ Billing Ownership
 
 ## Statistics
 
-- **Total ADRs**: 39 (ADR-0001 through ADR-0039)
-- **Active**: 33 (Accepted + Implemented)
+- **Total ADRs**: 40 (ADR-0001 through ADR-0040)
+- **Active**: 34 (Accepted + Implemented)
 - **Partially Superseded**: 1
 - **Superseded / Historical**: 5
-- **Next available**: ADR-0040
+- **Next available**: ADR-0041

--- a/services/platform/apps/api/billing/views.py
+++ b/services/platform/apps/api/billing/views.py
@@ -79,12 +79,16 @@ def _uuid(value: object) -> uuid.UUID | None:
 
 
 def _active_card_methods(customer: Customer) -> QuerySet[CustomerPaymentMethod]:
-    return CustomerPaymentMethod.objects.filter(
-        customer=customer,
-        method_type="stripe_card",
-        is_active=True,
-        deleted_at__isnull=True,
-    ).order_by("-is_default", "created_at")
+    return (
+        CustomerPaymentMethod.objects.filter(
+            customer=customer,
+            method_type="stripe_card",
+            is_active=True,
+            deleted_at__isnull=True,
+        )
+        .defer("bank_details")
+        .order_by("-is_default", "created_at")
+    )
 
 
 def _serialize_recurring_overview(customer: Customer) -> dict[str, Any]:
@@ -93,7 +97,9 @@ def _serialize_recurring_overview(customer: Customer) -> dict[str, Any]:
         for authorization in RecurringPaymentAuthorization.objects.filter(
             customer=customer,
             status="active",
-        ).select_related("payment_method")
+        )
+        .select_related("payment_method")
+        .defer("payment_method__bank_details")
     }
     payment_methods = []
     for method in _active_card_methods(customer):

--- a/services/platform/apps/billing/payment_convergence.py
+++ b/services/platform/apps/billing/payment_convergence.py
@@ -368,7 +368,14 @@ class PaymentSuccessService:
         subscriptions = {
             subscription.id: subscription
             for subscription in Subscription.objects.select_for_update(of=("self",))
-            .select_related("saved_payment_method", "payment_authorization")
+            .select_related(
+                "saved_payment_method",
+                "payment_authorization__payment_method",
+            )
+            .defer(
+                "saved_payment_method__bank_details",
+                "payment_authorization__payment_method__bank_details",
+            )
             .filter(id__in=subscription_ids)
             .order_by("id")
         }

--- a/services/platform/apps/billing/payment_service.py
+++ b/services/platform/apps/billing/payment_service.py
@@ -165,6 +165,7 @@ def _revalidate_invoice_payment_reservation(  # noqa: PLR0913  # Keyword-only re
             return reason
         saved_method = (
             CustomerPaymentMethod.objects.select_for_update(of=("self",))
+            .defer("bank_details")
             .filter(id=expected_saved_method_id, customer_id=invoice.customer_id, is_active=True)
             .first()
         )
@@ -276,6 +277,7 @@ def _revalidate_proforma_payment_reservation(  # noqa: PLR0913  # Keyword-only r
             return reason
         saved_method = (
             CustomerPaymentMethod.objects.select_for_update(of=("self",))
+            .defer("bank_details")
             .filter(id=expected_saved_method_id, customer_id=proforma.customer_id, is_active=True)
             .first()
         )
@@ -758,6 +760,7 @@ class PaymentService:
                     stripe_payment_method_id=payment_method_id,
                     is_active=True,
                 )
+                .defer("bank_details")
                 .exclude(stripe_customer_id="")
                 .first()
             )
@@ -1090,6 +1093,7 @@ class PaymentService:
                     stripe_payment_method_id=payment_method_id,
                     is_active=True,
                 )
+                .defer("bank_details")
                 .exclude(stripe_customer_id="")
                 .first()
             )

--- a/services/platform/apps/billing/recurring_authorization_service.py
+++ b/services/platform/apps/billing/recurring_authorization_service.py
@@ -195,7 +195,10 @@ class RecurringPaymentAuthorizationService:
         with transaction.atomic():
             locked_customer = lock_recurring_collection_customer(customer.id)
             locked_payment_method = (
-                CustomerPaymentMethod.objects.select_for_update().filter(pk=payment_method.pk).first()
+                CustomerPaymentMethod.objects.select_for_update()
+                .defer("bank_details")
+                .filter(pk=payment_method.pk)
+                .first()
             )
             if locked_payment_method is None:
                 return Err("Saved payment method is not active")
@@ -333,6 +336,7 @@ class RecurringPaymentAuthorizationService:
                 locked_authorization = (
                     RecurringPaymentAuthorization.objects.select_for_update()
                     .select_related("payment_method")
+                    .defer("payment_method__bank_details")
                     .get(pk=authorization.pk)
                 )
 

--- a/services/platform/apps/billing/recurring_billing.py
+++ b/services/platform/apps/billing/recurring_billing.py
@@ -155,10 +155,15 @@ class RecurringCollectionGate:
         from .metering_models import BillingCycle  # noqa: PLC0415
 
         cycles = list(
-            BillingCycle.objects.filter(Q(invoice=invoice) | Q(usage_invoice=invoice)).select_related(
+            BillingCycle.objects.filter(Q(invoice=invoice) | Q(usage_invoice=invoice))
+            .select_related(
                 "subscription__service",
                 "subscription__saved_payment_method",
                 "subscription__payment_authorization__payment_method",
+            )
+            .defer(
+                "subscription__saved_payment_method__bank_details",
+                "subscription__payment_authorization__payment_method__bank_details",
             )
         )
         if not cycles:
@@ -210,10 +215,15 @@ class RecurringCollectionGate:
         from .metering_models import BillingCycle  # noqa: PLC0415
 
         cycles = list(
-            BillingCycle.objects.filter(proforma=proforma).select_related(
+            BillingCycle.objects.filter(proforma=proforma)
+            .select_related(
                 "subscription__service",
                 "subscription__saved_payment_method",
                 "subscription__payment_authorization__payment_method",
+            )
+            .defer(
+                "subscription__saved_payment_method__bank_details",
+                "subscription__payment_authorization__payment_method__bank_details",
             )
         )
         if not cycles:
@@ -303,6 +313,11 @@ class RecurringBillingOrchestrator:
                         "service",
                         "saved_payment_method",
                         "payment_authorization",
+                        "payment_authorization__payment_method",
+                    )
+                    .defer(
+                        "saved_payment_method__bank_details",
+                        "payment_authorization__payment_method__bank_details",
                     )
                     .filter(
                         status__in=["active", "trialing"],
@@ -501,6 +516,7 @@ class RecurringBillingOrchestrator:
                     cycles = list(
                         BillingCycle.objects.select_for_update(of=("self",))
                         .select_related("subscription__saved_payment_method")
+                        .defer("subscription__saved_payment_method__bank_details")
                         .filter(proforma=proforma)
                         .order_by("subscription_id", "id")
                     )

--- a/services/platform/apps/billing/tasks.py
+++ b/services/platform/apps/billing/tasks.py
@@ -576,6 +576,7 @@ def process_auto_payment(invoice_id: str) -> dict[str, Any]:
         cycles = list(
             BillingCycle.objects.filter(Q(invoice=invoice) | Q(usage_invoice=invoice))
             .select_related("subscription__saved_payment_method")
+            .defer("subscription__saved_payment_method__bank_details")
             .order_by("subscription_id", "id")
         )
         payment_method_ids = {
@@ -924,6 +925,7 @@ def _retry_collection_target(original_payment: Any) -> tuple[Any, int | None, An
                 Q(invoice_id=original_payment.invoice_id) | Q(usage_invoice_id=original_payment.invoice_id)
             )
             .select_related("subscription__saved_payment_method")
+            .defer("subscription__saved_payment_method__bank_details")
             .order_by("subscription_id")
             .first()
         )
@@ -933,6 +935,7 @@ def _retry_collection_target(original_payment: Any) -> tuple[Any, int | None, An
     if original_payment.proforma_id is not None:
         cycle = (
             original_payment.proforma.billing_cycles.select_related("subscription__saved_payment_method")
+            .defer("subscription__saved_payment_method__bank_details")
             .order_by("subscription_id")
             .first()
         )

--- a/services/platform/apps/common/encryption.py
+++ b/services/platform/apps/common/encryption.py
@@ -13,10 +13,13 @@ Standard: NIST SP 800-38D (GCM), AES-256 (quantum-safe per NIST PQC)
 """
 
 import base64
+import hmac
 import logging
 import os
 import secrets
 import struct
+from collections import OrderedDict
+from threading import Lock
 from typing import Any
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -34,6 +37,7 @@ AES_KEY_SIZE = 32  # 256 bits
 NONCE_SIZE = 12  # 96 bits (GCM standard)
 AAD_LEN_SIZE = 2  # uint16 for AAD length
 MAX_AAD_LEN = 65535  # AAD length is encoded as uint16 (struct "!H") in the v2 wire format
+MAX_AESGCM_CACHE_SIZE = 8
 
 # --- Exceptions ---
 
@@ -47,19 +51,36 @@ class DecryptionError(Exception):
 
 
 # --- Internal state (lazy-init) ---
-_aesgcm_cache: dict[bytes, AESGCM] = {}
+_aesgcm_cache: OrderedDict[bytes, AESGCM] = OrderedDict()
+_aesgcm_cache_lock = Lock()
 
 
 def _get_aesgcm(key: bytes) -> AESGCM:
-    """Get or create a cached AESGCM instance for the given key."""
-    if key not in _aesgcm_cache:
-        _aesgcm_cache[key] = AESGCM(key)
-    return _aesgcm_cache[key]
+    """Get or create a cached AESGCM instance without retaining unlimited old keys."""
+    with _aesgcm_cache_lock:
+        cached = _aesgcm_cache.pop(key, None)
+        if cached is not None:
+            _aesgcm_cache[key] = cached
+            return cached
+        if len(_aesgcm_cache) >= MAX_AESGCM_CACHE_SIZE:
+            _aesgcm_cache.popitem(last=False)
+        created = AESGCM(key)
+        _aesgcm_cache[key] = created
+        return created
 
 
 def _clear_aesgcm_cache() -> None:
     """Clear the AESGCM cache (for testing only)."""
-    _aesgcm_cache.clear()
+    with _aesgcm_cache_lock:
+        _aesgcm_cache.clear()
+
+
+def _strict_urlsafe_b64decode(encoded: str) -> bytes:
+    """Decode RFC 4648 URL-safe base64 without silently discarding junk."""
+    try:
+        return base64.b64decode(encoded.encode("ascii"), altchars=b"-_", validate=True)
+    except (UnicodeEncodeError, ValueError) as exc:
+        raise DecryptionError("Ciphertext is not valid URL-safe base64") from exc
 
 
 # --- Key management ---
@@ -145,6 +166,9 @@ def encrypt_sensitive_data(data: str, *, aad: bytes | None = None) -> str:
     Raises:
         EncryptionError: If encryption fails.
     """
+    if aad == b"":
+        raise EncryptionError("AAD must contain at least one byte; use None for unbound v1 ciphertext")
+
     if not data:
         return ""
 
@@ -181,8 +205,8 @@ def decrypt_sensitive_data(encrypted_data: str, *, aad: bytes | None = None) -> 
 
     Args:
         encrypted_data: Encrypted string with "aes:" prefix.
-        aad: Optional AAD for v1/legacy format override. Ignored for v2
-             (AAD is embedded in the payload).
+        aad: Optional expected AAD. For v2 it must match the embedded AAD;
+             for v1/legacy it is supplied to AES-GCM as before.
 
     Returns:
         Decrypted plain text string. Empty string if input is empty.
@@ -210,13 +234,17 @@ def _parse_ciphertext(encrypted_data: str, aad_override: bytes | None) -> dict[s
     """Parse wire format and extract nonce, ciphertext+tag, and AAD."""
     if encrypted_data.startswith(VERSIONED_V2_PREFIX):
         encoded = encrypted_data[len(VERSIONED_V2_PREFIX) :]
-        raw = base64.urlsafe_b64decode(encoded)
+        raw = _strict_urlsafe_b64decode(encoded)
         if len(raw) < AAD_LEN_SIZE:
             raise DecryptionError("v2 ciphertext too short for AAD length")
         aad_len = struct.unpack("!H", raw[:AAD_LEN_SIZE])[0]
+        if aad_len == 0:
+            raise DecryptionError("v2 ciphertext must contain non-empty AAD")
         if len(raw) < AAD_LEN_SIZE + aad_len + NONCE_SIZE + 16:
             raise DecryptionError("v2 ciphertext too short")
         aad = raw[AAD_LEN_SIZE : AAD_LEN_SIZE + aad_len]
+        if aad_override is not None and not hmac.compare_digest(aad, aad_override):
+            raise DecryptionError("Ciphertext AAD does not match the expected context")
         rest = raw[AAD_LEN_SIZE + aad_len :]
         nonce = rest[:NONCE_SIZE]
         ciphertext_and_tag = rest[NONCE_SIZE:]
@@ -228,7 +256,7 @@ def _parse_ciphertext(encrypted_data: str, aad_override: bytes | None) -> dict[s
         # Legacy format: "aes:<payload>" (pre-versioning)
         encoded = encrypted_data[len(ENCRYPTED_PREFIX) :]
 
-    raw = base64.urlsafe_b64decode(encoded)
+    raw = _strict_urlsafe_b64decode(encoded)
     if len(raw) < NONCE_SIZE + 16:
         raise DecryptionError("Ciphertext too short")
     nonce = raw[:NONCE_SIZE]

--- a/services/platform/apps/common/fields.py
+++ b/services/platform/apps/common/fields.py
@@ -9,30 +9,42 @@ transplant attacks between rows/tables.
 
 from __future__ import annotations
 
-import base64
 import json
 import logging
 import struct
-from typing import Any
+from typing import Any, cast
 
 from django.db import models
+from django.db.models.expressions import Col
+from django.db.utils import NotSupportedError
 
 from apps.common.encryption import (
     AAD_LEN_SIZE,
     ENCRYPTED_PREFIX,
     VERSIONED_V2_PREFIX,
+    DecryptionError,
+    EncryptionError,
+    _strict_urlsafe_b64decode,
     decrypt_sensitive_data,
     encrypt_sensitive_data,
 )
 
 logger = logging.getLogger(__name__)
 
+_AAD_CONTEXT_KEY = "__praho_encrypted_aad_context__"
+_ENCRYPTED_VALUE_KEY = "__praho_encrypted_value__"
+SQLParams = list[str | int] | tuple[str | int, ...] | tuple[()]
+
+
+class _PreparedEncryptedValue(str):
+    """Ciphertext produced or verified with a concrete model instance."""
+
 
 def _extract_embedded_aad(encrypted_str: str) -> bytes | None:
     """Extract the embedded AAD from a v2 ciphertext string, or None if parsing fails."""
     try:
         encoded = encrypted_str[len(VERSIONED_V2_PREFIX) :]
-        raw = base64.urlsafe_b64decode(encoded)
+        raw = _strict_urlsafe_b64decode(encoded)
         if len(raw) < AAD_LEN_SIZE:
             return None
         aad_len = struct.unpack("!H", raw[:AAD_LEN_SIZE])[0]
@@ -43,47 +55,99 @@ def _extract_embedded_aad(encrypted_str: str) -> bytes | None:
         return None
 
 
+# SQL identifiers come only from Django's compiler/model metadata and the JSON
+# property names are fixed module constants; no request or stored value is interpolated.
+# nosemgrep: python.django.security.audit.extends-custom-expression.extends-custom-expression  # noqa: ERA001
+class EncryptedJSONCol(Col):
+    """Select an encrypted value together with its immutable row context."""
+
+    def select_format(
+        self,
+        compiler: Any,
+        sql: str,
+        params: SQLParams,
+    ) -> tuple[str, list[str | int]]:
+        field = cast("EncryptedJSONField", self.target)
+        context_name = field.aad_context_field
+        if context_name is None:
+            raise DecryptionError("EncryptedJSONCol requires an AAD context field")
+        context_field = cast(
+            "models.Field[Any, Any]",
+            field.model._meta.get_field(context_name),
+        )
+        context_sql, context_params = compiler.compile(Col(self.alias, context_field))
+
+        if compiler.connection.vendor == "postgresql":
+            wrapped = (
+                f"jsonb_build_object('{_AAD_CONTEXT_KEY}', ({context_sql})::text, '{_ENCRYPTED_VALUE_KEY}', {sql})"
+            )
+        elif compiler.connection.vendor == "sqlite":
+            # SQLite stores UUIDField values as 32 hex characters. Normalize them
+            # to UUID's canonical representation so write- and read-time AAD match.
+            canonical_context = (
+                f"lower(substr({context_sql}, 1, 8) || '-' || substr({context_sql}, 9, 4) || '-' || "
+                f"substr({context_sql}, 13, 4) || '-' || substr({context_sql}, 17, 4) || '-' || "
+                f"substr({context_sql}, 21, 12))"
+            )
+            wrapped = f"json_object('{_AAD_CONTEXT_KEY}', {canonical_context}, '{_ENCRYPTED_VALUE_KEY}', json({sql}))"
+        else:
+            raise NotSupportedError("Context-bound EncryptedJSONField supports PostgreSQL and SQLite only")
+        return wrapped, [*context_params, *params]
+
+
 class EncryptedJSONField(models.JSONField):
     """JSONField with transparent AES-256-GCM encryption at rest.
 
     Data is encrypted before writing to the database and decrypted on read.
-    Legacy unencrypted data (plain JSON objects) is handled transparently —
-    returned as-is on read and encrypted on next save.
+    Decryption, downgrade, and AAD mismatches raise ``DecryptionError``.
 
-    AAD binding: encrypts with ``aad=b"{db_table}:{field_name}:{pk}"``. The
-    ``{db_table}:{field_name}`` component is verified on read, so ciphertext
-    transplanted between a DIFFERENT table or field fails on read.
-
-    Scope limits (do not over-read the protection):
-      * Same-table/same-field row→row transplant is NOT currently prevented — the
-        pk component is not verified on read, and it is empty at INSERT for
-        autoincrement pks. Tracked in issue #205.
-      * ``require_v2=False`` (the default) is a COMPATIBILITY mode: it still reads
-        v1/legacy/plaintext and therefore does NOT enforce downgrade protection.
+    When ``aad_context_field`` is configured, AAD binds to a stable row
+    identity available before INSERT. The select expression carries that identity
+    in an internal envelope so model and projection reads verify exact AAD.
 
     Wire format in DB: jsonb string containing ``"aes:v2:<base64>"`` (AAD-bound)
     Python interface: plain dict (identical to standard JSONField)
 
-    ``require_v2``: when True, the field rejects (fail-closed → None + security log)
+    ``require_v2``: when True, the field rejects
     any stored value that is not v2 AAD-bound ciphertext — v1/legacy ciphertext or
     plaintext. This closes the downgrade bypass where an attacker with DB write
     access supplies a v1 blob (which carries no AAD binding) to sidestep transplant
     protection. Set it True only after ``reencrypt_with_aad`` has upgraded existing
-    rows to v2; otherwise unmigrated rows read back as None.
+    rows to v2; otherwise unmigrated rows raise ``DecryptionError``.
     """
 
-    def __init__(self, *args: Any, require_v2: bool = False, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *args: Any,
+        require_v2: bool = False,
+        aad_context_field: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         # require_v2 is read-time behavior only (no DB column). deconstruct() preserves it
         # when non-default so Field.clone() and historical migration models keep the flag;
         # the default (False) is omitted, so no schema migration is generated by default.
         self.require_v2 = require_v2
+        self.aad_context_field = aad_context_field
         super().__init__(*args, **kwargs)
+
+    def get_col(self, alias: str, output_field: models.Field[Any, Any] | None = None) -> Col:
+        if self.aad_context_field and (output_field is None or output_field == self):
+            return EncryptedJSONCol(alias, self, output_field)
+        return super().get_col(alias, output_field)
 
     def _build_aad(self, model_instance: models.Model) -> bytes:
         """Build AAD context string for this field on this instance."""
         table = model_instance._meta.db_table
         field = self.attname
-        # Use "is not None" (not truthiness) so a legitimate pk of 0 binds to "0", not "".
+        if self.aad_context_field:
+            context = getattr(model_instance, self.aad_context_field, None)
+            if context is None or str(context) == "":
+                raise EncryptionError(
+                    f"EncryptedJSONField {table}.{field} requires {self.aad_context_field} before save"
+                )
+            return f"{table}:{field}:{context}".encode()
+
+        # Compatibility mode for fields not yet assigned a stable row identity.
         pk = model_instance.pk if model_instance.pk is not None else ""
         return f"{table}:{field}:{pk}".encode()
 
@@ -99,12 +163,17 @@ class EncryptedJSONField(models.JSONField):
         value = getattr(model_instance, self.attname)
         if value is None:
             return None
-        if isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX):
-            # Already a wire string (e.g. a migration writing a pre-built value).
-            return value
         aad = self._build_aad(model_instance)
+        if isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX):
+            if self.require_v2 and not value.startswith(VERSIONED_V2_PREFIX):
+                raise EncryptionError(
+                    f"EncryptedJSONField {self.model._meta.db_table}.{self.attname} requires v2 ciphertext"
+                )
+            if value.startswith(VERSIONED_V2_PREFIX):
+                decrypt_sensitive_data(value, aad=aad)
+            return _PreparedEncryptedValue(value)
         json_str = json.dumps(value, cls=self.encoder)
-        return encrypt_sensitive_data(json_str, aad=aad)
+        return _PreparedEncryptedValue(encrypt_sensitive_data(json_str, aad=aad))
 
     def get_prep_value(self, value: Any) -> Any:
         """Prepare a value for the DB adapter.
@@ -113,12 +182,19 @@ class EncryptedJSONField(models.JSONField):
         string; that string passes straight through here. A raw (unencrypted) value
         reaching this point came from a write path that bypassed pre_save —
         ``QuerySet.update()``/``bulk_update()`` or a raw/fixture save (``loaddata``) —
-        where no model instance is available, so AAD context cannot be bound. Rather
-        than fail (which would break ``dumpdata``→``loaddata``) or silently downgrade,
-        encrypt WITHOUT AAD (v1) and log a warning so the unbound write is visible.
+        where no model instance is available, so AAD context cannot be bound.
+        Context-bound or v2-only fields reject that write; compatibility fields
+        retain the legacy v1 fallback.
         """
         if value is None:
             return None
+        if isinstance(value, _PreparedEncryptedValue):
+            return super().get_prep_value(value)
+        if self.aad_context_field or self.require_v2:
+            raise EncryptionError(
+                f"EncryptedJSONField {self.model._meta.db_table}.{self.attname} "
+                "cannot be written without model AAD context"
+            )
         if isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX):
             return super().get_prep_value(value)
         logger.warning(
@@ -131,22 +207,33 @@ class EncryptedJSONField(models.JSONField):
         return super().get_prep_value(encrypt_sensitive_data(json_str))
 
     def from_db_value(self, value: Any, expression: Any, connection: Any) -> Any:
-        """Decrypt on read; handle legacy unencrypted data transparently.
-
-        v2 format: AAD is embedded in the payload and verified by GCM.
-        Also cross-checks embedded AAD prefix against expected table:field:
-        to detect ciphertext transplant between different tables/fields.
-        v1/legacy: decrypted without AAD (backward compatible).
-        """
+        """Decrypt on read and fail loudly on integrity or downgrade failures."""
         result = super().from_db_value(value, expression, connection)
         if result is None:
             return None
 
+        expected_aad: bytes | None = None
+        if self.aad_context_field:
+            if not isinstance(result, dict) or not {
+                _AAD_CONTEXT_KEY,
+                _ENCRYPTED_VALUE_KEY,
+            }.issubset(result):
+                raise DecryptionError(
+                    f"EncryptedJSONField {self.model._meta.db_table}.{self.attname} "
+                    "was selected without its row AAD context"
+                )
+            context = result[_AAD_CONTEXT_KEY]
+            result = result[_ENCRYPTED_VALUE_KEY]
+            if result is None:
+                return None
+            if not isinstance(context, str) or not context:
+                raise DecryptionError(
+                    f"EncryptedJSONField {self.model._meta.db_table}.{self.attname} has no row AAD context"
+                )
+            expected_aad = f"{self.model._meta.db_table}:{self.attname}:{context}".encode()
+
         is_v2 = isinstance(result, str) and result.startswith(VERSIONED_V2_PREFIX)
         if self.require_v2 and not is_v2:
-            # Fail closed: a require_v2 field must only ever yield AAD-bound v2 data.
-            # Anything else — v1/legacy ciphertext or raw plaintext — is either a
-            # downgrade attempt or unmigrated data; do not return it.
             encrypted = isinstance(result, str) and result.startswith(ENCRYPTED_PREFIX)
             logger.error(
                 "EncryptedJSONField requires v2 AAD-bound ciphertext but found %s on %s.%s — "
@@ -155,34 +242,33 @@ class EncryptedJSONField(models.JSONField):
                 self.model._meta.db_table,
                 self.attname,
             )
-            return None
+            raise DecryptionError(
+                f"EncryptedJSONField {self.model._meta.db_table}.{self.attname} requires v2 ciphertext"
+            )
 
         if isinstance(result, str) and result.startswith(ENCRYPTED_PREFIX):
             try:
-                decrypted = decrypt_sensitive_data(result)
-
-                # Cross-check embedded AAD for v2 ciphertext
-                if result.startswith(VERSIONED_V2_PREFIX):
+                decrypted = decrypt_sensitive_data(result, aad=expected_aad)
+                if is_v2 and expected_aad is None:
                     embedded_aad = _extract_embedded_aad(result)
-                    if embedded_aad is not None:
-                        expected_prefix = self._expected_aad_prefix()
-                        if not embedded_aad.startswith(expected_prefix):
-                            logger.error(
-                                "EncryptedJSONField AAD context mismatch — possible ciphertext transplant. "
-                                "Expected prefix %r, got %r",
-                                expected_prefix,
-                                embedded_aad[:50],
-                            )
-                            return None
-
+                    if embedded_aad is None or not embedded_aad.startswith(self._expected_aad_prefix()):
+                        raise DecryptionError("Ciphertext AAD does not match the encrypted field")
                 return json.loads(decrypted)
-            except Exception:
+            except DecryptionError:
                 logger.error(
-                    "Failed to decrypt EncryptedJSONField value (possible key rotation or data corruption). "
-                    "Returning None.",
+                    "Failed to decrypt EncryptedJSONField %s.%s; refusing to return a replacement value.",
+                    self.model._meta.db_table,
+                    self.attname,
                     exc_info=True,
                 )
-                return None
+                raise
+            except (TypeError, ValueError) as exc:
+                logger.error(
+                    "EncryptedJSONField %s.%s plaintext is not valid JSON.",
+                    self.model._meta.db_table,
+                    self.attname,
+                )
+                raise DecryptionError("Decrypted field value is not valid JSON") from exc
         return result
 
     def _expected_aad_prefix(self) -> bytes:
@@ -200,4 +286,6 @@ class EncryptedJSONField(models.JSONField):
         # migration; the default False stays omitted, so no migration is generated today.
         if self.require_v2:
             kwargs["require_v2"] = True
+        if self.aad_context_field:
+            kwargs["aad_context_field"] = self.aad_context_field
         return name, path, list(args), kwargs

--- a/services/platform/apps/common/fields.py
+++ b/services/platform/apps/common/fields.py
@@ -37,7 +37,15 @@ SQLParams = list[str | int] | tuple[str | int, ...] | tuple[()]
 
 
 class _PreparedEncryptedValue(str):
-    """Ciphertext produced or verified with a concrete model instance."""
+    """Marks ciphertext produced or verified by ``pre_save`` with a concrete model instance.
+
+    This is a pre_save -> get_prep_value hand-off marker, NOT a cryptographic authenticity
+    boundary: it defends against accidental unbound writes (a raw dict/string reaching
+    ``QuerySet.update()``/``bulk_update()``/``loaddata`` is rejected), not against application
+    code that deliberately constructs this private type. The real transplant guard is
+    read-time — any ciphertext whose embedded AAD does not match the row's context fails
+    closed on read, regardless of how it was written.
+    """
 
 
 def _extract_embedded_aad(encrypted_str: str) -> bytes | None:

--- a/services/platform/apps/common/management/commands/reencrypt_with_aad.py
+++ b/services/platform/apps/common/management/commands/reencrypt_with_aad.py
@@ -1,7 +1,8 @@
 """Re-encrypt EncryptedJSONField values with AAD context binding.
 
 Migrates existing v1/legacy ciphertext (and any stored plaintext JSON) to the v2
-wire format with AAD bound to ``table:field:pk``.
+wire format with AAD bound to the field's configured stable row context (falling
+back to the primary key for compatibility fields).
 
 Design notes (why this reads raw SQL rather than the ORM):
   * ``EncryptedJSONField.from_db_value`` decrypts on read, so a value fetched via the
@@ -33,18 +34,37 @@ from __future__ import annotations
 import json
 import logging
 from collections import Counter
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, cast
 
 from django.core.management.base import BaseCommand, CommandError, CommandParser
 from django.db import connection, models
 
 from apps.common.encryption import ENCRYPTED_PREFIX, VERSIONED_V2_PREFIX, decrypt_sensitive_data, encrypt_sensitive_data
-from apps.common.fields import EncryptedJSONField, _extract_embedded_aad
+from apps.common.fields import EncryptedJSONField
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_BATCH_SIZE = 100
 MAX_CAS_ATTEMPTS = 3  # re-read + retry a row that changed under us before giving up
+
+
+@dataclass(frozen=True)
+class FieldSQL:
+    table_name: str
+    attname: str
+    q_table: str
+    q_col: str
+    q_pk: str
+    q_context: str
+
+
+@dataclass(frozen=True)
+class MigrationRow:
+    field: FieldSQL
+    expected_aad: bytes
+    pk: Any
+    raw: Any
 
 
 class Command(BaseCommand):
@@ -110,6 +130,20 @@ class Command(BaseCommand):
         pk_name = model._meta.pk.column
         quote = connection.ops.quote_name
         q_table, q_col, q_pk = quote(table_name), quote(column_name), quote(pk_name)
+        context_field = cast(
+            "models.Field[Any, Any]",
+            (model._meta.get_field(field.aad_context_field) if field.aad_context_field else model._meta.pk),
+        )
+        if context_field.column is None:
+            raise CommandError(f"AAD context field for {table_name}.{attname} has no database column")
+        field_sql = FieldSQL(
+            table_name=table_name,
+            attname=attname,
+            q_table=q_table,
+            q_col=q_col,
+            q_pk=q_pk,
+            q_context=quote(context_field.column),
+        )
 
         self.stdout.write(f"  Processing {table_name}.{column_name}...")
 
@@ -117,48 +151,70 @@ class Command(BaseCommand):
         # Reads are drained fully before any write so we never write on an open read cursor.
         last_pk: Any = None
         while True:
-            rows = self._read_batch(q_table, q_col, q_pk, last_pk, batch_size)
+            rows = self._read_batch(field_sql, last_pk, batch_size)
             if not rows:
                 break
-            for pk, raw in rows:
+            for pk, raw_context, raw in rows:
                 last_pk = pk
-                self._migrate_row(table_name, attname, q_table, q_col, q_pk, pk, raw, dry_run, totals)
+                context = context_field.to_python(raw_context)
+                if context is None:
+                    totals["corrupt"] += 1
+                    self.stdout.write(self.style.WARNING(f"    Missing AAD context {table_name}.{attname} pk={pk}"))
+                    continue
+                expected_aad = f"{table_name}:{attname}:{context}".encode()
+                self._migrate_row(
+                    MigrationRow(
+                        field=field_sql,
+                        expected_aad=expected_aad,
+                        pk=pk,
+                        raw=raw,
+                    ),
+                    dry_run,
+                    totals,
+                )
 
-    def _read_batch(self, q_table: str, q_col: str, q_pk: str, last_pk: Any, batch_size: int) -> list[tuple[Any, Any]]:
+    def _read_batch(
+        self,
+        field: FieldSQL,
+        last_pk: Any,
+        batch_size: int,
+    ) -> list[tuple[Any, Any, Any]]:
+        raw_column = f"{field.q_col}::text" if connection.vendor == "postgresql" else field.q_col
         with connection.cursor() as cursor:
             if last_pk is None:
                 cursor.execute(
-                    f"SELECT {q_pk}, {q_col} FROM {q_table} "  # noqa: S608 — identifiers are quoted model metadata
-                    f"WHERE {q_col} IS NOT NULL ORDER BY {q_pk} LIMIT %s",
+                    f"SELECT {field.q_pk}, {field.q_context}, {raw_column} "  # noqa: S608
+                    f"FROM {field.q_table} WHERE {field.q_col} IS NOT NULL "
+                    f"ORDER BY {field.q_pk} LIMIT %s",
                     [batch_size],
                 )
             else:
                 cursor.execute(
-                    f"SELECT {q_pk}, {q_col} FROM {q_table} "  # noqa: S608 — identifiers are quoted model metadata
-                    f"WHERE {q_col} IS NOT NULL AND {q_pk} > %s ORDER BY {q_pk} LIMIT %s",
+                    f"SELECT {field.q_pk}, {field.q_context}, {raw_column} "  # noqa: S608
+                    f"FROM {field.q_table} WHERE {field.q_col} IS NOT NULL "
+                    f"AND {field.q_pk} > %s ORDER BY {field.q_pk} LIMIT %s",
                     [last_pk, batch_size],
                 )
-            rows: list[tuple[Any, Any]] = cursor.fetchall()
+            rows: list[tuple[Any, Any, Any]] = cursor.fetchall()
             return rows
 
-    def _migrate_row(  # noqa: PLR0913 — cohesive per-row context, not worth a dataclass here
+    def _migrate_row(
         self,
-        table_name: str,
-        attname: str,
-        q_table: str,
-        q_col: str,
-        q_pk: str,
-        pk: Any,
-        raw: Any,
+        row: MigrationRow,
         dry_run: bool,
         totals: Counter[str],
     ) -> None:
+        raw = row.raw
         for _attempt in range(MAX_CAS_ATTEMPTS):
-            kind, new_stored = self._classify(table_name, attname, pk, raw)
+            kind, new_stored = self._classify(row.expected_aad, raw)
 
             if kind == "corrupt":
                 totals["corrupt"] += 1
-                self.stdout.write(self.style.WARNING(f"    Corrupt (unreadable) {table_name}.{attname} pk={pk}"))
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"    Corrupt (unreadable) {row.field.table_name}.{row.field.attname} pk={row.pk}"
+                    )
+                )
                 return
             if kind == "skip_v2":
                 totals["skipped_v2"] += 1
@@ -166,17 +222,17 @@ class Command(BaseCommand):
 
             if dry_run:
                 totals["migrated"] += 1
-                self.stdout.write(f"    Would migrate {table_name}.{attname} pk={pk}")
+                self.stdout.write(f"    Would migrate {row.field.table_name}.{row.field.attname} pk={row.pk}")
                 return
 
             assert new_stored is not None  # kind == "migrate" guarantees this
-            if self._cas_update(q_table, q_col, q_pk, pk, new_stored, raw) == 1:
+            if self._cas_update(row.field, row.pk, new_stored, raw) == 1:
                 totals["migrated"] += 1
                 return
 
             # CAS miss: the row changed since we read it. Re-read the current value and retry
             # so we never advance past a row that is still un-migrated.
-            raw = self._read_one(q_table, q_col, q_pk, pk)
+            raw = self._read_one(row.field, row.pk)
             if raw is None:
                 totals["skipped_deleted"] += 1
                 return
@@ -184,11 +240,12 @@ class Command(BaseCommand):
         totals["unresolved"] += 1
         self.stdout.write(
             self.style.WARNING(
-                f"    Unresolved after {MAX_CAS_ATTEMPTS} attempts (row kept changing) {table_name}.{attname} pk={pk}"
+                f"    Unresolved after {MAX_CAS_ATTEMPTS} attempts (row kept changing) "
+                f"{row.field.table_name}.{row.field.attname} pk={row.pk}"
             )
         )
 
-    def _classify(self, table_name: str, attname: str, pk: Any, raw: Any) -> tuple[str, str | None]:
+    def _classify(self, expected_aad: bytes, raw: Any) -> tuple[str, str | None]:
         """Return (kind, new_stored) for a raw column value.
 
         kind is 'corrupt', 'skip_v2', or 'migrate' (new_stored set only for 'migrate').
@@ -197,20 +254,17 @@ class Command(BaseCommand):
         try:
             inner = json.loads(raw) if isinstance(raw, str) else raw
         except (ValueError, TypeError):
-            return "corrupt", None
+            if isinstance(raw, str) and raw.startswith(ENCRYPTED_PREFIX):
+                inner = raw
+            else:
+                return "corrupt", None
 
-        # Already v2 — confirm it is actually readable BY THIS FIELD before skipping, so a
-        # corrupt/tampered/transplanted v2 blob is flagged rather than reported healthy (which
-        # would read back as None under require_v2). Check both that it decrypts and that the
-        # embedded AAD prefix matches this table:field (the same cross-check from_db_value does).
+        # Already v2 — confirm it is readable under this row's exact AAD before
+        # skipping, so a corrupt, tampered, or transplanted blob is never reported healthy.
         if isinstance(inner, str) and inner.startswith(VERSIONED_V2_PREFIX):
             try:
-                decrypt_sensitive_data(inner)
+                decrypt_sensitive_data(inner, aad=expected_aad)
             except Exception:
-                return "corrupt", None
-            embedded = _extract_embedded_aad(inner)
-            expected_prefix = f"{table_name}:{attname}:".encode()
-            if embedded is None or not embedded.startswith(expected_prefix):
                 return "corrupt", None
             return "skip_v2", None
 
@@ -223,31 +277,34 @@ class Command(BaseCommand):
         else:
             plaintext_value = inner
 
-        # AAD uses attname (not the column) to match EncryptedJSONField._build_aad / the
-        # read-time prefix check; otherwise a field with db_column would migrate to an AAD
-        # the ORM rejects, reading back as None.
-        aad = f"{table_name}:{attname}:{pk}".encode()
-        new_wire = encrypt_sensitive_data(json.dumps(plaintext_value), aad=aad)
+        new_wire = encrypt_sensitive_data(json.dumps(plaintext_value), aad=expected_aad)
         return "migrate", json.dumps(new_wire)  # store as a JSON string, matching the ORM's write
 
-    def _cas_update(  # noqa: PLR0913 — cohesive quoted-identifier + value args
-        self, q_table: str, q_col: str, q_pk: str, pk: Any, new_stored: str, old_raw: Any
+    def _cas_update(
+        self,
+        field: FieldSQL,
+        pk: Any,
+        new_stored: str,
+        old_raw: Any,
     ) -> int:
         # Only overwrite if the row still holds the value we read. On PostgreSQL the jsonb
         # column is compared as text to match the value the cursor returned. A single
         # UPDATE statement is atomic on its own — no surrounding transaction needed.
-        cas = f"{q_col}::text = %s" if connection.vendor == "postgresql" else f"{q_col} = %s"
+        cas = f"{field.q_col}::text = %s" if connection.vendor == "postgresql" else f"{field.q_col} = %s"
         with connection.cursor() as cursor:
             cursor.execute(
-                f"UPDATE {q_table} SET {q_col} = %s WHERE {q_pk} = %s AND {cas}",  # noqa: S608 — quoted identifiers
+                f"UPDATE {field.q_table} SET {field.q_col} = %s "  # noqa: S608
+                f"WHERE {field.q_pk} = %s AND {cas}",
                 [new_stored, pk, old_raw],
             )
             return int(cursor.rowcount)
 
-    def _read_one(self, q_table: str, q_col: str, q_pk: str, pk: Any) -> Any:
+    def _read_one(self, field: FieldSQL, pk: Any) -> Any:
+        raw_column = f"{field.q_col}::text" if connection.vendor == "postgresql" else field.q_col
         with connection.cursor() as cursor:
             cursor.execute(
-                f"SELECT {q_col} FROM {q_table} WHERE {q_pk} = %s",  # noqa: S608 — quoted identifiers
+                f"SELECT {raw_column} FROM {field.q_table} "  # noqa: S608
+                f"WHERE {field.q_pk} = %s",
                 [pk],
             )
             row = cursor.fetchone()

--- a/services/platform/apps/customers/contact_models.py
+++ b/services/platform/apps/customers/contact_models.py
@@ -5,6 +5,7 @@ Address, payment methods, and notes models for customer contact management.
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, ClassVar
 
 from django.db import models
@@ -150,12 +151,18 @@ class CustomerPaymentMethod(SoftDeleteModel):
     is_default = models.BooleanField(default=False, verbose_name=_("Implicit"))
     is_active = models.BooleanField(default=True, verbose_name=_("Activ"))
 
-    # Bank Transfer Details (AES-256-GCM encrypted at rest).
-    # NOTE: pass require_v2=True to reject v1/plaintext downgrade (review H1), but
-    # only AFTER `manage.py reencrypt_with_aad` has upgraded existing rows to v2 —
-    # it intentionally drops the legacy-plaintext backward-compat read path, so it
-    # is a deliberate maintainer decision (left False here to preserve current behavior).
-    bank_details = EncryptedJSONField(blank=True, null=True, verbose_name=_("Detalii bancare"))
+    # Stable, database-immutable identity used to bind encrypted values before
+    # an auto-increment primary key exists.
+    encryption_context_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
+
+    # Bank Transfer Details (AES-256-GCM encrypted and row-bound at rest).
+    bank_details = EncryptedJSONField(
+        aad_context_field="encryption_context_id",
+        blank=True,
+        null=True,
+        require_v2=True,
+        verbose_name=_("Detalii bancare"),
+    )
 
     # Audit
     created_at = models.DateTimeField(auto_now_add=True)

--- a/services/platform/apps/customers/contact_service.py
+++ b/services/platform/apps/customers/contact_service.py
@@ -160,7 +160,7 @@ class ContactService:
     @staticmethod
     def get_active_payment_methods(customer: Customer) -> QuerySet[CustomerPaymentMethod]:
         """Get active payment methods for customer."""
-        return CustomerPaymentMethod.objects.filter(customer=customer, is_active=True)
+        return CustomerPaymentMethod.objects.filter(customer=customer, is_active=True).defer("bank_details")
 
     @staticmethod
     def get_recent_notes(customer: Customer, limit: int = 10) -> QuerySet[CustomerNote]:

--- a/services/platform/apps/customers/migrations/0019_bind_payment_method_encryption_context.py
+++ b/services/platform/apps/customers/migrations/0019_bind_payment_method_encryption_context.py
@@ -1,0 +1,294 @@
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+from django.db import migrations, models
+
+import apps.common.fields
+from apps.common.encryption import (
+    ENCRYPTED_PREFIX,
+    VERSIONED_V2_PREFIX,
+    decrypt_sensitive_data,
+    encrypt_sensitive_data,
+)
+from apps.common.fields import _extract_embedded_aad
+
+TABLE = "customer_payment_methods"
+COLUMN = "bank_details"
+CONTEXT_COLUMN = "encryption_context_id"
+BATCH_SIZE = 500
+
+
+def _decoded_column(raw: Any) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        # Django's PostgreSQL adapter can return a JSON string as its already-decoded
+        # Python string, while SQLite returns the quoted JSON representation.
+        if raw.startswith(ENCRYPTED_PREFIX):
+            return raw
+        raise RuntimeError("customer payment bank details contain invalid JSON") from exc
+
+
+def _plaintext_for_forward(inner: Any, pk: Any) -> dict[str, Any]:
+    if isinstance(inner, str) and inner.startswith(ENCRYPTED_PREFIX):
+        if inner.startswith(VERSIONED_V2_PREFIX):
+            embedded = _extract_embedded_aad(inner)
+            allowed = {
+                f"{TABLE}:{COLUMN}:{pk}".encode(),
+                f"{TABLE}:{COLUMN}:".encode(),
+            }
+            if embedded not in allowed:
+                raise RuntimeError(
+                    f"customer payment method {pk} has ciphertext bound to an unexpected context"
+                )
+            plaintext = decrypt_sensitive_data(inner, aad=embedded)
+        else:
+            plaintext = decrypt_sensitive_data(inner)
+        try:
+            value = json.loads(plaintext)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"customer payment method {pk} decrypts to invalid JSON"
+            ) from exc
+    else:
+        value = inner
+
+    if not isinstance(value, dict):
+        raise RuntimeError(
+            f"customer payment method {pk} bank details must be a JSON object"
+        )
+    return value
+
+
+def _stored_wire(value: dict[str, Any], aad: bytes) -> str:
+    wire = encrypt_sensitive_data(json.dumps(value), aad=aad)
+    return json.dumps(wire)
+
+
+def _rows(schema_editor: Any) -> Iterator[tuple[Any, Any, Any]]:
+    connection = schema_editor.connection
+    quote = connection.ops.quote_name
+    q_table = quote(TABLE)
+    q_pk = quote("id")
+    q_context = quote(CONTEXT_COLUMN)
+    q_column = quote(COLUMN)
+    raw_column = (
+        f"{q_column}::text"
+        if connection.vendor == "postgresql"
+        else q_column
+    )
+    last_pk: Any = None
+    while True:
+        with connection.cursor() as cursor:
+            if last_pk is None:
+                cursor.execute(
+                    f"SELECT {q_pk}, {q_context}, {raw_column} FROM {q_table} "  # noqa: S608
+                    f"ORDER BY {q_pk} LIMIT %s",
+                    [BATCH_SIZE],
+                )
+            else:
+                cursor.execute(
+                    f"SELECT {q_pk}, {q_context}, {raw_column} FROM {q_table} "  # noqa: S608
+                    f"WHERE {q_pk} > %s ORDER BY {q_pk} LIMIT %s",
+                    [last_pk, BATCH_SIZE],
+                )
+            batch = cursor.fetchall()
+        if not batch:
+            return
+        yield from batch
+        last_pk = batch[-1][0]
+
+
+def bind_encryption_context(apps: Any, schema_editor: Any) -> None:
+    connection = schema_editor.connection
+    quote = connection.ops.quote_name
+    q_table = quote(TABLE)
+    q_pk = quote("id")
+    q_context = quote(CONTEXT_COLUMN)
+    q_column = quote(COLUMN)
+    context_field = apps.get_model("customers", "CustomerPaymentMethod")._meta.get_field(
+        CONTEXT_COLUMN
+    )
+
+    for pk, existing_context, raw in _rows(schema_editor):
+        if existing_context is not None:
+            raise RuntimeError(
+                f"customer payment method {pk} already has an encryption context"
+            )
+        context = uuid.uuid4()
+        stored_context = context_field.get_db_prep_value(context, connection)
+        stored_value = None
+        if raw is not None:
+            plaintext = _plaintext_for_forward(_decoded_column(raw), pk)
+            aad = f"{TABLE}:{COLUMN}:{context}".encode()
+            stored_value = _stored_wire(plaintext, aad)
+
+        with connection.cursor() as cursor:
+            raw_cas = (
+                f"{q_column}::text = %s"
+                if connection.vendor == "postgresql"
+                else f"{q_column} = %s"
+            )
+            value_predicate = (
+                f"{q_column} IS NULL"
+                if raw is None
+                else raw_cas
+            )
+            params = [stored_context, stored_value, pk]
+            if raw is not None:
+                params.append(raw)
+            cursor.execute(
+                f"UPDATE {q_table} SET {q_context} = %s, {q_column} = %s "  # noqa: S608
+                f"WHERE {q_pk} = %s AND {q_context} IS NULL "
+                f"AND {value_predicate}",
+                params,
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"customer payment method {pk} changed during encryption migration"
+                )
+
+
+def restore_primary_key_context(apps: Any, schema_editor: Any) -> None:
+    connection = schema_editor.connection
+    quote = connection.ops.quote_name
+    q_table = quote(TABLE)
+    q_pk = quote("id")
+    q_context = quote(CONTEXT_COLUMN)
+    q_column = quote(COLUMN)
+
+    for pk, context, raw in _rows(schema_editor):
+        if context is None:
+            raise RuntimeError(
+                f"customer payment method {pk} has no encryption context"
+            )
+        if raw is None:
+            continue
+        inner = _decoded_column(raw)
+        if not isinstance(inner, str) or not inner.startswith(VERSIONED_V2_PREFIX):
+            raise RuntimeError(
+                f"customer payment method {pk} is not context-bound v2 ciphertext"
+            )
+        canonical_context = str(uuid.UUID(str(context)))
+        current_aad = f"{TABLE}:{COLUMN}:{canonical_context}".encode()
+        try:
+            value = json.loads(decrypt_sensitive_data(inner, aad=current_aad))
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError(
+                f"customer payment method {pk} cannot be restored"
+            ) from exc
+        old_aad = f"{TABLE}:{COLUMN}:{pk}".encode()
+        restored = _stored_wire(value, old_aad)
+        with connection.cursor() as cursor:
+            raw_cas = (
+                f"{q_column}::text = %s"
+                if connection.vendor == "postgresql"
+                else f"{q_column} = %s"
+            )
+            cursor.execute(
+                f"UPDATE {q_table} SET {q_column} = %s "  # noqa: S608
+                f"WHERE {q_pk} = %s AND {q_context} = %s AND {raw_cas}",
+                [restored, pk, context, raw],
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"customer payment method {pk} changed during encryption rollback"
+                )
+
+
+def create_context_immutability_trigger(apps: Any, schema_editor: Any) -> None:
+    vendor = schema_editor.connection.vendor
+    if vendor == "postgresql":
+        schema_editor.execute(
+            """
+            CREATE FUNCTION customer_payment_method_encryption_context_immutable()
+            RETURNS trigger AS $$
+            BEGIN
+                IF NEW.encryption_context_id IS DISTINCT FROM OLD.encryption_context_id THEN
+                    RAISE EXCEPTION 'customer payment method encryption context is immutable';
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql
+            """
+        )
+        schema_editor.execute(
+            """
+            CREATE TRIGGER customer_payment_method_encryption_context_immutable
+            BEFORE UPDATE OF encryption_context_id ON customer_payment_methods
+            FOR EACH ROW
+            EXECUTE FUNCTION customer_payment_method_encryption_context_immutable()
+            """
+        )
+    elif vendor == "sqlite":
+        schema_editor.execute(
+            """
+            CREATE TRIGGER customer_payment_method_encryption_context_immutable
+            BEFORE UPDATE OF encryption_context_id ON customer_payment_methods
+            FOR EACH ROW
+            WHEN OLD.encryption_context_id IS NOT NEW.encryption_context_id
+            BEGIN
+                SELECT RAISE(ABORT, 'customer payment method encryption context is immutable');
+            END
+            """
+        )
+    else:
+        raise RuntimeError(
+            "payment-method encryption context supports PostgreSQL and SQLite only"
+        )
+
+
+def drop_context_immutability_trigger(apps: Any, schema_editor: Any) -> None:
+    vendor = schema_editor.connection.vendor
+    schema_editor.execute(
+        "DROP TRIGGER IF EXISTS customer_payment_method_encryption_context_immutable "
+        "ON customer_payment_methods"
+        if vendor == "postgresql"
+        else "DROP TRIGGER IF EXISTS customer_payment_method_encryption_context_immutable"
+    )
+    if vendor == "postgresql":
+        schema_editor.execute(
+            "DROP FUNCTION IF EXISTS customer_payment_method_encryption_context_immutable()"
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("customers", "0018_remove_dormant_auto_payment_flag"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customerpaymentmethod",
+            name="encryption_context_id",
+            field=models.UUIDField(editable=False, null=True),
+        ),
+        migrations.RunPython(
+            bind_encryption_context,
+            restore_primary_key_context,
+        ),
+        migrations.AlterField(
+            model_name="customerpaymentmethod",
+            name="encryption_context_id",
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+        ),
+        migrations.AlterField(
+            model_name="customerpaymentmethod",
+            name="bank_details",
+            field=apps.common.fields.EncryptedJSONField(
+                aad_context_field="encryption_context_id",
+                blank=True,
+                null=True,
+                require_v2=True,
+                verbose_name="Detalii bancare",
+            ),
+        ),
+        migrations.RunPython(
+            create_context_immutability_trigger,
+            drop_context_immutability_trigger,
+        ),
+    ]

--- a/services/platform/apps/customers/signals.py
+++ b/services/platform/apps/customers/signals.py
@@ -574,7 +574,7 @@ def store_original_payment_values(
 
         if instance.pk:
             try:
-                original = CustomerPaymentMethod.objects.get(pk=instance.pk)
+                original = CustomerPaymentMethod.objects.defer("bank_details").get(pk=instance.pk)
                 instance._original_payment_values = {
                     "method_type": getattr(original, "method_type", None),
                     "display_name": getattr(original, "display_name", None),

--- a/services/platform/tests/api/test_recurring_payments_api.py
+++ b/services/platform/tests/api/test_recurring_payments_api.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from unittest.mock import MagicMock, patch
 
+from django.db import connection
 from django.test import TestCase, override_settings
+from django.utils import timezone
 from tests.helpers.hmac import HMAC_TEST_MIDDLEWARE, HMAC_TEST_SECRET, HMACTestMixin
 
+from apps.billing.models import RecurringPaymentAuthorization
 from apps.billing.recurring_authorization_service import RecurringPaymentAuthorizationService
 from apps.customers.models import Customer, CustomerPaymentMethod
 from apps.users.models import CustomerMembership, User
@@ -52,6 +57,37 @@ class RecurringPaymentsAPITestCase(HMACTestMixin, TestCase):
         self.assertEqual(body["payment_methods"][0]["id"], self.method.id)
         self.assertNotIn("stripe_payment_method_id", body["payment_methods"][0])
         self.assertNotIn("stripe_customer_id", body["payment_methods"][0])
+
+    def test_overview_does_not_read_unrelated_bank_details(self) -> None:
+        terms = "Authorized recurring collection terms"
+        RecurringPaymentAuthorization.objects.create(
+            customer=self.customer,
+            payment_method=self.method,
+            status="active",
+            setup_intent_id="seti_corrupt_unrelated_bank",
+            terms_version="test-v1",
+            terms_text=terms,
+            terms_text_hash=hashlib.sha256(terms.encode()).hexdigest(),
+            granted_by=self.owner,
+            granted_by_role="owner",
+            granted_at=timezone.now(),
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [json.dumps("aes:v2:!!!garbage!!!"), self.method.id],
+            )
+
+        response = self.portal_post(
+            "/api/billing/recurring-payments/",
+            self._payload("recurring_payment_overview"),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["payment_methods"][0]["id"], self.method.id)
+        self.assertIsNotNone(
+            response.json()["payment_methods"][0]["authorization"]
+        )
 
     def test_technical_member_cannot_read_or_manage_recurring_payment_state(self) -> None:
         technician = User.objects.create_user(email="api-tech@example.test")

--- a/services/platform/tests/billing/test_subscription_invoice_payments.py
+++ b/services/platform/tests/billing/test_subscription_invoice_payments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import uuid
 from datetime import datetime, timedelta
@@ -28,7 +29,11 @@ from apps.billing.payment_service import (
 )
 from apps.billing.proforma_models import ProformaInvoice, ProformaLine
 from apps.billing.recurring_authorization_service import RecurringPaymentAuthorizationService
-from apps.billing.recurring_billing import RecurringBillingOrchestrator, next_billing_period_end
+from apps.billing.recurring_billing import (
+    RecurringBillingOrchestrator,
+    RecurringCollectionGate,
+    next_billing_period_end,
+)
 from apps.billing.recurring_models import RecurringPaymentAuthorization
 from apps.billing.subscription_models import Subscription
 from apps.billing.subscription_service import SubscriptionLifecycleService
@@ -238,6 +243,33 @@ class _SubscriptionInvoicePaymentFixture:
 
 class SubscriptionInvoicePaymentTestCase(_SubscriptionInvoicePaymentFixture, TestCase):
     """Exercise the real invoice, Payment, and recurring-billing path."""
+
+    def _corrupt_unrelated_bank_details(self) -> None:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [json.dumps("aes:v2:!!!garbage!!!"), self.payment_method.pk],
+            )
+
+    def test_collection_gate_does_not_read_unrelated_bank_details(self) -> None:
+        self._corrupt_unrelated_bank_details()
+
+        result = RecurringCollectionGate.authorize_invoice(
+            self.invoice,
+            self.payment_method,
+        )
+
+        self.assertTrue(result.is_ok(), result)
+
+    def test_proforma_preparation_does_not_read_unrelated_bank_details(self) -> None:
+        now = timezone.now()
+        self._create_aligned_subscription("CORRUPT-BANK", now)
+        self._corrupt_unrelated_bank_details()
+
+        result = RecurringBillingOrchestrator.prepare_due_proformas(as_of=now)
+
+        self.assertEqual(result["proformas_created"], 1)
+        self.assertEqual(result["errors"], [])
 
     def test_due_aligned_services_share_one_cycle_linked_proforma_idempotently(self) -> None:
         now = timezone.now()

--- a/services/platform/tests/common/test_encrypted_json_field.py
+++ b/services/platform/tests/common/test_encrypted_json_field.py
@@ -2,13 +2,14 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import patch
 
-from django.db import connection
+from django.db import DatabaseError, connection, transaction
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from apps.common.encryption import (
     VERSIONED_V2_PREFIX,
+    DecryptionError,
+    EncryptionError,
     _clear_aesgcm_cache,
     decrypt_sensitive_data,
     encrypt_sensitive_data,
@@ -121,7 +122,7 @@ class EncryptedJSONFieldRoundtripTest(TestCase):
 
 @override_settings(ENCRYPTION_KEY=TEST_KEY)
 class EncryptedJSONFieldLegacyDataTest(TestCase):
-    """Backward compatibility with pre-existing unencrypted data."""
+    """Payment data rejects unmigrated plaintext instead of treating it as healthy."""
 
     def setUp(self) -> None:
         self.customer = Customer.objects.create(
@@ -132,8 +133,7 @@ class EncryptedJSONFieldLegacyDataTest(TestCase):
             primary_phone="+40712345679",
         )
 
-    def test_legacy_unencrypted_dict_still_readable(self) -> None:
-        """Pre-existing plaintext JSON dicts are returned as-is on read."""
+    def test_legacy_unencrypted_dict_fails_loud(self) -> None:
         # Insert plaintext JSON directly (simulating pre-encryption data)
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer,
@@ -148,13 +148,10 @@ class EncryptedJSONFieldLegacyDataTest(TestCase):
                 ['{"bank_name": "Legacy BT", "iban": "RO49BTRL1B31007593840001"}', pm.id],
             )
 
-        pm.refresh_from_db()
-        # Should be readable as a dict (backward compat)
-        self.assertIsInstance(pm.bank_details, dict)
-        self.assertEqual(pm.bank_details["bank_name"], "Legacy BT")
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=pm.pk)
 
-    def test_legacy_data_encrypted_on_resave(self) -> None:
-        """Legacy plaintext data gets encrypted when re-saved."""
+    def test_failed_read_preserves_legacy_ciphertext_evidence(self) -> None:
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer,
             method_type="bank_transfer",
@@ -167,21 +164,45 @@ class EncryptedJSONFieldLegacyDataTest(TestCase):
                 "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
                 ['{"iban": "RO49AAAA1B31007593840000"}', pm.id],
             )
-        pm.refresh_from_db()
-        # Re-save to trigger encryption
-        pm.save()
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT bank_details FROM customer_payment_methods WHERE id = %s", [pm.id])
+            before = cursor.fetchone()[0]
 
-        # Verify raw DB now contains encrypted data
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=pm.pk)
+
         with connection.cursor() as cursor:
             cursor.execute(
                 "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
                 [pm.id],
             )
-            raw_value = cursor.fetchone()[0]
+            after = cursor.fetchone()[0]
+        self.assertEqual(after, before)
 
-        raw_str = raw_value if isinstance(raw_value, str) else str(raw_value)
-        self.assertIn("aes:", raw_str)
-        self.assertNotIn("RESAVE", raw_str)
+    def test_corrupt_ciphertext_fails_loud_and_remains_untouched(self) -> None:
+        pm = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Corrupt Bank",
+            bank_details=None,
+        )
+        corrupt = json.dumps("aes:v2:!!!garbage!!!")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [corrupt, pm.id],
+            )
+
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=pm.pk)
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
+                [pm.id],
+            )
+            after = cursor.fetchone()[0]
+        self.assertEqual(after, corrupt)
 
 
 @override_settings(ENCRYPTION_KEY=TEST_KEY)
@@ -217,8 +238,7 @@ class EncryptedJSONFieldAADTest(TestCase):
         raw_str = raw_value if isinstance(raw_value, str) else str(raw_value)
         self.assertIn("aes:v2:", raw_str)
 
-    def test_aad_embedded_includes_table_and_field(self) -> None:
-        """Embedded AAD must include table name and field name for context binding."""
+    def test_first_insert_aad_uses_exact_row_encryption_identity(self) -> None:
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer,
             method_type="bank_transfer",
@@ -237,35 +257,72 @@ class EncryptedJSONFieldAADTest(TestCase):
         encrypted_str = json.loads(raw_str) if raw_str.startswith('"') else raw_str
         aad = _extract_embedded_aad(encrypted_str)
         self.assertIsNotNone(aad)
-        aad_str = aad.decode() if aad else ""
-        # AAD contains table:field: (pk may be empty on INSERT for auto-increment)
-        self.assertIn("customer_payment_methods", aad_str)
-        self.assertIn("bank_details", aad_str)
+        self.assertEqual(
+            aad,
+            f"customer_payment_methods:bank_details:{pm.encryption_context_id}".encode(),
+        )
 
-    def test_resaved_aad_includes_pk(self) -> None:
-        """After re-save, AAD includes the pk for full context binding."""
+    def test_same_field_cross_row_transplant_fails_for_models_and_values(self) -> None:
+        source = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Source",
+            bank_details={"iban": "RO49SOURCE11111111111111"},
+        )
+        target = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Target",
+            bank_details={"iban": "RO49TARGET11111111111111"},
+        )
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT bank_details FROM customer_payment_methods WHERE id = %s", [source.id])
+            source_raw = cursor.fetchone()[0]
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [source_raw, target.id],
+            )
+
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=target.pk)
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.filter(pk=target.pk).values_list("bank_details", flat=True).get()
+
+    def test_row_encryption_identity_is_database_immutable(self) -> None:
+        source = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Identity source",
+            bank_details={"iban": "RO49SOURCE11111111111111"},
+        )
+        target = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Identity target",
+            bank_details={"iban": "RO49TARGET11111111111111"},
+        )
+
+        with self.assertRaises(DatabaseError), transaction.atomic():
+            CustomerPaymentMethod.objects.filter(pk=target.pk).update(
+                encryption_context_id=source.encryption_context_id
+            )
+        target.refresh_from_db()
+        self.assertNotEqual(target.encryption_context_id, source.encryption_context_id)
+
+    def test_values_and_values_list_preserve_valid_plaintext_shape(self) -> None:
+        details = {"bank_name": "BT", "iban": "RO49VALUE111111111111111"}
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer,
             method_type="bank_transfer",
-            display_name="Resave AAD",
-            bank_details={"iban": "RO49AAAA1111111111111111"},
+            display_name="Projection",
+            bank_details=details,
         )
-        # Re-save: now pk is known
-        pm.save()
 
-        with connection.cursor() as cursor:
-            cursor.execute(
-                "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
-                [pm.id],
-            )
-            raw = cursor.fetchone()[0]
-
-        raw_str = raw if isinstance(raw, str) else str(raw)
-        encrypted_str = json.loads(raw_str) if raw_str.startswith('"') else raw_str
-        aad = _extract_embedded_aad(encrypted_str)
-        self.assertIsNotNone(aad)
-        aad_str = aad.decode() if aad else ""
-        self.assertIn(str(pm.id), aad_str)
+        projected = CustomerPaymentMethod.objects.filter(pk=pm.pk).values("bank_details").get()
+        listed = CustomerPaymentMethod.objects.filter(pk=pm.pk).values_list("bank_details", flat=True).get()
+        self.assertEqual(projected["bank_details"], details)
+        self.assertEqual(listed, details)
 
     def test_roundtrip_with_aad(self) -> None:
         """Normal save/load cycle works with AAD binding."""
@@ -307,9 +364,8 @@ class EncryptedJSONFieldRequireV2Test(TestCase):
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer, method_type="bank_transfer", display_name="V2", bank_details=details
         )
-        with patch.object(self.field, "require_v2", True):
-            pm.refresh_from_db()
-            self.assertEqual(pm.bank_details, details)
+        pm.refresh_from_db()
+        self.assertEqual(pm.bank_details, details)
 
     def test_v1_ciphertext_is_rejected(self) -> None:
         pm = CustomerPaymentMethod.objects.create(
@@ -320,9 +376,8 @@ class EncryptedJSONFieldRequireV2Test(TestCase):
         self.assertTrue(v1_cipher.startswith("aes:v1:"))
         self._write_raw(pm.id, json.dumps(v1_cipher))
 
-        with patch.object(self.field, "require_v2", True):
-            pm.refresh_from_db()
-            self.assertIsNone(pm.bank_details)
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=pm.pk)
 
     def test_plaintext_is_rejected(self) -> None:
         pm = CustomerPaymentMethod.objects.create(
@@ -330,20 +385,11 @@ class EncryptedJSONFieldRequireV2Test(TestCase):
         )
         self._write_raw(pm.id, '{"iban": "RO00PLAINTEXT"}')
 
-        with patch.object(self.field, "require_v2", True):
-            pm.refresh_from_db()
-            self.assertIsNone(pm.bank_details)
+        with self.assertRaises(DecryptionError):
+            CustomerPaymentMethod.objects.get(pk=pm.pk)
 
-    def test_default_still_reads_v1_for_backward_compat(self) -> None:
-        """With require_v2 left False (default), v1 ciphertext is still readable."""
-        pm = CustomerPaymentMethod.objects.create(
-            customer=self.customer, method_type="bank_transfer", display_name="Compat", bank_details=None
-        )
-        v1_cipher = encrypt_sensitive_data(json.dumps({"iban": "RO00COMPAT"}))
-        self._write_raw(pm.id, json.dumps(v1_cipher))
-
-        pm.refresh_from_db()
-        self.assertEqual(pm.bank_details, {"iban": "RO00COMPAT"})
+    def test_customer_payment_method_requires_v2(self) -> None:
+        self.assertTrue(self.field.require_v2)
 
 
 # ===============================================================================
@@ -406,25 +452,41 @@ class EncryptedJSONFieldWritePathTest(TestCase):
             primary_phone="+40712345682",
         )
 
-    def test_queryset_update_stores_unbound_v1_and_warns(self) -> None:
-        """.update(field=dict) bypasses pre_save — stores unbound v1 WITH a warning (not silent, not raised).
-
-        Raising here would break dumpdata→loaddata (which also bypasses pre_save); silently
-        writing v1 was the original defect. The middle ground: encrypt v1 and log loudly.
-        """
+    def test_queryset_update_rejects_unbound_plaintext(self) -> None:
         pm = CustomerPaymentMethod.objects.create(
             customer=self.customer, method_type="bank_transfer", display_name="U", bank_details={}
         )
-        with self.assertLogs("apps.common.fields", level="WARNING") as logs:
+        with self.assertRaises(EncryptionError), transaction.atomic():
             CustomerPaymentMethod.objects.filter(pk=pm.pk).update(bank_details={"bank_name": "BT"})
-        self.assertTrue(any("without AAD context" in line for line in logs.output))
 
         pm.refresh_from_db()
-        self.assertEqual(pm.bank_details, {"bank_name": "BT"})  # readable (require_v2 default False)
+        self.assertEqual(pm.bank_details, {})
+
+    def test_queryset_update_rejects_prebuilt_ciphertext(self) -> None:
+        source = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Source",
+            bank_details={"iban": "RO49SOURCE11111111111111"},
+        )
+        target = CustomerPaymentMethod.objects.create(
+            customer=self.customer,
+            method_type="bank_transfer",
+            display_name="Target",
+            bank_details={"iban": "RO49TARGET11111111111111"},
+        )
         with connection.cursor() as cursor:
-            cursor.execute("SELECT bank_details FROM customer_payment_methods WHERE id = %s", [pm.id])
+            cursor.execute(
+                "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
+                [source.pk],
+            )
             raw = cursor.fetchone()[0]
-        self.assertIn("aes:v1:", str(raw))  # stored unbound (v1), no AAD
+        wire = json.loads(raw) if isinstance(raw, str) and raw.startswith('"') else raw
+
+        with self.assertRaises(EncryptionError), transaction.atomic():
+            CustomerPaymentMethod.objects.filter(pk=target.pk).update(
+                bank_details=wire
+            )
 
     def test_bulk_create_roundtrips_encrypted_v2(self) -> None:
         """bulk_create DOES run pre_save, so values are encrypted (v2) and round-trip."""
@@ -445,13 +507,18 @@ class EncryptedJSONFieldWritePathTest(TestCase):
             )
         )
         self.assertEqual(len(rows), 2)
+        self.assertNotEqual(rows[0].encryption_context_id, rows[1].encryption_context_id)
         self.assertEqual(rows[0].bank_details["iban"], ibans[0])
         self.assertEqual(rows[1].bank_details["iban"], ibans[1])
         with connection.cursor() as cursor:
             cursor.execute("SELECT bank_details FROM customer_payment_methods WHERE id = %s", [rows[0].id])
             raw = cursor.fetchone()[0]
         raw_str = raw if isinstance(raw, str) else str(raw)
-        self.assertIn("aes:v2:", raw_str)
+        wire = json.loads(raw_str) if raw_str.startswith('"') else raw_str
+        self.assertEqual(
+            _extract_embedded_aad(wire),
+            f"customer_payment_methods:bank_details:{rows[0].encryption_context_id}".encode(),
+        )
 
 
 # ===============================================================================
@@ -472,3 +539,8 @@ class EncryptedJSONFieldDeconstructTest(SimpleTestCase):
         field = EncryptedJSONField()
         _name, _path, _args, kwargs = field.deconstruct()
         self.assertNotIn("require_v2", kwargs)
+
+    def test_deconstruct_preserves_aad_context_field(self) -> None:
+        field = EncryptedJSONField(aad_context_field="encryption_context_id")
+        _name, _path, _args, kwargs = field.deconstruct()
+        self.assertEqual(kwargs["aad_context_field"], "encryption_context_id")

--- a/services/platform/tests/common/test_encryption.py
+++ b/services/platform/tests/common/test_encryption.py
@@ -14,7 +14,9 @@ from apps.common.encryption import (
     VERSIONED_V2_PREFIX,
     DecryptionError,
     EncryptionError,
+    _aesgcm_cache,
     _clear_aesgcm_cache,
+    _get_aesgcm,
     decrypt_if_needed,
     decrypt_sensitive_data,
     decrypt_value,
@@ -310,8 +312,13 @@ class TestAADBinding(SimpleTestCase):
     def test_aad_roundtrip(self) -> None:
         aad = b"table:field:pk"
         encrypted = encrypt_sensitive_data("aad-data", aad=aad)
-        # v2 decryption is self-contained — AAD is embedded
-        self.assertEqual(decrypt_sensitive_data(encrypted), "aad-data")
+        self.assertEqual(decrypt_sensitive_data(encrypted, aad=aad), "aad-data")
+
+    def test_v2_expected_aad_mismatch_is_rejected(self) -> None:
+        encrypted = encrypt_sensitive_data("row-a", aad=b"table:field:row-a")
+
+        with self.assertRaises(DecryptionError):
+            decrypt_sensitive_data(encrypted, aad=b"table:field:row-b")
 
     def test_aad_mismatch_fails_gcm_auth(self) -> None:
         """Ciphertext encrypted with one AAD cannot be decrypted if AAD is tampered."""
@@ -332,10 +339,31 @@ class TestAADBinding(SimpleTestCase):
         encrypted = encrypt_sensitive_data("no-aad")
         self.assertTrue(encrypted.startswith(VERSIONED_V1_PREFIX))
 
-    def test_v2_with_empty_aad(self) -> None:
-        encrypted = encrypt_sensitive_data("empty-aad", aad=b"")
-        self.assertTrue(encrypted.startswith(VERSIONED_V2_PREFIX))
-        self.assertEqual(decrypt_sensitive_data(encrypted), "empty-aad")
+    def test_v2_with_empty_aad_is_rejected(self) -> None:
+        with self.assertRaises(EncryptionError):
+            encrypt_sensitive_data("empty-aad", aad=b"")
+
+        with self.assertRaises(EncryptionError):
+            encrypt_sensitive_data("", aad=b"")
+
+    def test_existing_v2_ciphertext_with_empty_aad_is_rejected(self) -> None:
+        key = base64.urlsafe_b64decode(TEST_KEY)
+        nonce = os.urandom(12)
+        ciphertext = AESGCM(key).encrypt(nonce, b"legacy-empty-aad", b"")
+        wire = VERSIONED_V2_PREFIX + base64.urlsafe_b64encode(
+            b"\x00\x00" + nonce + ciphertext
+        ).decode("ascii")
+
+        with self.assertRaises(DecryptionError):
+            decrypt_sensitive_data(wire)
+
+    def test_v2_ciphertext_rejects_non_base64_characters(self) -> None:
+        encrypted = encrypt_sensitive_data("strict-base64", aad=b"table:field:row")
+        prefix, encoded = encrypted.rsplit(":", 1)
+        malformed = f"{prefix}:{encoded[:5]}!{encoded[5:]}"
+
+        with self.assertRaises(DecryptionError):
+            decrypt_sensitive_data(malformed)
 
     def test_v2_with_long_aad(self) -> None:
         aad = b"a" * 500
@@ -408,6 +436,12 @@ class TestKeyringStrictValidation(SimpleTestCase):
 
     def setUp(self) -> None:
         _clear_aesgcm_cache()
+
+    def test_aesgcm_cache_is_bounded_during_key_rotation(self) -> None:
+        for marker in range(32):
+            _get_aesgcm(bytes([marker]) * 32)
+
+        self.assertLessEqual(len(_aesgcm_cache), 8)
 
     @override_settings(ENCRYPTION_KEYS=[TEST_KEY, "not-valid-base64-@@@@"])
     def test_malformed_previous_key_raises_not_skipped(self) -> None:

--- a/services/platform/tests/common/test_reencrypt_with_aad.py
+++ b/services/platform/tests/common/test_reencrypt_with_aad.py
@@ -15,6 +15,7 @@ from apps.common.encryption import (
     decrypt_sensitive_data,
     encrypt_sensitive_data,
 )
+from apps.common.fields import _extract_embedded_aad
 from apps.customers.models import Customer, CustomerPaymentMethod
 
 TEST_KEY = "iuTrSBoKchmRt7RiySTHNuANNDmWe_xIqZWtMQaLMXs="
@@ -67,6 +68,10 @@ class ReencryptWithAadCommandTest(TestCase):
         self.assertIsInstance(stored, str)
         assert isinstance(stored, str)
         self.assertTrue(stored.startswith(VERSIONED_V2_PREFIX))
+        self.assertEqual(
+            _extract_embedded_aad(stored),
+            f"customer_payment_methods:bank_details:{pm.encryption_context_id}".encode(),
+        )
         self.assertEqual(json.loads(decrypt_sensitive_data(stored)), VALID)
 
     def test_idempotent_second_run_is_a_true_noop(self) -> None:
@@ -133,7 +138,7 @@ class ReencryptWithAadCommandTest(TestCase):
         self.assertEqual(self._read_raw(pm.id), "aes:v2:!!!garbage!!!")  # untouched
 
     def test_transplanted_v2_row_flagged_not_skipped_as_healthy(self) -> None:
-        """A v2 blob bound to a DIFFERENT table:field decrypts but reads back None under require_v2.
+        """A v2 blob bound to a DIFFERENT table:field fails under require_v2.
 
         The command must flag it (it can't safely report 'already v2'), not skip it as healthy.
         """
@@ -144,6 +149,22 @@ class ReencryptWithAadCommandTest(TestCase):
         with self.assertRaises(CommandError):
             call_command("reencrypt_with_aad", stdout=StringIO(), stderr=StringIO())
         self.assertEqual(self._read_raw(pm.id), wrong)  # untouched (not migrated, not reported healthy)
+
+    def test_same_field_cross_row_v2_is_flagged_not_skipped_as_healthy(self) -> None:
+        source = self._make_pm("Source")
+        target = self._make_pm("Target")
+        wrong = encrypt_sensitive_data(
+            json.dumps(VALID),
+            aad=(
+                f"customer_payment_methods:bank_details:"
+                f"{source.encryption_context_id}"
+            ).encode(),
+        )
+        self._write_raw(target.id, wrong)
+
+        with self.assertRaises(CommandError):
+            call_command("reencrypt_with_aad", stdout=StringIO(), stderr=StringIO())
+        self.assertEqual(self._read_raw(target.id), wrong)
 
     def test_cas_retries_and_resolves_after_a_stale_read(self) -> None:
         """A first CAS miss (stale read) is retried against the row's real current value and migrates."""
@@ -158,9 +179,12 @@ class ReencryptWithAadCommandTest(TestCase):
         pk = pm.id
 
         def fake_read_batch(
-            _self: Command, _q_table: str, _q_col: str, _q_pk: str, last_pk: object, _batch: int
-        ) -> list[tuple[object, object]]:
-            return [(pk, stale_raw)] if last_pk is None else []
+            _self: Command,
+            _field: object,
+            last_pk: object,
+            _batch: int,
+        ) -> list[tuple[object, object, object]]:
+            return [(pk, pm.encryption_context_id, stale_raw)] if last_pk is None else []
 
         with patch.object(Command, "_read_batch", fake_read_batch):
             call_command("reencrypt_with_aad", stdout=StringIO())
@@ -180,11 +204,18 @@ class ReencryptWithAadCommandTest(TestCase):
         pk = pm.id
 
         def fake_read_batch(
-            _self: Command, _q_table: str, _q_col: str, _q_pk: str, last_pk: object, _batch: int
-        ) -> list[tuple[object, object]]:
-            return [(pk, stale_raw)] if last_pk is None else []
+            _self: Command,
+            _field: object,
+            last_pk: object,
+            _batch: int,
+        ) -> list[tuple[object, object, object]]:
+            return [(pk, pm.encryption_context_id, stale_raw)] if last_pk is None else []
 
-        def fake_read_one(_self: Command, _q_table: str, _q_col: str, _q_pk: str, _pk: object) -> object:
+        def fake_read_one(
+            _self: Command,
+            _field: object,
+            _pk: object,
+        ) -> object:
             return stale_raw  # every re-read is still stale → CAS always misses
 
         with (

--- a/services/platform/tests/customers/test_contact_service.py
+++ b/services/platform/tests/customers/test_contact_service.py
@@ -137,6 +137,16 @@ class TestContactServiceCreatePaymentMethod(TestCase):
         active = ContactService.get_active_payment_methods(self.customer)
         self.assertGreater(active.count(), 0)
 
+    def test_get_active_payment_methods_defers_sensitive_bank_details(self) -> None:
+        created = ContactService.create_payment_method(
+            self.customer, self.user, "stripe_card", "Visa *9999"
+        )
+
+        payment_method = ContactService.get_active_payment_methods(self.customer).get(
+            pk=created.pk
+        )
+        self.assertIn("bank_details", payment_method.get_deferred_fields())
+
 
 class TestContactServiceCreateAddress(TestCase):
     """ContactService.create_address() — versioning and current-flag management."""

--- a/services/platform/tests/customers/test_payment_method_encryption_migration.py
+++ b/services/platform/tests/customers/test_payment_method_encryption_migration.py
@@ -1,0 +1,209 @@
+"""Migration coverage for row-bound customer payment-method encryption."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from importlib import import_module
+from unittest.mock import patch
+
+from django.db import DatabaseError, connection, transaction
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TransactionTestCase, override_settings
+
+from apps.common.encryption import (
+    VERSIONED_V2_PREFIX,
+    decrypt_sensitive_data,
+    encrypt_sensitive_data,
+)
+from apps.common.fields import _extract_embedded_aad
+
+TEST_KEY = "iuTrSBoKchmRt7RiySTHNuANNDmWe_xIqZWtMQaLMXs="
+MIGRATE_FROM = ("customers", "0018_remove_dormant_auto_payment_flag")
+MIGRATE_TO = ("customers", "0019_bind_payment_method_encryption_context")
+DETAILS = {"bank_name": "BT", "iban": "RO49AAAA1B31007593840000"}
+
+
+@override_settings(ENCRYPTION_KEY=TEST_KEY)
+class PaymentMethodEncryptionMigrationTest(TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self) -> None:
+        super().setUp()
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_FROM])
+        old_apps = executor.loader.project_state([MIGRATE_FROM]).apps
+        Customer = old_apps.get_model("customers", "Customer")
+        payment_method_model = old_apps.get_model("customers", "CustomerPaymentMethod")
+        customer = Customer.objects.create(
+            name="Migration Customer",
+            customer_type="company",
+            status="active",
+            primary_email="migration@example.test",
+        )
+        self.payment_method = payment_method_model.objects.create(
+            customer=customer,
+            method_type="bank_transfer",
+            display_name="Legacy bank",
+            bank_details=None,
+        )
+        # Reproduce the old auto-increment INSERT behavior: the pk was unavailable,
+        # so the v2 AAD row component was empty.
+        old_wire = encrypt_sensitive_data(
+            json.dumps(DETAILS),
+            aad=b"customer_payment_methods:bank_details:",
+        )
+        self.initial_raw = json.dumps(old_wire)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [self.initial_raw, self.payment_method.pk],
+            )
+
+    def tearDown(self) -> None:
+        MigrationExecutor(connection).migrate([MIGRATE_TO])
+        super().tearDown()
+
+    def test_forward_and_reverse_preserve_data_and_bind_exact_context(self) -> None:
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_TO])
+        migrated_apps = executor.loader.project_state([MIGRATE_TO]).apps
+        payment_method_model = migrated_apps.get_model(
+            "customers",
+            "CustomerPaymentMethod",
+        )
+        migrated = payment_method_model.objects.get(pk=self.payment_method.pk)
+
+        self.assertEqual(migrated.bank_details, DETAILS)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT encryption_context_id, bank_details "
+                "FROM customer_payment_methods WHERE id = %s",
+                [self.payment_method.pk],
+            )
+            raw_context, raw_value = cursor.fetchone()
+        context = uuid.UUID(str(raw_context))
+        wire = json.loads(raw_value) if isinstance(raw_value, str) else raw_value
+        self.assertTrue(wire.startswith(VERSIONED_V2_PREFIX))
+        self.assertEqual(
+            _extract_embedded_aad(wire),
+            f"customer_payment_methods:bank_details:{context}".encode(),
+        )
+
+        with self.assertRaises(DatabaseError), transaction.atomic():
+            payment_method_model.objects.filter(pk=migrated.pk).update(
+                encryption_context_id=uuid.uuid4()
+            )
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_FROM])
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
+                [self.payment_method.pk],
+            )
+            restored_raw = cursor.fetchone()[0]
+        restored_wire = (
+            json.loads(restored_raw)
+            if isinstance(restored_raw, str)
+            else restored_raw
+        )
+        expected_aad = (
+            f"customer_payment_methods:bank_details:{self.payment_method.pk}".encode()
+        )
+        self.assertEqual(_extract_embedded_aad(restored_wire), expected_aad)
+        self.assertEqual(
+            json.loads(decrypt_sensitive_data(restored_wire, aad=expected_aad)),
+            DETAILS,
+        )
+
+    def test_forward_migration_aborts_instead_of_overwriting_changed_ciphertext(self) -> None:
+        migration = import_module(
+            "apps.customers.migrations.0019_bind_payment_method_encryption_context"
+        )
+        stale_wire = encrypt_sensitive_data(
+            json.dumps({"bank_name": "Stale"}),
+            aad=b"customer_payment_methods:bank_details:",
+        )
+        stale_row = (
+            self.payment_method.pk,
+            None,
+            json.dumps(stale_wire),
+        )
+
+        executor = MigrationExecutor(connection)
+        with (
+            patch.object(
+                migration,
+                "_rows",
+                return_value=iter([stale_row]),
+            ),
+            self.assertRaises(RuntimeError),
+        ):
+            executor.migrate([MIGRATE_TO])
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
+                [self.payment_method.pk],
+            )
+            unchanged = cursor.fetchone()[0]
+        self.assertNotEqual(unchanged, stale_row[2])
+
+    def test_forward_accepts_historical_primary_key_bound_v2(self) -> None:
+        historical = encrypt_sensitive_data(
+            json.dumps(DETAILS),
+            aad=(
+                f"customer_payment_methods:bank_details:{self.payment_method.pk}"
+            ).encode(),
+        )
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [json.dumps(historical), self.payment_method.pk],
+            )
+
+        executor = MigrationExecutor(connection)
+        executor.migrate([MIGRATE_TO])
+        migrated_apps = executor.loader.project_state([MIGRATE_TO]).apps
+        payment_method_model = migrated_apps.get_model(
+            "customers",
+            "CustomerPaymentMethod",
+        )
+
+        self.assertEqual(
+            payment_method_model.objects.get(pk=self.payment_method.pk).bank_details,
+            DETAILS,
+        )
+
+    def test_forward_rejects_v2_bound_to_an_unexpected_context(self) -> None:
+        unexpected = encrypt_sensitive_data(
+            json.dumps(DETAILS),
+            aad=b"customer_payment_methods:bank_details:another-row",
+        )
+        unexpected_raw = json.dumps(unexpected)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                [unexpected_raw, self.payment_method.pk],
+            )
+
+        try:
+            with self.assertRaises(RuntimeError):
+                MigrationExecutor(connection).migrate([MIGRATE_TO])
+
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT bank_details FROM customer_payment_methods WHERE id = %s",
+                    [self.payment_method.pk],
+                )
+                unchanged = cursor.fetchone()[0]
+            self.assertEqual(unchanged, unexpected_raw)
+        finally:
+            # Leave the pre-migration fixture valid so tearDown can restore the
+            # schema even after this deliberately rejected migration.
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "UPDATE customer_payment_methods SET bank_details = %s WHERE id = %s",
+                    [self.initial_raw, self.payment_method.pk],
+                )


### PR DESCRIPTION
## Summary

- bind customer payment-method bank details to an immutable per-row UUID from the first insert, preventing same-field ciphertext transplants without changing public integer IDs
- make encrypted reads fail loudly on corruption, downgrade, malformed base64, empty AAD, or exact-context mismatch so forensic ciphertext is never converted into a plausible null
- harden AES-GCM expected-AAD verification and key caching, upgrade the repair command, and defer unrelated bank data from Stripe-only billing paths
- document the design and deploy/rollback consequences in ADR-0040

Closes #205
Closes #267
Closes #268

## Architecture and migration

- customers.0019 assigns every payment-method row, including soft-deleted rows, a unique encryption_context_id and re-encrypts non-null bank details under exact UUID-bound AAD
- PostgreSQL and SQLite triggers make the encryption identity database-immutable
- the migration accepts only known historical primary-key or empty-first-insert AAD, plus v1/plaintext compatibility data; unexpected or corrupt data and concurrent row changes abort deployment
- rollback validates and re-encrypts data under the previous primary-key AAD before removing the context field
- context-bound field reads preserve model, values(), values_list(), only(), and deferred-load behavior while rejecting context-free bulk updates

## Verification

- make lint: pass, including Ruff delta, MyPy over 415 source files, Django checks, audit coverage, i18n, test layout, code health, and FSM guardrails
- make test: pass after rebasing onto current master; all platform, portal, integration, cache, and service-isolation phases completed successfully, with 7,256 platform tests discovered
- focused affected set: 216 tests passed
- migration and encryption paths were also exercised against PostgreSQL; exact new containment tests passed there
- make lint-security: zero new findings and hardcoded-credential checks passed; the command remains nonzero because master has 47 pre-existing blocking Semgrep findings
- merge verification: range-diff confirmed the signed patch was unchanged by the rebase and incoming refund/task changes remain intact

## Operational notes

The migration is deliberately fail-closed. Investigate any deployment failure rather than coercing or discarding an unreadable bank-details value. Plaintext dumpdata/loaddata round-tripping is no longer supported for this context-bound encrypted field; use database backups or sanitized fixtures instead.