### PR TITLE
feat(infrastructure): auto-provision Virtualmin API credentials — deployed nodes become customer-ready (#347)

### DIFF
--- a/services/platform/apps/infrastructure/ansible_service.py
+++ b/services/platform/apps/infrastructure/ansible_service.py
@@ -146,7 +146,7 @@ class AnsibleService:
         logger.info(f"📜 [Ansible] All {len(results)} playbooks completed successfully")
         return Ok(results)
 
-    def run_playbook(  # noqa: PLR0911, PLR0912  # Explicit fail-closed boundary checks
+    def run_playbook(  # noqa: PLR0911, PLR0912, C901  # Explicit fail-closed boundary checks + guarded temp-file cleanup
         self,
         deployment: NodeDeployment,
         playbook: str,
@@ -265,12 +265,17 @@ class AnsibleService:
             logger.error(f"🚨 [Ansible] Playbook {playbook} failed: {e}")
             return Err(f"Playbook execution failed: {e}")
         finally:
-            # Cleanup any temp files that were created (key, inventory, vars).
+            # Cleanup temp files (key, inventory, vars). Remove the SECRET-bearing vars file FIRST,
+            # and guard each unlink independently so one failure can't strand the others (a lingering
+            # 0600 credential file matters more than a leftover inventory).
             local_vars = locals()
-            for _tmp_name in ("key_file", "inventory_file", "vars_file"):
+            for _tmp_name in ("vars_file", "key_file", "inventory_file"):
                 _tmp_path = local_vars.get(_tmp_name)
-                if isinstance(_tmp_path, Path) and _tmp_path.exists():
-                    _tmp_path.unlink()
+                if isinstance(_tmp_path, Path):
+                    try:
+                        _tmp_path.unlink(missing_ok=True)
+                    except OSError as _cleanup_err:
+                        logger.warning(f"⚠️ [Ansible] Could not remove temp file {_tmp_path}: {_cleanup_err}")
 
     @staticmethod
     def _write_vars_file(vars_dict: dict[str, Any]) -> Path:
@@ -279,9 +284,16 @@ class AnsibleService:
         the host's process list. The caller removes it in its finally block."""
         vars_fd, vars_path_str = tempfile.mkstemp(prefix="praho_ansible_vars_", suffix=".json")
         vars_file = Path(vars_path_str)
-        with os.fdopen(vars_fd, "w") as vars_fh:
-            json.dump(vars_dict, vars_fh)
-        os.chmod(vars_file, 0o600)
+        try:
+            with os.fdopen(vars_fd, "w") as vars_fh:
+                json.dump(vars_dict, vars_fh)
+            os.chmod(vars_file, 0o600)
+        except Exception:
+            # A raise mid-write (non-serializable vars, disk full, chmod failure) would otherwise
+            # orphan a partial-secret 0600 file: the caller keys its finally cleanup on the RETURNED
+            # path, which never binds when this raises. Clean up our own temp before propagating.
+            vars_file.unlink(missing_ok=True)
+            raise
         return vars_file
 
     @staticmethod
@@ -309,10 +321,16 @@ class AnsibleService:
 [all:vars]
 ansible_python_interpreter=/usr/bin/python3
 """
-        # Write to temp file
+        # Write to temp file. Clean up our own temp on a mid-write failure so a raise here can't
+        # orphan it — the caller keys its finally cleanup on the RETURNED path, which never binds
+        # when this raises (mirrors _write_vars_file, #348 #5).
         fd, path = tempfile.mkstemp(prefix="ansible_inv_", suffix=".ini")
-        with os.fdopen(fd, "w") as f:
-            f.write(inventory_content)
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(inventory_content)
+        except Exception:
+            Path(path).unlink(missing_ok=True)
+            raise
 
         return Path(path)
 

--- a/services/platform/apps/infrastructure/ansible_service.py
+++ b/services/platform/apps/infrastructure/ansible_service.py
@@ -196,7 +196,11 @@ class AnsibleService:
 
             # Build extra vars
             vars_dict = self._build_vars(deployment, extra_vars)
-            vars_json = json.dumps(vars_dict)
+            # Pass vars via a 0600 temp file (`-e @file`), never `-e <json>` on the
+            # command line: extra_vars can carry secrets (the Virtualmin API
+            # password, #347) that would otherwise leak into the process list.
+            # Cleaned up in the finally block.
+            vars_file = self._write_vars_file(vars_dict)
 
             # Build command
             cmd = [
@@ -206,7 +210,7 @@ class AnsibleService:
                 "--private-key",
                 str(key_file),
                 "-e",
-                vars_json,
+                f"@{vars_file}",
                 str(playbook_path),
             ]
 
@@ -261,11 +265,24 @@ class AnsibleService:
             logger.error(f"🚨 [Ansible] Playbook {playbook} failed: {e}")
             return Err(f"Playbook execution failed: {e}")
         finally:
-            # Cleanup temporary files
-            if key_file.exists():
-                key_file.unlink()
-            if "inventory_file" in locals() and inventory_file.exists():
-                inventory_file.unlink()
+            # Cleanup any temp files that were created (key, inventory, vars).
+            local_vars = locals()
+            for _tmp_name in ("key_file", "inventory_file", "vars_file"):
+                _tmp_path = local_vars.get(_tmp_name)
+                if isinstance(_tmp_path, Path) and _tmp_path.exists():
+                    _tmp_path.unlink()
+
+    @staticmethod
+    def _write_vars_file(vars_dict: dict[str, Any]) -> Path:
+        """Write playbook vars to a 0600 temp file so secrets in extra_vars (the
+        Virtualmin API password, #347) never reach the ansible command line or
+        the host's process list. The caller removes it in its finally block."""
+        vars_fd, vars_path_str = tempfile.mkstemp(prefix="praho_ansible_vars_", suffix=".json")
+        vars_file = Path(vars_path_str)
+        with os.fdopen(vars_fd, "w") as vars_fh:
+            json.dump(vars_dict, vars_fh)
+        os.chmod(vars_file, 0o600)
+        return vars_file
 
     @staticmethod
     def _build_ansible_env() -> dict[str, str]:

--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -427,18 +427,44 @@ class NodeDeploymentService:
                     else str(deployment.panel_type)
                 )
 
-            # #347: generate the dedicated Virtualmin API credential BEFORE the
-            # Ansible stages so the panel playbook can provision it ON the node
-            # (create the ACL user with this password). Registration stores the
-            # same password in the vault, so the first API call — and
-            # verify_and_activate below — authenticate. Threaded via a 0600 vars
-            # file, so the secret never reaches the ansible command line.
-            import string  # noqa: PLC0415  # Deferred: stdlib, local use
+            # #347: resolve the dedicated Virtualmin API credential BEFORE the Ansible stages so the
+            # panel playbook can provision it ON the node (create the ACL user with this password).
+            # register_node stores it in the vault, so the first API call — and verify_and_activate
+            # below — authenticate. Threaded via a 0600 vars file, never the ansible command line.
+            #
+            # #348 finding #8: REUSE an existing vault credential for this node so a re-deploy is
+            # convergent ONCE A CREDENTIAL ALREADY EXISTS IN THE VAULT. create-admin tolerates an
+            # already-existing praho-api user WITHOUT resetting its password, so minting a fresh
+            # password every deploy would leave the node on the OLD password while the vault stored the
+            # NEW one -> verify_and_activate 401 -> disabled. The vault is the credential source of
+            # truth (ADR-0033). Residual edge (NOT converged): if a prior deploy created the node user
+            # but failed BEFORE the vault store, no vault entry exists, a fresh password is generated,
+            # and the node stays safely DISABLED (never active with a mismatch) until create-admin is
+            # reset on the node.
+            from apps.common.credential_vault import (  # noqa: PLC0415  # Deferred: avoids circular import
+                get_credential_vault,
+            )
 
             virtualmin_api_username = "praho-api"
-            virtualmin_api_password = "".join(
-                secrets.choice(string.ascii_letters + string.digits + "!@#$%^&*") for _ in range(24)
+            # The vault key MUST stay aligned with register_node (service_identifier=server.hostname)
+            # and verify_and_activate (reads by server.hostname). server.hostname is assigned
+            # =deployment.fqdn at registration, so this read key matches; keep them coupled to the same
+            # attribute if hostname derivation ever changes, or reuse silently never hits (fresh pw
+            # every re-deploy -> permanent 401/disabled).
+            _existing_cred = get_credential_vault().get_credential(
+                service_type="virtualmin",
+                service_identifier=deployment.fqdn,
+                reason=f"Node deploy credential resolution for {deployment.hostname} (#348)",
             )
+            if _existing_cred.is_ok() and _existing_cred.unwrap()[0] and _existing_cred.unwrap()[1]:
+                virtualmin_api_username, virtualmin_api_password, _ = _existing_cred.unwrap()
+                log_deployment("info", "Reusing existing Virtualmin API credential from the vault (re-deploy)")
+            else:
+                import string  # noqa: PLC0415  # Deferred: stdlib, local use
+
+                virtualmin_api_password = "".join(
+                    secrets.choice(string.ascii_letters + string.digits + "!@#$%^&*") for _ in range(24)
+                )
 
             playbook_names = self._ansible.get_playbook_order(panel_type)
             stage_keys = ["ansible_base", "ansible_panel", "ansible_harden", "ansible_backup"]
@@ -448,13 +474,23 @@ class NodeDeploymentService:
                 report_progress(stage_name)
                 log_deployment("info", f"Running Ansible playbook: {playbook}")
 
+                # Only the panel playbook (virtualmin.yml, the "ansible_panel" stage) provisions the
+                # ACL user, so scope the API credential to that stage. Broadcasting it to base/harden/
+                # backup would write the secret into a 0600 vars file for each and expose it to every
+                # task/callback in playbooks that never use it (#348 finding #6).
+                stage_extra_vars = (
+                    {
+                        "praho_api_user": virtualmin_api_username,
+                        "praho_api_password": virtualmin_api_password,
+                    }
+                    if stage_name == "ansible_panel"
+                    else None
+                )
+
                 playbook_result = self._ansible.run_playbook(
                     deployment=deployment,
                     playbook=playbook,
-                    extra_vars={
-                        "praho_api_user": virtualmin_api_username,
-                        "praho_api_password": virtualmin_api_password,
-                    },
+                    extra_vars=stage_extra_vars,
                 )
 
                 if playbook_result.is_err():
@@ -544,11 +580,21 @@ class NodeDeploymentService:
                 # authenticates, then activate. A failed check leaves the server
                 # 'disabled' (safe, never customer-routed) — the deployment still
                 # completes; the node simply isn't customer-ready until resolved.
-                activation = self._registration.verify_and_activate(server)
-                if activation.is_ok():
-                    log_deployment("info", f"VirtualminServer(id={server.id}) credential-verified and activated")
+                # Activation is best-effort: a failed/raised check leaves the server 'disabled'
+                # (safe, never customer-routed) but must NEVER fail an otherwise-complete deployment
+                # (#348 finding #7). verify_and_activate is total, but guard the call anyway so a
+                # future regression there can't roll back paid provisioning work.
+                try:
+                    activation = self._registration.verify_and_activate(server)
+                except Exception as activation_err:  # best-effort: activation must never be fatal to the deploy
+                    log_deployment(
+                        "warning", f"Node registered but activation raised (left disabled): {activation_err}"
+                    )
                 else:
-                    log_deployment("warning", f"Node registered but left disabled: {activation.unwrap_err()}")
+                    if activation.is_ok():
+                        log_deployment("info", f"VirtualminServer(id={server.id}) credential-verified and activated")
+                    else:
+                        log_deployment("warning", f"Node registered but left disabled: {activation.unwrap_err()}")
 
             stages_completed.append("registration")
 

--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -427,6 +427,19 @@ class NodeDeploymentService:
                     else str(deployment.panel_type)
                 )
 
+            # #347: generate the dedicated Virtualmin API credential BEFORE the
+            # Ansible stages so the panel playbook can provision it ON the node
+            # (create the ACL user with this password). Registration stores the
+            # same password in the vault, so the first API call — and
+            # verify_and_activate below — authenticate. Threaded via a 0600 vars
+            # file, so the secret never reaches the ansible command line.
+            import string  # noqa: PLC0415  # Deferred: stdlib, local use
+
+            virtualmin_api_username = "praho-api"
+            virtualmin_api_password = "".join(
+                secrets.choice(string.ascii_letters + string.digits + "!@#$%^&*") for _ in range(24)
+            )
+
             playbook_names = self._ansible.get_playbook_order(panel_type)
             stage_keys = ["ansible_base", "ansible_panel", "ansible_harden", "ansible_backup"]
             ansible_playbooks = list(zip(stage_keys, playbook_names, strict=False))
@@ -438,6 +451,10 @@ class NodeDeploymentService:
                 playbook_result = self._ansible.run_playbook(
                     deployment=deployment,
                     playbook=playbook,
+                    extra_vars={
+                        "praho_api_user": virtualmin_api_username,
+                        "praho_api_password": virtualmin_api_password,
+                    },
                 )
 
                 if playbook_result.is_err():
@@ -508,17 +525,10 @@ class NodeDeploymentService:
             deployment.transition_to("registering")
             log_deployment("info", "Registering node as VirtualminServer")
 
-            # Generate a random password for Virtualmin admin
-            import string  # noqa: PLC0415  # Deferred: avoids circular import
-
-            admin_password = "".join(
-                secrets.choice(string.ascii_letters + string.digits + "!@#$%^&*") for _ in range(24)
-            )
-
             registration_result = self._registration.register_node(
                 deployment=deployment,
-                admin_username="root",
-                admin_password=admin_password,
+                admin_username=virtualmin_api_username,
+                admin_password=virtualmin_api_password,
                 user=user,
             )
 
@@ -530,6 +540,15 @@ class NodeDeploymentService:
                 server = registration_result.unwrap()
                 virtualmin_server_id = server.id
                 log_deployment("info", f"Registered as VirtualminServer(id={server.id})")
+                # #347: confirm the credential the playbook provisioned actually
+                # authenticates, then activate. A failed check leaves the server
+                # 'disabled' (safe, never customer-routed) — the deployment still
+                # completes; the node simply isn't customer-ready until resolved.
+                activation = self._registration.verify_and_activate(server)
+                if activation.is_ok():
+                    log_deployment("info", f"VirtualminServer(id={server.id}) credential-verified and activated")
+                else:
+                    log_deployment("warning", f"Node registered but left disabled: {activation.unwrap_err()}")
 
             stages_completed.append("registration")
 

--- a/services/platform/apps/infrastructure/registration_service.py
+++ b/services/platform/apps/infrastructure/registration_service.py
@@ -133,7 +133,12 @@ class NodeRegistrationService:
                     vault = get_credential_vault()
                     credential_data = CredentialData(
                         service_type="virtualmin",
-                        service_identifier=deployment.fqdn,
+                        # Couple the vault WRITE key to server.hostname — the exact key the gateway
+                        # resolver READS by (resolve_server_credentials → get_credential by
+                        # server.hostname). Equal to deployment.fqdn today, but binding them to the
+                        # same attribute prevents a future hostname-derivation change from silently
+                        # desynchronizing writes and reads (fleet-wide fail-closed 401s otherwise).
+                        service_identifier=server.hostname,
                         username=admin_username,
                         password=admin_password,
                         metadata={

--- a/services/platform/apps/infrastructure/registration_service.py
+++ b/services/platform/apps/infrastructure/registration_service.py
@@ -171,7 +171,7 @@ class NodeRegistrationService:
             logger.error(f"🚨 [Registration] Failed to register node {deployment.hostname}: {e}")
             return Err(f"Registration failed: {e}")
 
-    def verify_and_activate(self, server: VirtualminServer) -> Result[VirtualminServer, str]:
+    def verify_and_activate(self, server: VirtualminServer) -> Result[VirtualminServer, str]:  # noqa: PLR0911  # Guarded credential-verification workflow: one early Err per gate (vault-miss/empty-cred/handshake/not-healthy/CAS)
         """
         #347 GAP 2: confirm the API credential provisioned on the node actually
         authenticates, then transition the server disabled -> active so placement
@@ -182,6 +182,9 @@ class NodeRegistrationService:
         """
         from django.utils import timezone  # noqa: PLC0415  # Deferred: local use
 
+        from apps.common.credential_vault import (  # noqa: PLC0415  # Circular: cross-app  # Deferred: avoids circular import
+            get_credential_vault,
+        )
         from apps.provisioning.virtualmin_gateway import (  # noqa: PLC0415  # Circular: cross-app  # Deferred: avoids circular import
             VirtualminConfig,
             VirtualminGateway,
@@ -192,11 +195,37 @@ class NodeRegistrationService:
         )
 
         try:
+            # Fetch the credential PRODUCTION will use: register_node stores it in the
+            # vault (keyed by hostname) and leaves encrypted_api_password=b"", so the
+            # server's own get_api_password() is empty. Verifying against the vault
+            # credential means activation proves the node accepts EXACTLY the credential
+            # every later API call will present. A vault miss (register_node tolerates a
+            # failed store) leaves the node disabled — never activated blind.
+            vault_result = get_credential_vault().get_credential(
+                service_type="virtualmin",
+                service_identifier=server.hostname,
+                reason="Node activation credential check (#347)",
+            )
+            if vault_result.is_err():
+                return Err(f"No vault credential for {server.hostname}, leaving disabled: {vault_result.unwrap_err()}")
+            vault_username, vault_password, _meta = vault_result.unwrap()
+            if not vault_username or not vault_password:
+                return Err(f"Empty vault credential for {server.hostname}, leaving disabled")
+
             config_data = get_virtualmin_config()
-            config = VirtualminConfig(
-                server=server,
-                timeout=config_data["timeout"],
+            # Probe with the vault credential via from_credentials. It carries an
+            # active-status probe object, so the gateway's non-active guard (which exists
+            # to stop routing to not-yet-live servers) does not block the one call whose
+            # purpose is to verify a not-yet-active node. This still makes a REAL
+            # authenticated `info` call to the real node over the pinned-cert TLS policy.
+            config = VirtualminConfig.from_credentials(
+                hostname=server.hostname,
+                username=vault_username,
+                password=vault_password,
+                port=server.api_port,
+                use_ssl=server.use_ssl,
                 verify_ssl=server.ssl_verify,
+                timeout=config_data["timeout"],
                 cert_fingerprint=server.ssl_cert_fingerprint or config_data.get("pinned_cert_sha256", ""),
             )
             health = VirtualminGateway(config).test_connection()

--- a/services/platform/apps/infrastructure/registration_service.py
+++ b/services/platform/apps/infrastructure/registration_service.py
@@ -171,6 +171,56 @@ class NodeRegistrationService:
             logger.error(f"🚨 [Registration] Failed to register node {deployment.hostname}: {e}")
             return Err(f"Registration failed: {e}")
 
+    def verify_and_activate(self, server: VirtualminServer) -> Result[VirtualminServer, str]:
+        """
+        #347 GAP 2: confirm the API credential provisioned on the node actually
+        authenticates, then transition the server disabled -> active so placement
+        can use it. A failed handshake leaves it disabled with a clear reason —
+        PRAHO never activates a server it cannot authenticate to. Requires an
+        AFFIRMATIVE health result (#325 posture): a missing/non-True 'healthy' is
+        not proof and does not activate.
+        """
+        from django.utils import timezone  # noqa: PLC0415  # Deferred: local use
+
+        from apps.provisioning.virtualmin_gateway import (  # noqa: PLC0415  # Circular: cross-app  # Deferred: avoids circular import
+            VirtualminConfig,
+            VirtualminGateway,
+            get_virtualmin_config,
+        )
+        from apps.provisioning.virtualmin_models import (  # noqa: PLC0415  # Circular: cross-app  # Deferred: avoids circular import
+            VirtualminServer as VMServer,
+        )
+
+        try:
+            config_data = get_virtualmin_config()
+            config = VirtualminConfig(
+                server=server,
+                timeout=config_data["timeout"],
+                verify_ssl=server.ssl_verify,
+                cert_fingerprint=server.ssl_cert_fingerprint or config_data.get("pinned_cert_sha256", ""),
+            )
+            health = VirtualminGateway(config).test_connection()
+        except Exception as e:
+            return Err(f"Credential verification raised for {server.hostname}: {e}")
+
+        if health.is_err():
+            return Err(f"Credential check failed for {server.hostname}, leaving disabled: {health.unwrap_err()}")
+        if health.unwrap().get("healthy") is not True:
+            return Err(f"Server {server.hostname} did not report healthy, leaving disabled: {health.unwrap()}")
+
+        # CAS: only a still-'disabled' server may be activated — never resurrect a
+        # 'failed'/'maintenance' server, and never race a concurrent transition.
+        updated = VMServer.objects.filter(pk=server.pk, status="disabled").update(
+            status="active", updated_at=timezone.now()
+        )
+        if not updated:
+            server.refresh_from_db()
+            return Err(f"Server {server.hostname} left 'disabled' before activation (now '{server.status}')")
+
+        server.refresh_from_db()
+        logger.info(f"✅ [Registration] Node {server.hostname} credential-verified and activated")
+        return Ok(server)
+
     def unregister_node(
         self,
         deployment: NodeDeployment,

--- a/services/platform/apps/infrastructure/registration_service.py
+++ b/services/platform/apps/infrastructure/registration_service.py
@@ -8,6 +8,7 @@ the deployed infrastructure.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from typing import TYPE_CHECKING
 
@@ -234,24 +235,32 @@ class NodeRegistrationService:
                 cert_fingerprint=server.ssl_cert_fingerprint or config_data.get("pinned_cert_sha256", ""),
             )
             health = VirtualminGateway(config).test_connection()
+
+            if health.is_err():
+                return Err(f"Credential check failed for {server.hostname}, leaving disabled: {health.unwrap_err()}")
+            if health.unwrap().get("healthy") is not True:
+                return Err(f"Server {server.hostname} did not report healthy, leaving disabled: {health.unwrap()}")
+
+            # CAS: only a still-'disabled' server may be activated — never resurrect a
+            # 'failed'/'maintenance' server, and never race a concurrent transition.
+            updated = VMServer.objects.filter(pk=server.pk, status="disabled").update(
+                status="active", updated_at=timezone.now()
+            )
+            if not updated:
+                with contextlib.suppress(Exception):
+                    server.refresh_from_db()
+                return Err(f"Server {server.hostname} left 'disabled' before activation (now '{server.status}')")
         except Exception as e:
+            # Any DB/gateway error during verification OR activation is a Result, never a raise: a
+            # transient failure must leave the node DISABLED (fail-safe) and NEVER crash the caller's
+            # deployment (#348 finding #7). If the CAS above already committed, the node is active
+            # regardless of this Err (still usable); a later reconcile syncs the in-memory row.
             return Err(f"Credential verification raised for {server.hostname}: {e}")
 
-        if health.is_err():
-            return Err(f"Credential check failed for {server.hostname}, leaving disabled: {health.unwrap_err()}")
-        if health.unwrap().get("healthy") is not True:
-            return Err(f"Server {server.hostname} did not report healthy, leaving disabled: {health.unwrap()}")
-
-        # CAS: only a still-'disabled' server may be activated — never resurrect a
-        # 'failed'/'maintenance' server, and never race a concurrent transition.
-        updated = VMServer.objects.filter(pk=server.pk, status="disabled").update(
-            status="active", updated_at=timezone.now()
-        )
-        if not updated:
+        # Activation committed. The final refresh is cosmetic — a hiccup here must NOT turn a
+        # successful activation into a reported failure.
+        with contextlib.suppress(Exception):
             server.refresh_from_db()
-            return Err(f"Server {server.hostname} left 'disabled' before activation (now '{server.status}')")
-
-        server.refresh_from_db()
         logger.info(f"✅ [Registration] Node {server.hostname} credential-verified and activated")
         return Ok(server)
 

--- a/services/platform/apps/infrastructure/ssh_key_manager.py
+++ b/services/platform/apps/infrastructure/ssh_key_manager.py
@@ -309,6 +309,7 @@ class SSHKeyManager:
 
         key_pair = result.unwrap()
 
+        path: str | None = None
         try:
             # Create secure temporary file
             fd, path = tempfile.mkstemp(prefix="praho_ssh_", suffix=".key")
@@ -323,6 +324,9 @@ class SSHKeyManager:
             return Ok(Path(path))
 
         except Exception as e:
+            # #348: never leave a partial PRIVATE KEY temp file behind if the write/chmod fails.
+            if path is not None:
+                Path(path).unlink(missing_ok=True)
             logger.error(f"🚨 [SSH Manager] Failed to write key file: {e}")
             return Err(f"Failed to write key file: {e}")
 
@@ -446,6 +450,7 @@ class SSHKeyManager:
 
         key_content = result.unwrap()
 
+        path: str | None = None
         try:
             fd, path = tempfile.mkstemp(prefix="praho_master_ssh_", suffix=".key")
             with os.fdopen(fd, "w") as f:
@@ -456,6 +461,9 @@ class SSHKeyManager:
             return Ok(Path(path))
 
         except Exception as e:
+            # #348: never leave a partial master PRIVATE KEY temp file behind if the write/chmod fails.
+            if path is not None:
+                Path(path).unlink(missing_ok=True)
             return Err(f"Failed to write master key file: {e}")
 
     def get_effective_key_for_deployment(

--- a/services/platform/apps/provisioning/virtualmin_auth_manager.py
+++ b/services/platform/apps/provisioning/virtualmin_auth_manager.py
@@ -30,6 +30,7 @@ from .virtualmin_gateway import (
     VirtualminGateway,
     VirtualminRateLimitedError,
     VirtualminTransientError,
+    resolve_server_credentials,
 )
 from .virtualmin_models import VirtualminServer
 from .virtualmin_validators import VirtualminValidator
@@ -42,7 +43,11 @@ AUTH_METHOD_MASTER_PROXY = "master_proxy"
 AUTH_METHOD_SSH_SUDO = "ssh_sudo"
 
 # Cache keys for auth method tracking
-CACHE_AUTH_METHOD_PREFIX = "virtualmin_auth_method_"
+# v2: bumped when ACL credential resolution moved vault-first (#348). Any pre-fix cached
+# "master_proxy is the working method" entry — set when an empty ACL field forced escalation —
+# is now ignored, so a node re-evaluates ACL-first with the repaired resolution instead of
+# persistently authenticating as master.
+CACHE_AUTH_METHOD_PREFIX = "virtualmin_auth_method_v2_"
 CACHE_AUTH_HEALTH_PREFIX = "virtualmin_auth_health_"
 _DEFAULT_CACHE_TIMEOUT = 3600  # 1 hour
 CACHE_TIMEOUT = _DEFAULT_CACHE_TIMEOUT
@@ -94,7 +99,17 @@ class AuthMethodUnavailableError(Exception):
     """An explicitly configured fallback method is unavailable on this installation."""
 
 
-AuthFailure = str | VirtualminAPIError | AuthMethodUnavailableError
+class ACLCredentialResolutionError(Exception):
+    """The node's own ACL credential could not be RESOLVED (no vault entry and no usable field).
+
+    Distinct from a 401 (credential present but rejected) and from AuthMethodUnavailableError (a
+    *fallback* method simply not configured): when PRAHO cannot even resolve a node's own ACL
+    credential, escalating to master/root would be a privilege jump we refuse. This is TERMINAL —
+    the escalation loop must NOT fall through to _execute_master_proxy on it.
+    """
+
+
+AuthFailure = str | VirtualminAPIError | AuthMethodUnavailableError | ACLCredentialResolutionError
 
 
 @dataclass
@@ -147,7 +162,7 @@ class VirtualminAuthenticationManager:
         self.server = server
         self._ssh_client: paramiko.SSHClient | None = None
 
-    def execute_virtualmin_command(
+    def execute_virtualmin_command(  # noqa: PLR0911  # Terminal-vs-escalate branches: 403 / ACL-resolution / unavailable / ambiguous-mutation / exhausted
         self, program: str, parameters: dict[str, Any], force_method: AuthMethod | None = None
     ) -> Result[Any, str]:
         """
@@ -203,6 +218,11 @@ class VirtualminAuthenticationManager:
                         # to a higher-privilege method would bypass the ACL —
                         # terminal, never fall through.
                         return Err(last_error, retriability=last_retriability)
+                    if isinstance(error, ACLCredentialResolutionError):
+                        # (#348) Could not resolve the node's OWN ACL credential. Escalating to
+                        # master/root here would send privileged credentials to a node we cannot
+                        # even authenticate to normally — refuse. Terminal, never fall through.
+                        return Err(last_error, retriability=Retriability.NOT_RETRIABLE)
                     if isinstance(error, AuthMethodUnavailableError):
                         # Method NOT configured: nothing was ever attempted, so
                         # it carries zero double-execution risk — try the next
@@ -260,13 +280,41 @@ class VirtualminAuthenticationManager:
         return handler(program, parameters)
 
     def _execute_acl_auth(self, program: str, parameters: dict[str, Any]) -> Result[Any, AuthFailure]:
-        """Execute using current ACL user authentication"""
+        """Execute using the node's ACL user, resolving its credential vault-first (ADR-0033).
+
+        The ACL credential lives in the CredentialVault (deploy-path nodes carry an empty
+        encrypted_api_password). Resolving vault-first means such a node authenticates as its real
+        ACL user instead of sending an empty password, 401-ing, and escalating to master. A
+        resolution FAILURE returns the TERMINAL ACLCredentialResolutionError so the escalation loop
+        refuses to reach master — never send root credentials to a node whose own ACL credential we
+        cannot even resolve.
+        """
         try:
-            # Use existing gateway with ACL credentials
+            from apps.common.credential_vault import (  # noqa: PLC0415  # Deferred: avoids circular import
+                get_credential_vault,
+            )
+
+            try:
+                vault = get_credential_vault()
+            except Exception:
+                # Vault unreachable → resolve from the server field only (manual servers keep
+                # working; a deploy-path node's empty field yields a terminal Err below).
+                logger.warning(f"⚠️ [Virtualmin Auth] Vault unavailable for {self.server.hostname}; trying server field")
+                vault = None
+
+            creds = resolve_server_credentials(self.server, vault=vault, reason=f"ACL auth: {program}")
+            if creds.is_err():
+                return Err(
+                    ACLCredentialResolutionError(
+                        f"No usable ACL credential for {self.server.hostname}: {creds.unwrap_err()}"
+                    )
+                )
+            acl_username, acl_password = creds.unwrap()
+
             config = VirtualminConfig.from_credentials(
                 hostname=self.server.hostname,
-                username=self.server.api_username,
-                password=self.server.get_api_password(),
+                username=acl_username,
+                password=acl_password,
                 port=self.server.api_port,
                 use_ssl=self.server.use_ssl,
                 verify_ssl=self.server.ssl_verify,

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -584,6 +584,70 @@ class VirtualminResponseParser:
         }
 
 
+# Couples the resolver's fail-open guard to CredentialVault.get_credential's not-found message.
+# ONLY a genuine "no vault entry" permits the legacy encrypted-field fallback; expired /
+# access-denied / decryption / DB-outage errors are TERMINAL (fail-closed) so a stale model
+# credential can never resurrect a revoked or expired vault credential (ADR-0033 vault lifecycle).
+# A typed vault-error refactor would remove this string coupling (tracked follow-up).
+_VAULT_NOT_FOUND_PREFIX = "Credential not found"
+
+
+def resolve_server_credentials(
+    server: Any,
+    *,
+    vault: CredentialVault | None = None,
+    reason: str = "Virtualmin API call",
+) -> Result[tuple[str, str], str]:
+    """ADR-0033 vault-first Virtualmin credential resolution — fail-closed.
+
+    Resolution order:
+      1. If a vault is supplied, try it. A present, non-empty (username, password) wins.
+      2. The legacy encrypted server field is used ONLY when the vault has genuinely no entry
+         (not-found) — never on expired / denied / decryption / outage, which are terminal.
+      3. Fail-closed: Err when neither source yields a NON-EMPTY (username, password).
+
+    The ``if username and password`` guards are LOAD-BEARING: get_api_password() on an empty
+    field returns "" SILENTLY (decrypt_sensitive_data("") -> "", no exception), so emptiness —
+    not an exception — is what stops an empty credential from reaching the wire.
+    """
+    if vault is not None:
+        vault_result = vault.get_credential(
+            service_type="virtualmin", service_identifier=server.hostname, reason=reason
+        )
+        if vault_result.is_ok():
+            username, password, _metadata = vault_result.unwrap()
+            if username and password:
+                logger.debug(f"🔐 [Virtualmin] Using vault credential for {server.hostname}")
+                return Ok((username, password))
+            # A vault row with an empty credential is treated as absent → try the field.
+        else:
+            err = vault_result.unwrap_err()
+            if not err.startswith(_VAULT_NOT_FOUND_PREFIX):
+                # Expired / denied / decryption / DB-outage: TERMINAL. Do NOT resurrect the field.
+                logger.warning(f"⚠️ [Virtualmin] Vault credential unusable for {server.hostname}: {err}")
+                return Err(f"Vault credential unavailable for {server.hostname}: {err}")
+            logger.debug(f"🔐 [Virtualmin] No vault entry for {server.hostname}; trying server field")
+
+    # Legacy encrypted-field fallback (manually-registered servers with no vault entry).
+    try:
+        username = getattr(server, "api_username", "") or ""
+        password = server.get_api_password() if hasattr(server, "get_api_password") else ""
+    except DecryptionError:
+        logger.error(
+            f"🔥 [Virtualmin] Credential decryption failed for {server.hostname} — encryption key may have rotated"
+        )
+        return Err("Credential decryption failed — encryption key may have rotated")
+    except Exception:
+        # SECURITY: never surface exception detail that could leak credential material.
+        logger.exception("🔥 [Virtualmin] Credential retrieval failed")
+        return Err("Credential retrieval error")
+
+    if username and password:  # LOAD-BEARING: an empty field decrypts to "" silently, never raises
+        logger.debug(f"🔐 [Virtualmin] Using server-field credential for {server.hostname}")
+        return Ok((username, password))
+    return Err("No valid credentials found in vault or server config")
+
+
 class VirtualminGateway:
     """
     Production-ready Virtualmin gateway with enterprise patterns.
@@ -629,55 +693,16 @@ class VirtualminGateway:
         return self._credential_vault
 
     def _get_credentials(self, reason: str = "Virtualmin API call") -> Result[tuple[str, str], str]:
+        """Vault-first credential resolution (ADR-0033), respecting ``use_credential_vault``.
+
+        ``from_credentials`` configs (use_credential_vault=False — the verify_and_activate probe
+        and _execute_master_proxy) resolve their DIRECT credential and never consult the vault, so
+        master-proxy escalation can never silently authenticate with the ACL vault credential.
+        Delegates to the shared ``resolve_server_credentials`` so this path and the auth manager
+        use one implementation (no parallel credential logic to drift).
         """
-        Get credentials using vault-first approach with environment fallback.
-
-        Implements the migration strategy from virtualmin_review.md:
-        1. Try credential vault first (new approach)
-        2. Fall back to environment variables (current approach)
-        3. Log which method was used for migration tracking
-        """
-
-        # Try credential vault first if enabled
-        vault = self._get_credential_vault()
-        if vault:
-            vault_result = vault.get_credential(
-                service_type="virtualmin", service_identifier=self.server.hostname, reason=reason
-            )
-
-            if vault_result.is_ok():
-                username, password, _metadata = vault_result.unwrap()
-                if username and password:
-                    logger.debug(f"🔐 [Virtualmin Gateway] Using vault credentials for {self.server.hostname}")
-                    return Ok((username, password))
-            else:
-                logger.warning(
-                    f"⚠️ [Virtualmin Gateway] Vault failed for {self.server.hostname}: {vault_result.unwrap_err()}"
-                )
-
-        # Try server-specific credentials
-        try:
-            if hasattr(self.server, "api_username") and hasattr(self.server, "get_api_password"):
-                username = self.server.api_username
-                password = self.server.get_api_password()
-
-                if username and password:
-                    logger.debug(f"🔐 [Virtualmin Gateway] Using server credentials for {self.server.hostname}")
-                    return Ok((username, password))
-
-            return Err("No valid credentials found in vault or server config")
-
-        except DecryptionError:
-            logger.error(
-                f"🔥 [Virtualmin Gateway] Credential decryption failed for {self.server.hostname}"
-                " — encryption key may have rotated"
-            )
-            return Err("Credential decryption failed — encryption key may have rotated")
-
-        except Exception:
-            # SECURITY: Don't expose exception details that could leak credential info
-            logger.exception("🔥 [Virtualmin Gateway] Credential retrieval failed")
-            return Err("Credential retrieval error")
+        vault = self._get_credential_vault() if self.config.use_credential_vault else None
+        return resolve_server_credentials(self.server, vault=vault, reason=reason)
 
     def call_with_auth_fallback(
         self, program: str, parameters: dict[str, Any] | None = None, use_fallback_auth: bool = True
@@ -751,7 +776,7 @@ class VirtualminGateway:
 
         return Ok(True)
 
-    def call(  # noqa: PLR0911  # Explicit per-stage guard returns
+    def call(  # noqa: PLR0911, C901  # Explicit per-stage guard returns (validate/health/rate-limit/auth) + retry loop
         self,
         program: str,
         params: dict[str, Any] | None = None,
@@ -828,12 +853,26 @@ class VirtualminGateway:
             f"{f' (correlation: {correlation_id})' if correlation_id else ''}"
         )
 
+        # Resolve the credential ONCE per call() — shared across retries, kept as a local (no
+        # instance residency). Fail closed: an unresolvable credential never reaches the wire.
+        auth_result = self._get_credentials(reason=f"Virtualmin {program}")
+        if auth_result.is_err():
+            return Err(
+                VirtualminAuthError(
+                    f"No usable Virtualmin credential for {self.server.hostname}: {auth_result.unwrap_err()}",
+                    self.server.hostname,
+                    program,
+                ),
+                retriability=Retriability.NOT_RETRIABLE,
+            )
+        call_auth = auth_result.unwrap()
+
         # Make API request with retries
         last_error: VirtualminAPIError | None = None
         is_read_only = program == "info" or program.startswith("list-")
         for attempt in range(VIRTUALMIN_MAX_RETRIES):
             try:
-                response = self._make_request(api_params, attempt + 1)
+                response = self._make_request(api_params, attempt + 1, auth=call_auth)
                 execution_time = time.time() - start_time
 
                 # Parse response
@@ -881,13 +920,17 @@ class VirtualminGateway:
             last_error = VirtualminTransientError(error_msg, self.server.hostname, program)
         return Err(last_error, retriability=last_error.retriability)
 
-    def _make_request(self, params: dict[str, Any], attempt: int) -> requests.Response:
+    def _make_request(
+        self, params: dict[str, Any], attempt: int, auth: tuple[str, str] | None = None
+    ) -> requests.Response:
         """
         Make HTTP request to Virtualmin API.
 
         Args:
             params: Request parameters
             attempt: Current attempt number
+            auth: (username, password) resolved once per call(); when omitted the request
+                resolves it inline (defensive — direct callers/tests), still fail-closed.
 
         Returns:
             HTTP response object
@@ -897,7 +940,7 @@ class VirtualminGateway:
             VirtualminAPIError: On API-specific errors
         """
         try:
-            response = self._execute_http_request(params)
+            response = self._execute_http_request(params, auth=auth)
             self._validate_response_size(response)
             self._validate_http_status(response)
             return response
@@ -937,8 +980,13 @@ class VirtualminGateway:
                 retriability=Retriability.UNKNOWN,
             ) from e
 
-    def _execute_http_request(self, params: dict[str, Any]) -> requests.Response:
-        """Execute HTTPS with DNS pinning and optional handshake-time certificate pinning."""
+    def _execute_http_request(self, params: dict[str, Any], auth: tuple[str, str] | None = None) -> requests.Response:
+        """Execute HTTPS with DNS pinning and optional handshake-time certificate pinning.
+
+        ``auth`` is the (username, password) resolved once per call(). When omitted (a direct
+        caller/test), it is resolved inline vault-first — fail-closed: an unresolvable credential
+        raises before the request rather than authenticating with an empty password (ADR-0033).
+        """
         if not self.server.use_ssl or not self.server.api_url.lower().startswith("https://"):
             raise VirtualminAPIError("Virtualmin API requires HTTPS", self.server.hostname)
         if not self.config.verify_ssl and not self.config.cert_fingerprint:
@@ -946,6 +994,15 @@ class VirtualminGateway:
                 "Disabling CA verification requires a pinned SHA-256 certificate fingerprint",
                 self.server.hostname,
             )
+
+        if auth is None:
+            creds = self._get_credentials(reason="Virtualmin API request")
+            if creds.is_err():
+                raise VirtualminAuthError(
+                    f"No usable Virtualmin credential for {self.server.hostname}: {creds.unwrap_err()}",
+                    self.server.hostname,
+                )
+            auth = creds.unwrap()
 
         # Get current timeout configuration (supports hot-reloading)
         timeout_config = get_virtualmin_timeouts()
@@ -967,7 +1024,7 @@ class VirtualminGateway:
             self.server.api_url,
             policy=virtualmin_policy,
             params=params,
-            auth=(self.server.api_username, self.server.get_api_password()),
+            auth=auth,
         )
 
     def _validate_response_size(self, response: requests.Response) -> None:

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -82,12 +82,31 @@ class VirtualminProvisioningService:
         self.server = server
         self._gateway: VirtualminGateway | None = None
 
-    def _get_gateway(self, server: VirtualminServer | None = None) -> VirtualminGateway:
-        """Get or create gateway for server"""
+    def _get_gateway(
+        self, server: VirtualminServer | None = None, *, use_credential_vault: bool = True
+    ) -> VirtualminGateway:
+        """Get or create gateway for server.
+
+        use_credential_vault=False forces the gateway to authenticate with the server object's own
+        encrypted field instead of the vault — required by the staff "test these supplied
+        credentials" flow, which must probe the operator-entered password, not whatever the vault
+        happens to hold for that hostname. A non-vault gateway is never cached.
+        """
         target_server = server or self.server
 
         if not target_server:
             raise ValidationError(_("No server specified for gateway"))
+
+        if not use_credential_vault:
+            config_data = get_virtualmin_config()
+            config = VirtualminConfig(
+                server=target_server,
+                timeout=config_data["timeout"],
+                verify_ssl=target_server.ssl_verify,
+                cert_fingerprint=target_server.ssl_cert_fingerprint or config_data.get("pinned_cert_sha256", ""),
+                use_credential_vault=False,
+            )
+            return VirtualminGateway(config)
 
         if not self._gateway or (server and server != self.server):
             # Get configuration from SystemSettings + environment
@@ -1222,18 +1241,23 @@ class VirtualminProvisioningService:
 
         return "".join(password)
 
-    def test_server_connection(self, server: VirtualminServer) -> Result[dict[str, Any], str]:
+    def test_server_connection(
+        self, server: VirtualminServer, *, use_credential_vault: bool = True
+    ) -> Result[dict[str, Any], str]:
         """
         Test connection to Virtualmin server.
 
         Args:
             server: Server to test
+            use_credential_vault: when False, authenticate with the server object's own encrypted
+                field instead of the vault — used by the staff "test these supplied credentials"
+                flow so it probes the operator-entered password, not the vault entry for that host.
 
         Returns:
             Result with connection info or error message
         """
         try:
-            gateway = self._get_gateway(server)
+            gateway = self._get_gateway(server, use_credential_vault=use_credential_vault)
             return gateway.test_connection()
         except Exception as e:
             # Gateway setup failures (no server configured, credential decryption)

--- a/services/platform/apps/provisioning/virtualmin_views.py
+++ b/services/platform/apps/provisioning/virtualmin_views.py
@@ -810,9 +810,11 @@ def virtualmin_server_test_connection(request: HttpRequest) -> HttpResponse:
         # Set the password using the proper method (handles encryption)
         temp_server.set_api_password(api_password)
 
-        # Test the connection
+        # Test the connection using the OPERATOR-SUPPLIED credentials (use_credential_vault=False),
+        # not whatever the vault holds for this hostname — otherwise testing an existing host would
+        # authenticate with the stored vault entry and report a misleading success/failure.
         provisioning_service = VirtualminProvisioningService()
-        result = provisioning_service.test_server_connection(temp_server)
+        result = provisioning_service.test_server_connection(temp_server, use_credential_vault=False)
 
         if result.is_ok():
             connection_info = result.unwrap()

--- a/services/platform/infrastructure/ansible/playbooks/DRILL_EXECUTION_PLAN.md
+++ b/services/platform/infrastructure/ansible/playbooks/DRILL_EXECUTION_PLAN.md
@@ -1,0 +1,77 @@
+# #347 end-to-end drill — execution plan (CLI + Web UI)
+
+Operational plan for running the live Hetzner → Virtualmin → order → provisioning
+drill. Companion to `NODE_DEPLOY_DRILL.md` (which is the acceptance checklist).
+Run on the `agent/347-credential-seam` branch — it has the fixed deploy path
+(#341) + the credential seam (#347 GAP 1/2) + idempotent destroy.
+
+## 0. Secrets & safety
+- The Hetzner API token was provided by the operator in chat. Store it via
+  `store_provider_token()` into the CredentialVault — **never echo it, never
+  commit it**. The operator will **rotate it after the drill** (it lived in a
+  chat transcript).
+- This creates a **real, billable** Hetzner server. **Destroy it at the end.**
+- If anything wedges, the server can also be killed directly in the Hetzner
+  console; then reconcile PRAHO state.
+
+## 1. Stand up PRAHO
+- `make dev-platform` — runs migrations, seeds data, starts the **django-q
+  workers** (the async deploy runs there — essential) + runserver on `:8700`,
+  SQLite DB. `make dev-all` also brings up the portal on `:8701`.
+- Confirm the qcluster is alive (`django_q.log`) before triggering a deploy.
+
+## 2. Configure the Hetzner provider (django shell or a mgmt command)
+- Create `CloudProvider(provider_type="hetzner", code="hetzner", credential_identifier=...)`.
+- `store_provider_token(provider, "<token>")` → vault (keyed by credential_identifier).
+- Seed real Hetzner-valid `NodeRegion` (e.g. `fsn1`/`nbg1`), `NodeSize`
+  (e.g. `cx22`), and a virtualmin `PanelType(panel_type="virtualmin",
+  ansible_playbook="virtualmin.yml")`.
+
+## 3. fqdn resolution (the dev hack)
+- PRAHO reaches the node's API by **hostname** (`https://<fqdn>:10000`), not IP
+  (`virtualmin_models.py:api_url`). So the fqdn must resolve to the node IP for
+  the credential handshake / activation to work.
+- Use `/etc/hosts` on the PRAHO host: `<node-ipv4>  <node-fqdn>`. The IP only
+  exists after `create_server`, and activation happens later in the same async
+  task — so either add the entry mid-deploy (after IP is known, before
+  `verify_and_activate`) or run the deploy in two stages. (`resolv.conf` is for
+  nameservers, not per-host maps — wrong tool.)
+
+## 4. CLI drill
+1. Trigger a deploy (`queue_deploy_node(...)` from a shell, or the mgmt path).
+2. Watch the FSM via `NodeDeploymentLog`: provisioning_node → configuring_dns →
+   installing_panel → configuring_backups → validating → registering → completed.
+   (virtualmin-install is ~40 min.)
+3. **Validate the `create-admin` flags** (biggest unknown): SSH to the node,
+   `virtualmin list-admins`, then test API auth:
+   `curl -k -u 'praho-api:<pw>' 'https://<ip>:10000/virtual-server/remote.cgi?program=list-domains'`.
+   If it 401s, set `no_log:false` on the create-admin task, re-run, read the real
+   error, `virtualmin create-admin --help` for the exact capability flags, fix.
+4. Confirm `verify_and_activate` flipped the `VirtualminServer` to `active`
+   (else the deployment log carries the "left disabled: …" reason = the handshake
+   failure = step 3).
+5. **SSH host-key trust for a brand-new node** — the fail-closed RejectPolicy +
+   known_hosts path needs the node's key trusted; watch how this behaves and
+   sort a TOFU/known-hosts step if it blocks.
+
+## 5. Web-UI drill (Claude-in-Chrome)
+- Load Chrome MCP tools; open `http://localhost:8700`, log in as a staff user
+  (seed one if needed).
+- Fill the **node deployment form** (provider / region / size / panel) → submit
+  → watch it spin up a real server through the same pipeline.
+- Create an **order** for a hosting service → confirm → watch **provisioning**
+  land on the node (`create_virtualmin_account`) — the full order→provisioning
+  path end-to-end.
+- Confirm the customer domain provisions and serves.
+
+## 6. Teardown
+- Destroy the node (`destroy_node` / the UI destroy action). Confirm the Hetzner
+  server + firewall are actually deleted (validates the idempotent-delete fix
+  against real Hetzner).
+- Remove the `/etc/hosts` entry. **Rotate the Hetzner key.**
+
+## Known unknowns this drill will settle
+1. The `virtualmin create-admin` capability flags (guessed; will likely need fixing).
+2. SSH host-key trust for a freshly created node (fail-closed policy).
+3. Hostname resolution on the PRAHO→node API path (the /etc/hosts hack; GAP 3 automates it later).
+4. `destroy_node` against real Hetzner (idempotent-delete fix, unproven live).

--- a/services/platform/infrastructure/ansible/playbooks/NODE_DEPLOY_DRILL.md
+++ b/services/platform/infrastructure/ansible/playbooks/NODE_DEPLOY_DRILL.md
@@ -19,23 +19,40 @@ Given a Hetzner key, `deploy_node` produces an **active, credentialed** `Virtual
 2. Watch the FSM (per-stage `NodeDeploymentLog`): pending → provisioning_node → configuring_dns → installing_panel → configuring_backups → validating → registering → completed.
 3. **CRITICAL — validate the `create-admin` flags (the biggest unknown).** SSH to the node:
    - `virtualmin list-admins` → confirm the `praho-api` admin exists.
-   - Test API auth directly:
-     `curl -k -u 'praho-api:<password>' 'https://<node-ip>:10000/virtual-server/remote.cgi?program=list-domains'`
-     → expect a valid response, **not** HTTP 401.
-   - If auth fails, the capability flags in `virtualmin.yml`'s create-admin task are wrong:
-     temporarily set `no_log: false` on that task, re-run the playbook, read the real error,
-     run `virtualmin create-admin --help` on the node for the exact flag names, and correct them.
+   - **Let PRAHO's own diagnostic prove auth — do NOT hand-auth with `curl -k`.** `-k` disables the
+     certificate validation the platform enforces (pinned-cert TLS), so a `curl -k` success would
+     "prove" a path PRAHO never uses. Step 4 below (`status=active`) IS the real auth proof:
+     `verify_and_activate` authenticates over the pinned-cert TLS with the vault credential — the exact
+     production path. If you must probe the API by hand, do it securely: read the password from the
+     vault into a shell variable (never type it on the command line / into shell history), validate the
+     node cert (`--cacert` / pinned fingerprint, not `-k`), and pass credentials via a `--netrc`/config
+     file rather than `-u user:pass` on argv.
+   - If auth fails, the capability flags in `virtualmin.yml`'s create-admin task are likely wrong. Do
+     NOT flip `no_log: false` — that logs the plaintext password. Diagnose safely: run
+     `virtualmin create-admin --help` on the node for the exact flag names, and/or re-create a THROWAWAY
+     admin manually with a DUMMY password to read the real CLI error — never with the real credential.
 4. **Confirm PRAHO activated the node.** The `VirtualminServer` row should be `status=active`
    (i.e. `verify_and_activate` succeeded). If still `disabled`, the deployment log carries the
    "Node registered but left disabled: …" reason — that reason IS the handshake failure from step 3.
-5. **Provision a test customer.** Create a service that provisions a domain onto the node:
-   - `create_virtualmin_account` should succeed (a `VirtualminAccount`, status active).
+5. **Provision a test customer — this is the ACL CAPABILITY gate, not just auth.** `info`/`list-domains`
+   prove the credential authenticates; they do NOT prove `--can-create`/`--can-edit` actually grant
+   domain provisioning. Creating a real domain does:
+   - `create_virtualmin_account` should succeed (a `VirtualminAccount`, status active) — this exercises
+     `create-domain`, proving the ACL user has the create capability the flags are meant to grant.
    - The domain should resolve (GAP 3 / DNS) and serve. Without GAP 3, resolve DNS manually to test.
+   Every auto-deploy runs the IDENTICAL `virtualmin.yml`, so proving the capability flags once here
+   proves them for all future deployments — this drill is the one-time capability acceptance.
 6. Record RTO (deploy start → active) and note any manual step you had to take — the goal is **zero**.
 
 ## Debugging aids
-- Hidden create-admin error → flip `no_log: true` to `false` on that task for one run.
-- The API password is passed via a `0600` temp vars file under the PRAHO host's tempdir (never argv), cleaned up after the run — inspect it mid-run only if debugging.
+- Hidden create-admin error → do NOT flip `no_log: false` (it logs the plaintext password). Read the
+  flag names with `virtualmin create-admin --help`, or reproduce with a throwaway admin + dummy password.
+- Credential transport: the API password reaches the ansible CONTROLLER via a `0600` temp vars file
+  (`-e @file`, never the `ansible-playbook` argv), cleaned up after the run. **Residual risk:** on the
+  TARGET node the password is briefly visible in the process list during the `create-admin` command
+  itself (`--pass` on argv) — inherent to the Virtualmin CLI; `no_log` only hides the CONTROLLER's
+  output. Mitigated by the node being freshly-provisioned + PRAHO-controlled and the command being
+  short-lived; a stdin/password-file facility on the node is a hardening follow-up to investigate.
 - `verify_and_activate` calls `gateway.test_connection()`; check its `{"healthy": …}` response.
 
 ## Definition of done for #347

--- a/services/platform/infrastructure/ansible/playbooks/NODE_DEPLOY_DRILL.md
+++ b/services/platform/infrastructure/ansible/playbooks/NODE_DEPLOY_DRILL.md
@@ -1,0 +1,42 @@
+# Node deploy → customer-ready acceptance drill (#347)
+
+The credential-seam code (PR #348) is unit-tested with mocks and the playbook
+passes `ansible-playbook --syntax-check`, but it has **never run against a real
+Virtualmin node**. This drill is the acceptance gate that turns "code that should
+work" into "provably works". Run it against ONE real Hetzner node before claiming
+auto-deploy is customer-ready.
+
+## Prerequisites
+- A Hetzner Cloud API token (project-scoped) configured in PRAHO (provider token / vault).
+- PRAHO platform running with node-deployment settings configured.
+- (For public hostname resolution + Let's Encrypt) a Cloudflare API token + zone — note GAP 3 (imperative-pipeline DNS) is NOT implemented yet, so the node hostname will not auto-resolve; the LE cert step may skip. Not required to prove the credential seam.
+
+## What it proves
+Given a Hetzner key, `deploy_node` produces an **active, credentialed** `VirtualminServer` with **zero manual steps**, onto which a customer domain can be provisioned.
+
+## Steps
+1. Trigger a deployment (`queue_deploy_node` / staff UI / management command). Record the deployment id.
+2. Watch the FSM (per-stage `NodeDeploymentLog`): pending → provisioning_node → configuring_dns → installing_panel → configuring_backups → validating → registering → completed.
+3. **CRITICAL — validate the `create-admin` flags (the biggest unknown).** SSH to the node:
+   - `virtualmin list-admins` → confirm the `praho-api` admin exists.
+   - Test API auth directly:
+     `curl -k -u 'praho-api:<password>' 'https://<node-ip>:10000/virtual-server/remote.cgi?program=list-domains'`
+     → expect a valid response, **not** HTTP 401.
+   - If auth fails, the capability flags in `virtualmin.yml`'s create-admin task are wrong:
+     temporarily set `no_log: false` on that task, re-run the playbook, read the real error,
+     run `virtualmin create-admin --help` on the node for the exact flag names, and correct them.
+4. **Confirm PRAHO activated the node.** The `VirtualminServer` row should be `status=active`
+   (i.e. `verify_and_activate` succeeded). If still `disabled`, the deployment log carries the
+   "Node registered but left disabled: …" reason — that reason IS the handshake failure from step 3.
+5. **Provision a test customer.** Create a service that provisions a domain onto the node:
+   - `create_virtualmin_account` should succeed (a `VirtualminAccount`, status active).
+   - The domain should resolve (GAP 3 / DNS) and serve. Without GAP 3, resolve DNS manually to test.
+6. Record RTO (deploy start → active) and note any manual step you had to take — the goal is **zero**.
+
+## Debugging aids
+- Hidden create-admin error → flip `no_log: true` to `false` on that task for one run.
+- The API password is passed via a `0600` temp vars file under the PRAHO host's tempdir (never argv), cleaned up after the run — inspect it mid-run only if debugging.
+- `verify_and_activate` calls `gateway.test_connection()`; check its `{"healthy": …}` response.
+
+## Definition of done for #347
+A deploy from a Hetzner key yields an `active` + credentialed node with no manual step, and a real customer domain provisions and serves on it. Until this drill passes, the code is "structurally complete, unproven."

--- a/services/platform/infrastructure/ansible/playbooks/virtualmin.yml
+++ b/services/platform/infrastructure/ansible/playbooks/virtualmin.yml
@@ -136,6 +136,29 @@
       failed_when: false
       changed_when: false
 
+    - name: Create the PRAHO API administrator (dedicated ACL user, never master admin)
+      # #347: PRAHO stores this same password in its vault at registration, so the
+      # first API call and verify_and_activate authenticate. The password arrives
+      # via a 0600 extra-vars file (never the ansible command line) and is no_log
+      # here so it never lands in ansible output.
+      # VALIDATE ON A REAL NODE: the exact `create-admin` capability flags govern
+      # what PRAHO can do via the API and must be confirmed against a live
+      # Virtualmin before this is trusted (part of the #347 acceptance drill).
+      ansible.builtin.command: >
+        virtualmin create-admin
+        --name {{ praho_api_user }}
+        --pass {{ praho_api_password }}
+        --desc "PRAHO platform API administrator"
+        --can-create
+        --can-edit
+      when: praho_api_user is defined and praho_api_password is defined
+      no_log: true
+      register: praho_admin_result
+      changed_when: praho_admin_result.rc == 0
+      failed_when:
+        - praho_admin_result.rc != 0
+        - "'already exists' not in (praho_admin_result.stderr | default(''))"
+
     - name: Create PRAHO tracking file
       ansible.builtin.copy:
         content: |

--- a/services/platform/infrastructure/ansible/playbooks/virtualmin.yml
+++ b/services/platform/infrastructure/ansible/playbooks/virtualmin.yml
@@ -139,8 +139,13 @@
     - name: Create the PRAHO API administrator (dedicated ACL user, never master admin)
       # #347: PRAHO stores this same password in its vault at registration, so the
       # first API call and verify_and_activate authenticate. The password arrives
-      # via a 0600 extra-vars file (never the ansible command line) and is no_log
-      # here so it never lands in ansible output.
+      # via a 0600 extra-vars file (never the CONTROLLER's ansible command line) and
+      # is no_log here so it never lands in ansible output.
+      # RESIDUAL RISK (#348 #4): `--pass` still places the plaintext password on THIS
+      # node's process list (/proc, ps) for the brief duration of the command — no_log
+      # only hides the controller's output, not the target's argv. Accepted as low risk
+      # (freshly-provisioned, PRAHO-controlled node; short-lived command). A stdin/
+      # password-file facility is a hardening follow-up to investigate on a real node.
       # VALIDATE ON A REAL NODE: the exact `create-admin` capability flags govern
       # what PRAHO can do via the API and must be confirmed against a live
       # Virtualmin before this is trusted (part of the #347 acceptance drill).

--- a/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
+++ b/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
@@ -191,13 +191,92 @@ class TestCredentialSeamWiring(TestCase):
             result = service.deploy_node(deployment=deployment, credentials={"api_token": "test-token"})
 
         self.assertTrue(result.is_ok(), f"deploy_node should succeed, got {result}")
-        extra = service._ansible.run_playbook.call_args.kwargs["extra_vars"]
-        self.assertEqual(extra["praho_api_user"], "praho-api")
-        self.assertTrue(extra["praho_api_password"], "API password must be generated and threaded")
+        # #348 finding #6: the credential goes ONLY to the panel playbook (virtualmin.yml), never
+        # broadcast to base/harden/backup which don't consume it.
+        calls = {c.kwargs["playbook"]: c.kwargs.get("extra_vars") for c in service._ansible.run_playbook.call_args_list}
+        panel_extra = calls["virtualmin.yml"]
+        self.assertEqual(panel_extra["praho_api_user"], "praho-api")
+        self.assertTrue(panel_extra["praho_api_password"], "API password must be generated and threaded")
+        for other in ("base.yml", "harden.yml", "backup.yml"):
+            self.assertIsNone(calls[other], f"the API credential must not reach {other}")
         reg_kwargs = service._registration.register_node.call_args.kwargs
         self.assertEqual(reg_kwargs["admin_username"], "praho-api")
-        self.assertEqual(reg_kwargs["admin_password"], extra["praho_api_password"])
+        self.assertEqual(reg_kwargs["admin_password"], panel_extra["praho_api_password"])
         service._registration.verify_and_activate.assert_called_once_with(registered)
+
+    @staticmethod
+    def _wire_happy_path(service, *, registered) -> MagicMock:
+        service._ssh_manager.generate_deployment_key.return_value = Ok(MagicMock(public_key="ssh-rsa AAAA"))
+        service._ansible.get_playbook_order.return_value = ["base.yml", "virtualmin.yml", "harden.yml", "backup.yml"]
+        service._ansible.run_playbook.return_value = Ok(MagicMock(success=True, stderr=""))
+        service._validation.validate_node.return_value = Ok(MagicMock(all_passed=True, summary="ok"))
+        service._registration.register_node.return_value = Ok(registered)
+        gateway = MagicMock()
+        gateway.upload_ssh_key.return_value = Ok("praho-key")
+        gateway.create_firewall.return_value = Ok("fw-1")
+        gateway.create_server.return_value = Ok(
+            ServerCreateResult(server_id="srv-1", ipv4_address="1.2.3.4", ipv6_address="")
+        )
+        return gateway
+
+    def test_redeploy_reuses_existing_vault_credential(self) -> None:
+        """#348 finding #8: a re-deploy REUSES the node's existing vault credential rather than
+        minting a fresh password. create-admin tolerates the already-existing praho-api user without
+        resetting it, so a fresh password would desync the node (old pw) from the vault (new pw) and
+        401 verify_and_activate. Convergence: the panel + registration use the REUSED vault password."""
+        from apps.common.credential_vault import (  # noqa: PLC0415  # local: test-only
+            CredentialData,
+            CredentialVault,
+        )
+
+        deployment = _create_deployment("pending")
+        CredentialVault().store_credential(
+            CredentialData(
+                service_type="virtualmin",
+                service_identifier=deployment.fqdn,
+                username="praho-api",
+                password="REUSED-VAULT-PW",
+            )
+        )
+        service = _make_service()
+        registered = MagicMock(id=9)
+        service._registration.verify_and_activate.return_value = Ok(registered)
+        gateway = self._wire_happy_path(service, registered=registered)
+
+        with (
+            patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True),
+            patch("apps.infrastructure.deployment_service.get_cloud_gateway", return_value=gateway),
+        ):
+            result = service.deploy_node(deployment=deployment, credentials={"api_token": "test-token"})
+
+        self.assertTrue(result.is_ok(), f"deploy_node should succeed, got {result}")
+        calls = {c.kwargs["playbook"]: c.kwargs.get("extra_vars") for c in service._ansible.run_playbook.call_args_list}
+        self.assertEqual(
+            calls["virtualmin.yml"]["praho_api_password"],
+            "REUSED-VAULT-PW",
+            "re-deploy must reuse the existing vault password, not mint a fresh one",
+        )
+        self.assertEqual(service._registration.register_node.call_args.kwargs["admin_password"], "REUSED-VAULT-PW")
+
+    def test_deploy_completes_even_if_activation_raises(self) -> None:
+        """#348 finding #7: verify_and_activate is best-effort. If it RAISES (e.g. a transient DB
+        error), the deployment must still COMPLETE (node registered, left disabled) — never be marked
+        failed and roll back the paid provisioning work."""
+        deployment = _create_deployment("pending")
+        service = _make_service()
+        registered = MagicMock(id=11)
+        service._registration.verify_and_activate.side_effect = RuntimeError("transient db error")
+        gateway = self._wire_happy_path(service, registered=registered)
+
+        with (
+            patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True),
+            patch("apps.infrastructure.deployment_service.get_cloud_gateway", return_value=gateway),
+        ):
+            result = service.deploy_node(deployment=deployment, credentials={"api_token": "test-token"})
+
+        self.assertTrue(result.is_ok(), f"deploy must complete despite activation raising, got {result}")
+        deployment.refresh_from_db()
+        self.assertEqual(deployment.status, "completed")
 
 
 # ===========================================================================

--- a/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
+++ b/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
@@ -157,6 +157,50 @@ class TestDeployNodeReachesCompletedThroughFSM(TestCase):
 
 
 # ===========================================================================
+# #347 GAP 1: deploy provisions a PRAHO-controlled credential, then activates
+# ===========================================================================
+
+
+class TestCredentialSeamWiring(TestCase):
+    """The deploy pipeline generates a Virtualmin API credential, hands it to the
+    panel playbook via extra_vars, registers with that ACL user (not root), and
+    verifies + activates the node."""
+
+    def test_credential_threaded_registered_and_activated(self) -> None:
+        deployment = _create_deployment("pending")
+        service = _make_service()
+        service._ssh_manager.generate_deployment_key.return_value = Ok(MagicMock(public_key="ssh-rsa AAAA"))
+        service._ansible.get_playbook_order.return_value = ["base.yml", "virtualmin.yml", "harden.yml", "backup.yml"]
+        service._ansible.run_playbook.return_value = Ok(MagicMock(success=True, stderr=""))
+        service._validation.validate_node.return_value = Ok(MagicMock(all_passed=True, summary="ok"))
+        registered = MagicMock(id=7)
+        service._registration.register_node.return_value = Ok(registered)
+        service._registration.verify_and_activate.return_value = Ok(registered)
+
+        gateway = MagicMock()
+        gateway.upload_ssh_key.return_value = Ok("praho-key")
+        gateway.create_firewall.return_value = Ok("fw-1")
+        gateway.create_server.return_value = Ok(
+            ServerCreateResult(server_id="srv-1", ipv4_address="1.2.3.4", ipv6_address="")
+        )
+
+        with (
+            patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True),
+            patch("apps.infrastructure.deployment_service.get_cloud_gateway", return_value=gateway),
+        ):
+            result = service.deploy_node(deployment=deployment, credentials={"api_token": "test-token"})
+
+        self.assertTrue(result.is_ok(), f"deploy_node should succeed, got {result}")
+        extra = service._ansible.run_playbook.call_args.kwargs["extra_vars"]
+        self.assertEqual(extra["praho_api_user"], "praho-api")
+        self.assertTrue(extra["praho_api_password"], "API password must be generated and threaded")
+        reg_kwargs = service._registration.register_node.call_args.kwargs
+        self.assertEqual(reg_kwargs["admin_username"], "praho-api")
+        self.assertEqual(reg_kwargs["admin_password"], extra["praho_api_password"])
+        service._registration.verify_and_activate.assert_called_once_with(registered)
+
+
+# ===========================================================================
 # H2: Transient errors must NOT clear external_node_id
 # ===========================================================================
 

--- a/services/platform/tests/infrastructure/test_node_activation.py
+++ b/services/platform/tests/infrastructure/test_node_activation.py
@@ -1,0 +1,82 @@
+"""
+#347 GAP 2 — the verify-and-activate bridge.
+
+A node is registered `disabled` after deploy. `verify_and_activate` performs a
+real credential handshake (gateway.test_connection) against the just-provisioned
+API user and transitions the server `disabled -> active` ONLY on affirmative
+health — never activating a server PRAHO cannot actually authenticate to.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from apps.common.types import Err, Ok
+from apps.infrastructure.registration_service import NodeRegistrationService
+from apps.provisioning.virtualmin_models import VirtualminServer
+
+
+class VerifyAndActivateTests(TestCase):
+    def _disabled_server(self) -> VirtualminServer:
+        return VirtualminServer.objects.create(
+            name="Node: prd-sha-tst-de-tst1-001",
+            hostname="prd-sha-tst-de-tst1-001.example.com",
+            api_port=10000,
+            use_ssl=True,
+            ssl_verify=False,
+            ssl_cert_fingerprint="ab" * 32,
+            status="disabled",
+            api_username="praho-api",
+            encrypted_api_password=b"",
+            max_domains=50,
+            max_bandwidth_gb=1000,
+        )
+
+    @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
+    def test_activates_when_credential_handshake_is_healthy(self, mock_gateway_cls):
+        server = self._disabled_server()
+        mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": True})
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        server.refresh_from_db()
+        self.assertEqual(server.status, "active")
+
+    @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
+    def test_stays_disabled_when_handshake_errs(self, mock_gateway_cls):
+        server = self._disabled_server()
+        mock_gateway_cls.return_value.test_connection.return_value = Err("401 unauthorized")
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err())
+        server.refresh_from_db()
+        self.assertEqual(server.status, "disabled")
+
+    @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
+    def test_stays_disabled_when_health_not_affirmative(self, mock_gateway_cls):
+        """A missing/non-True 'healthy' is not proof — do not activate (#325 posture)."""
+        server = self._disabled_server()
+        mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": "maybe"})
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err())
+        server.refresh_from_db()
+        self.assertEqual(server.status, "disabled")
+
+    @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
+    def test_only_activates_a_disabled_server(self, mock_gateway_cls):
+        """CAS guard: never flip a server that has since left 'disabled'."""
+        server = self._disabled_server()
+        VirtualminServer.objects.filter(pk=server.pk).update(status="failed")
+        mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": True})
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err())
+        server.refresh_from_db()
+        self.assertEqual(server.status, "failed")

--- a/services/platform/tests/infrastructure/test_node_activation.py
+++ b/services/platform/tests/infrastructure/test_node_activation.py
@@ -185,6 +185,24 @@ class VerifyAndActivateRealHandshakeTests(TestCase):
 
     @patch("apps.provisioning.virtualmin_gateway.safe_request")
     @patch("apps.common.credential_vault.get_credential_vault")
+    def test_activation_is_total_returns_err_on_db_error(self, mock_get_vault, mock_safe_request):
+        """#348 #7: a transient DB error during the CAS update (previously OUTSIDE the try) must
+        surface as Err — the node stays disabled (fail-safe) — never propagate as an exception that
+        would crash the caller's deployment."""
+        from django.db import OperationalError  # noqa: PLC0415  # local: test-only
+
+        server = self._disabled_server()
+        mock_get_vault.return_value = self._vault()
+        mock_safe_request.return_value = self._ok_info_response()
+
+        with patch.object(VirtualminServer.objects, "filter", side_effect=OperationalError("connection lost")):
+            result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err(), "a DB error in the CAS must be caught and returned as Err")
+        self.assertIn("raised", result.unwrap_err())
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
     def test_bad_credential_handshake_leaves_node_disabled(self, mock_get_vault, mock_safe_request):
         """Fail-safe: the node rejects the credential (real auth path, non-success info
         response) → stays disabled, never customer-routed."""

--- a/services/platform/tests/infrastructure/test_node_activation.py
+++ b/services/platform/tests/infrastructure/test_node_activation.py
@@ -201,3 +201,42 @@ class VerifyAndActivateRealHandshakeTests(TestCase):
         self.assertTrue(result.is_err())
         server.refresh_from_db()
         self.assertEqual(server.status, "disabled")
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_activated_node_provisions_with_vault_credential(self, mock_get_vault, mock_safe_request):
+        """#1 KILL-SHOT: the activation guarantee must transfer to PRODUCTION provisioning.
+
+        After verify_and_activate flips the node to active, a NORMAL provisioning gateway
+        — VirtualminConfig(server=server), the path every create-domain/backup/DR call uses,
+        NOT from_credentials — must authenticate with the VAULT credential. Pre-fix this FAILS:
+        the normal path reads server.get_api_password() which decrypts encrypted_api_password=b''
+        to '' and sends empty auth (active node, unusable credential — Codex #1). Post-fix the
+        gateway resolves the credential vault-first, so the wire carries the vault username/password.
+        """
+        server = self._disabled_server()  # encrypted_api_password=b"" — the real secret is in the vault
+        mock_get_vault.return_value = self._vault(username="praho-api", password="s3cr3t-vault-pw")
+        mock_safe_request.return_value = self._ok_info_response()
+
+        activate = NodeRegistrationService().verify_and_activate(server)
+        self.assertTrue(activate.is_ok(), activate.unwrap_err() if activate.is_err() else "")
+        server.refresh_from_db()
+        self.assertEqual(server.status, "active")
+
+        # PRODUCTION path: build a normal gateway from the persisted server row (not from_credentials).
+        from apps.provisioning.virtualmin_gateway import (  # noqa: PLC0415  # local: test-only path
+            VirtualminConfig,
+            VirtualminGateway,
+        )
+
+        mock_safe_request.reset_mock()
+        result = VirtualminGateway(VirtualminConfig(server=server)).call("info")
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        self.assertTrue(mock_safe_request.called, "normal provisioning never reached the network")
+        _args, kwargs = mock_safe_request.call_args
+        self.assertEqual(
+            kwargs["auth"],
+            ("praho-api", "s3cr3t-vault-pw"),
+            "production provisioning must authenticate with the vault credential, not the empty field",
+        )

--- a/services/platform/tests/infrastructure/test_node_activation.py
+++ b/services/platform/tests/infrastructure/test_node_activation.py
@@ -9,7 +9,7 @@ health — never activating a server PRAHO cannot actually authenticate to.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
@@ -34,9 +34,17 @@ class VerifyAndActivateTests(TestCase):
             max_bandwidth_gb=1000,
         )
 
+    @staticmethod
+    def _mock_vault(mock_get_vault):
+        """A present vault credential so the flow reaches the gateway decision logic
+        (verify_and_activate now fetches the vault credential first)."""
+        mock_get_vault.return_value.get_credential.return_value = Ok(("praho-api", "vault-pw", {}))
+
+    @patch("apps.common.credential_vault.get_credential_vault")
     @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
-    def test_activates_when_credential_handshake_is_healthy(self, mock_gateway_cls):
+    def test_activates_when_credential_handshake_is_healthy(self, mock_gateway_cls, mock_get_vault):
         server = self._disabled_server()
+        self._mock_vault(mock_get_vault)
         mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": True})
 
         result = NodeRegistrationService().verify_and_activate(server)
@@ -45,9 +53,11 @@ class VerifyAndActivateTests(TestCase):
         server.refresh_from_db()
         self.assertEqual(server.status, "active")
 
+    @patch("apps.common.credential_vault.get_credential_vault")
     @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
-    def test_stays_disabled_when_handshake_errs(self, mock_gateway_cls):
+    def test_stays_disabled_when_handshake_errs(self, mock_gateway_cls, mock_get_vault):
         server = self._disabled_server()
+        self._mock_vault(mock_get_vault)
         mock_gateway_cls.return_value.test_connection.return_value = Err("401 unauthorized")
 
         result = NodeRegistrationService().verify_and_activate(server)
@@ -56,10 +66,12 @@ class VerifyAndActivateTests(TestCase):
         server.refresh_from_db()
         self.assertEqual(server.status, "disabled")
 
+    @patch("apps.common.credential_vault.get_credential_vault")
     @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
-    def test_stays_disabled_when_health_not_affirmative(self, mock_gateway_cls):
+    def test_stays_disabled_when_health_not_affirmative(self, mock_gateway_cls, mock_get_vault):
         """A missing/non-True 'healthy' is not proof — do not activate (#325 posture)."""
         server = self._disabled_server()
+        self._mock_vault(mock_get_vault)
         mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": "maybe"})
 
         result = NodeRegistrationService().verify_and_activate(server)
@@ -68,10 +80,12 @@ class VerifyAndActivateTests(TestCase):
         server.refresh_from_db()
         self.assertEqual(server.status, "disabled")
 
+    @patch("apps.common.credential_vault.get_credential_vault")
     @patch("apps.provisioning.virtualmin_gateway.VirtualminGateway")
-    def test_only_activates_a_disabled_server(self, mock_gateway_cls):
+    def test_only_activates_a_disabled_server(self, mock_gateway_cls, mock_get_vault):
         """CAS guard: never flip a server that has since left 'disabled'."""
         server = self._disabled_server()
+        self._mock_vault(mock_get_vault)
         VirtualminServer.objects.filter(pk=server.pk).update(status="failed")
         mock_gateway_cls.return_value.test_connection.return_value = Ok({"healthy": True})
 
@@ -80,3 +94,110 @@ class VerifyAndActivateTests(TestCase):
         self.assertTrue(result.is_err())
         server.refresh_from_db()
         self.assertEqual(server.status, "failed")
+
+
+class VerifyAndActivateRealHandshakeTests(TestCase):
+    """#348 discriminators: exercise the REAL gateway health gate + auth path, mocking
+    ONLY the network (safe_request) and the vault. The original tests above mock
+    VirtualminGateway.test_connection, which hides two production defects:
+
+      P1a: a freshly-registered server is status='disabled', but the real
+           VirtualminGateway._validate_server_health rejects any non-active server's
+           'info' call (the failed_by_health_check sweep exception does not apply to a
+           fresh registration) — so the probe can never run and the node never activates.
+      P1b: register_node stores the credential in the vault and sets
+           encrypted_api_password=b'', but the HTTP auth uses server.get_api_password()
+           (empty) — so even if the probe ran it would send no password.
+
+    These tests flow a disabled node through the real gate + real auth construction, so
+    they FAIL against the pre-fix code and PASS after verify_and_activate uses
+    VirtualminConfig.from_credentials (active-status probe) with the vault credential.
+    """
+
+    def _disabled_server(self) -> VirtualminServer:
+        return VirtualminServer.objects.create(
+            name="Node: prd-sha-tst-de-tst1-002",
+            hostname="prd-sha-tst-de-tst1-002.example.com",
+            api_port=10000,
+            use_ssl=True,
+            ssl_verify=False,
+            ssl_cert_fingerprint="ab" * 32,
+            status="disabled",
+            api_username="praho-api",
+            encrypted_api_password=b"",  # the real secret lives in the vault
+            max_domains=50,
+            max_bandwidth_gb=1000,
+        )
+
+    @staticmethod
+    def _vault(username: str = "praho-api", password: str = "s3cr3t-vault-pw") -> MagicMock:  # noqa: S107  # test fixture, not a real secret
+        vault = MagicMock()
+        vault.get_credential.return_value = Ok((username, password, {}))
+        return vault
+
+    @staticmethod
+    def _ok_info_response() -> MagicMock:
+        resp = MagicMock()
+        resp.text = '{"status": "success", "data": {"version": "7.20"}}'
+        resp.status_code = 200
+        resp.headers = {}
+        return resp
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_disabled_node_activates_through_real_health_gate_with_vault_credential(
+        self, mock_get_vault, mock_safe_request
+    ):
+        """P1a + P1b discriminator: a disabled node with a valid vault credential must
+        activate, flowing through the REAL _validate_server_health and REAL auth
+        construction (only the network is mocked)."""
+        server = self._disabled_server()
+        mock_get_vault.return_value = self._vault(password="s3cr3t-vault-pw")
+        mock_safe_request.return_value = self._ok_info_response()
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        server.refresh_from_db()
+        self.assertEqual(server.status, "active")
+        # P1b: the probe must authenticate with the VAULT credential, not the empty
+        # encrypted_api_password. Assert the actual network call carried it.
+        self.assertTrue(mock_safe_request.called, "the probe never reached the network (health gate rejected it?)")
+        _args, kwargs = mock_safe_request.call_args
+        self.assertEqual(kwargs["auth"], ("praho-api", "s3cr3t-vault-pw"))
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_vault_miss_leaves_node_disabled(self, mock_get_vault, mock_safe_request):
+        """Fail-safe: no vault credential (e.g. register_node's vault store failed, which
+        it tolerates) → never activate, never even hit the network."""
+        server = self._disabled_server()
+        vault = MagicMock()
+        vault.get_credential.return_value = Err("credential not found")
+        mock_get_vault.return_value = vault
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err())
+        server.refresh_from_db()
+        self.assertEqual(server.status, "disabled")
+        self.assertFalse(mock_safe_request.called)
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_bad_credential_handshake_leaves_node_disabled(self, mock_get_vault, mock_safe_request):
+        """Fail-safe: the node rejects the credential (real auth path, non-success info
+        response) → stays disabled, never customer-routed."""
+        server = self._disabled_server()
+        mock_get_vault.return_value = self._vault()
+        resp = MagicMock()
+        resp.text = '{"status": "failure", "error": "Invalid login"}'
+        resp.status_code = 401
+        resp.headers = {}
+        mock_safe_request.return_value = resp
+
+        result = NodeRegistrationService().verify_and_activate(server)
+
+        self.assertTrue(result.is_err())
+        server.refresh_from_db()
+        self.assertEqual(server.status, "disabled")

--- a/services/platform/tests/infrastructure/test_security_hardening.py
+++ b/services/platform/tests/infrastructure/test_security_hardening.py
@@ -56,6 +56,30 @@ class AnsiblePlaybookBoundaryTests(SimpleTestCase):
             mock_run.call_args.kwargs["env"]["ANSIBLE_SSH_COMMON_ARGS"],
         )
 
+    @patch("apps.infrastructure.ansible_service.subprocess.run")
+    @override_settings(PRAHO_SSH_KNOWN_HOSTS_PATH="/etc/praho/known_hosts")
+    def test_secret_extra_vars_never_reach_the_command_line(self, mock_run: MagicMock) -> None:
+        """#347: extra_vars can carry the Virtualmin API password; it must be
+        passed via a 0600 temp file (-e @file), never `-e <json>` on argv, or it
+        leaks into the PRAHO host's process list."""
+        service = self._service()
+        service._ssh_manager.get_private_key_file.return_value = Ok(Path("nonexistent-praho-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10", hostname="node.example.com")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        secret = "SUPER-SECRET-API-PW-9f3a"  # test literal, not a real credential
+        with (
+            patch.object(service, "_generate_inventory", return_value=Path("nonexistent-praho-inventory")),
+            patch.object(service, "_build_vars", return_value={"praho_api_password": secret}),
+        ):
+            result = service.run_playbook(deployment, "virtualmin.yml", extra_vars={"praho_api_password": secret})
+
+        self.assertTrue(result.is_ok())
+        argv = [str(a) for a in mock_run.call_args.args[0]]
+        self.assertFalse(any(secret in a for a in argv), f"secret leaked onto the command line: {argv}")
+        e_idx = argv.index("-e")
+        self.assertTrue(argv[e_idx + 1].startswith("@"), f"expected -e @file, got {argv[e_idx + 1]!r}")
+
     @patch.dict(
         "os.environ",
         {
@@ -126,9 +150,7 @@ class InfrastructureSSHTrustTests(SimpleTestCase):
         service._ssh_manager.get_deployment_key.return_value = Ok(MagicMock(private_key="private-key"))
         deployment = MagicMock(ipv4_address="203.0.113.10", hostname="node.example.com")
         client = mock_client_class.return_value
-        client.connect.side_effect = paramiko.BadHostKeyException(
-            "203.0.113.10", MagicMock(), MagicMock()
-        )
+        client.connect.side_effect = paramiko.BadHostKeyException("203.0.113.10", MagicMock(), MagicMock())
 
         result = service.get_webmin_certificate_fingerprint(deployment)
 

--- a/services/platform/tests/infrastructure/test_security_hardening.py
+++ b/services/platform/tests/infrastructure/test_security_hardening.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -79,6 +80,28 @@ class AnsiblePlaybookBoundaryTests(SimpleTestCase):
         self.assertFalse(any(secret in a for a in argv), f"secret leaked onto the command line: {argv}")
         e_idx = argv.index("-e")
         self.assertTrue(argv[e_idx + 1].startswith("@"), f"expected -e @file, got {argv[e_idx + 1]!r}")
+
+    @patch("apps.infrastructure.ansible_service.subprocess.run")
+    def test_write_vars_file_does_not_leak_secret_temp_on_write_failure(self, _mock_run: MagicMock) -> None:
+        """#348: if writing the vars file raises mid-write, the partial 0600 secret file must NOT be
+        left behind. _write_vars_file cleans up its OWN temp before propagating — the caller's finally
+        keys cleanup on the returned path, which never binds when the write raises."""
+        service = self._service()
+        service._ssh_manager.get_private_key_file.return_value = Ok(Path("nonexistent-praho-key"))
+        deployment = MagicMock(ipv4_address="203.0.113.10", hostname="node.example.com")
+
+        tmpdir = Path(tempfile.gettempdir())
+        before = set(tmpdir.glob("praho_ansible_vars_*"))
+        with (
+            patch.object(service, "_generate_inventory", return_value=Path("nonexistent-praho-inventory")),
+            patch.object(service, "_build_vars", return_value={"praho_api_password": "secret-value"}),
+            patch("apps.infrastructure.ansible_service.json.dump", side_effect=OSError("disk full")),
+        ):
+            result = service.run_playbook(deployment, "virtualmin.yml", extra_vars={"praho_api_password": "secret-value"})
+
+        self.assertTrue(result.is_err(), "a vars-file write failure must surface as an Err")
+        leaked = set(tmpdir.glob("praho_ansible_vars_*")) - before
+        self.assertEqual(leaked, set(), f"partial-secret vars file(s) leaked in tempdir: {leaked}")
 
     @patch.dict(
         "os.environ",
@@ -257,3 +280,23 @@ class SSHKeyLifecycleAuditTests(TestCase):
         key_file = result.unwrap()
         self.addCleanup(key_file.unlink, missing_ok=True)
         mock_get_key.assert_called_once_with(deployment, None, "Ansible playbook: virtualmin_harden.yml")
+
+    def test_private_key_file_does_not_leak_secret_temp_on_write_failure(self) -> None:
+        """#348 (sibling of #5): if writing the PRIVATE KEY to its temp file raises, the partial key
+        file must NOT be left behind — get_private_key_file cleans up its own temp before returning
+        Err. The caller never sees a path to clean, so the leak would otherwise be permanent."""
+        manager = SSHKeyManager()
+        deployment = MagicMock(hostname="node.example.com")
+        key_pair = SSHKeyPair(public_key="ssh-ed25519 AAAA", private_key="PRIVATE", fingerprint="SHA256:test")
+
+        tmpdir = Path(tempfile.gettempdir())
+        before = set(tmpdir.glob("praho_ssh_*.key"))
+        with (
+            patch.object(manager, "get_deployment_key", return_value=Ok(key_pair)),
+            patch("apps.infrastructure.ssh_key_manager.os.fdopen", side_effect=OSError("disk full")),
+        ):
+            result = manager.get_private_key_file(deployment)
+
+        self.assertTrue(result.is_err())
+        leaked = set(tmpdir.glob("praho_ssh_*.key")) - before
+        self.assertEqual(leaked, set(), f"partial private-key file(s) leaked in tempdir: {leaked}")

--- a/services/platform/tests/provisioning/test_auth_manager_regressions.py
+++ b/services/platform/tests/provisioning/test_auth_manager_regressions.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
 
 from apps.common.types import Err, Ok, Retriability, retriability_of
 from apps.provisioning.virtualmin_auth_manager import (
+    ACLCredentialResolutionError,
     AuthMethod,
     AuthMethodUnavailableError,
     VirtualminAuthenticationManager,
@@ -369,6 +370,61 @@ class AuthorizationDenialDoesNotEscalateTests(TestCase):
 
         self.assertTrue(result.is_err())
         mock_execute.assert_called_once_with(AuthMethod.ACL, "delete-domain", {})
+
+
+class ACLCredentialResolutionTerminalTests(TestCase):
+    """#348: an UNRESOLVABLE ACL credential (no vault entry AND empty encrypted field) must be
+    terminal — escalating to master would send root credentials to a node whose own ACL credential
+    PRAHO cannot even resolve. A present-but-REJECTED credential (real 401) must still escalate."""
+
+    def setUp(self) -> None:
+        self.mock_server = MagicMock()
+        self.mock_server.hostname = "node.example.com"
+        self.mock_server.id = 8
+        self.manager = VirtualminAuthenticationManager(self.mock_server)
+
+    @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_unresolvable_acl_credential_is_terminal_never_escalates(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+        _cache_failed: MagicMock,
+    ) -> None:
+        mock_priority.return_value = [AuthMethod.ACL, AuthMethod.MASTER_PROXY, AuthMethod.SSH_SUDO]
+        # ACL credential cannot be resolved; master would succeed but must never be reached.
+        mock_execute.side_effect = [
+            Err(ACLCredentialResolutionError("No usable ACL credential for node.example.com: Credential not found")),
+            Ok({"success": True}),
+        ]
+
+        result = self.manager.execute_virtualmin_command("list-domains", {})
+
+        self.assertTrue(result.is_err())
+        mock_execute.assert_called_once_with(AuthMethod.ACL, "list-domains", {})
+
+    @patch.object(VirtualminAuthenticationManager, "_cache_failed_auth_method")
+    @patch.object(VirtualminAuthenticationManager, "_get_auth_method_priority")
+    @patch.object(VirtualminAuthenticationManager, "_execute_with_method")
+    def test_present_but_rejected_acl_credential_still_escalates(
+        self,
+        mock_execute: MagicMock,
+        mock_priority: MagicMock,
+        _cache_failed: MagicMock,
+    ) -> None:
+        """A RESOLVED-but-wrong ACL credential (real 401) preserves the legitimate ACL→master
+        fallback — only RESOLUTION failure is terminal, not authentication rejection."""
+        mock_priority.return_value = [AuthMethod.ACL, AuthMethod.MASTER_PROXY, AuthMethod.SSH_SUDO]
+        mock_execute.side_effect = [
+            Err(VirtualminAuthError("Authentication failed - check API credentials", "node.example.com")),
+            Ok({"success": True}),
+        ]
+
+        result = self.manager.execute_virtualmin_command("list-domains", {})
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(mock_execute.call_count, 2)  # escalated ACL → master
 
 
 class GatewayHttpStatusClassificationTests(TestCase):

--- a/services/platform/tests/provisioning/test_virtualmin_credentials.py
+++ b/services/platform/tests/provisioning/test_virtualmin_credentials.py
@@ -17,7 +17,12 @@ from apps.common.credential_vault import CredentialData, CredentialVault
 from apps.common.types import Err, Ok
 from apps.provisioning.models import Server
 from apps.provisioning.virtualmin_forms import VirtualminServerForm
-from apps.provisioning.virtualmin_gateway import VirtualminConfig, VirtualminGateway, get_virtualmin_config
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminConfig,
+    VirtualminGateway,
+    get_virtualmin_config,
+    resolve_server_credentials,
+)
 from apps.provisioning.virtualmin_models import VirtualminServer
 
 
@@ -162,13 +167,15 @@ class GetCredentialsNoEnvFallbackTest(TestCase):
         self.assertEqual(username, "vault_user")
         self.assertEqual(password, "vault_pass")
 
-    def test_vault_failure_falls_through_to_server_creds(self):
-        """When vault fails, server credentials are used as fallback."""
+    def test_vault_not_found_falls_through_to_server_creds(self):
+        """A genuine vault MISS (no entry) falls back to the encrypted server field — the intended
+        path for manually-registered servers that were never migrated into the vault."""
         server = create_test_virtualmin_server(api_username="fallback_user", _password="fallback_pass")
         gateway = self._make_gateway(server)
 
         mock_vault = MagicMock()
-        mock_vault.get_credential.return_value = Err("Vault unavailable")
+        # Matches CredentialVault.get_credential's real not-found message (credential_vault.py).
+        mock_vault.get_credential.return_value = Err("Credential not found: virtualmin:vmin-cred.example.com")
 
         with patch.object(gateway, "_get_credential_vault", return_value=mock_vault):
             result = gateway._get_credentials()
@@ -177,6 +184,185 @@ class GetCredentialsNoEnvFallbackTest(TestCase):
         username, password = result.unwrap()
         self.assertEqual(username, "fallback_user")
         self.assertEqual(password, "fallback_pass")
+
+    def test_vault_unavailable_is_terminal_no_field_fallback(self):
+        """A vault error that is NOT a genuine miss — outage, expiry, access-denied, decryption —
+        must be TERMINAL: the resolver must NOT resurrect the encrypted field, or a stale/revoked
+        model credential could bypass the vault lifecycle (ADR-0033). Fail-closed."""
+        server = create_test_virtualmin_server(api_username="fallback_user", _password="fallback_pass")
+        gateway = self._make_gateway(server)
+
+        for vault_err in ("Vault unavailable", "Credential expired 3 days ago", "Access denied to credential"):
+            with self.subTest(vault_err=vault_err):
+                mock_vault = MagicMock()
+                mock_vault.get_credential.return_value = Err(vault_err)
+                with patch.object(gateway, "_get_credential_vault", return_value=mock_vault):
+                    result = gateway._get_credentials()
+                self.assertTrue(result.is_err(), f"{vault_err!r} must be terminal, not fall back to the field")
+
+    def test_vault_not_found_message_matches_resolver_sentinel(self):
+        """CANARY (structural coupling): resolve_server_credentials permits the encrypted-field
+        fallback ONLY when the vault error starts with _VAULT_NOT_FOUND_PREFIX. If CredentialVault's
+        real not-found message ever drifts from that prefix, manual-server field fallback silently
+        breaks. This locks the coupling to the REAL vault message so a drift fails loudly here — the
+        other tests hardcode the message and would not catch it."""
+        from apps.provisioning.virtualmin_gateway import _VAULT_NOT_FOUND_PREFIX  # noqa: PLC0415  # local: canary
+
+        result = CredentialVault().get_credential(
+            service_type="virtualmin", service_identifier="no-such-host.example.com", reason="sentinel canary"
+        )
+
+        self.assertTrue(result.is_err())
+        self.assertTrue(
+            result.unwrap_err().startswith(_VAULT_NOT_FOUND_PREFIX),
+            f"vault not-found message {result.unwrap_err()!r} no longer starts with the resolver "
+            f"sentinel {_VAULT_NOT_FOUND_PREFIX!r} — manual-server field fallback will break",
+        )
+
+
+class GatewayHttpAuthVaultFirstTest(TestCase):
+    """#348 / ADR-0033: the gateway HTTP auth path (_execute_http_request) must resolve the
+    Virtualmin credential vault-first — VirtualMin server creds live in the CredentialVault —
+    never the (now-empty) encrypted_api_password field. Mocks ONLY the network + the vault so a
+    real gateway call flows through the real auth construction."""
+
+    def _vault_backed_server(self) -> VirtualminServer:
+        return VirtualminServer.objects.create(
+            name="vmin-vault-node",
+            hostname="vmin-vault.example.com",
+            api_port=10000,
+            use_ssl=True,
+            ssl_verify=False,
+            ssl_cert_fingerprint="ab" * 32,
+            status="active",
+            api_username="praho-api",
+            encrypted_api_password=b"",  # the real secret lives in the vault
+            max_domains=50,
+            max_bandwidth_gb=1000,
+        )
+
+    @staticmethod
+    def _ok_info_response() -> MagicMock:
+        resp = MagicMock()
+        resp.text = '{"status": "success", "data": {"version": "7.20"}}'
+        resp.status_code = 200
+        resp.headers = {}
+        return resp
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_http_auth_uses_vault_credential(self, mock_get_vault, mock_safe_request):
+        """DISCRIMINATOR: a normal gateway call authenticates with the vault credential, not b''."""
+        server = self._vault_backed_server()
+        vault = MagicMock()
+        vault.get_credential.return_value = Ok(("praho-api", "vault-pw", {}))
+        mock_get_vault.return_value = vault
+        mock_safe_request.return_value = self._ok_info_response()
+
+        result = VirtualminGateway(VirtualminConfig(server=server)).call("info")
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        _args, kwargs = mock_safe_request.call_args
+        self.assertEqual(kwargs["auth"], ("praho-api", "vault-pw"))
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_http_auth_fails_closed_without_any_credential(self, mock_get_vault, mock_safe_request):
+        """DISCRIMINATOR + security: empty field + vault miss → Err before the network. The gateway
+        must never send an empty-password request (which would 401 and, via the auth manager,
+        escalate toward master credentials)."""
+        server = self._vault_backed_server()
+        vault = MagicMock()
+        vault.get_credential.return_value = Err("credential not found")
+        mock_get_vault.return_value = vault
+
+        result = VirtualminGateway(VirtualminConfig(server=server)).call("info")
+
+        self.assertTrue(result.is_err())
+        self.assertFalse(mock_safe_request.called, "must not send an empty-credential request")
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_from_credentials_direct_password_never_consults_vault(self, mock_get_vault, mock_safe_request):
+        """GUARD: use_credential_vault=False (from_credentials — used by the verify_and_activate probe
+        AND by _execute_master_proxy) must use the DIRECT password and NOT touch the vault. Otherwise
+        master-proxy escalation would silently authenticate with the ACL vault credential instead of
+        the configured master password."""
+        mock_safe_request.return_value = self._ok_info_response()
+        config = VirtualminConfig.from_credentials(
+            hostname="vmin-direct.example.com",
+            username="master-admin",
+            password="master-pw",
+            cert_fingerprint="ab" * 32,
+            verify_ssl=False,
+        )
+
+        result = VirtualminGateway(config).call("info")
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        mock_get_vault.assert_not_called()
+        _args, kwargs = mock_safe_request.call_args
+        self.assertEqual(kwargs["auth"], ("master-admin", "master-pw"))
+
+    @patch("apps.provisioning.virtualmin_gateway.safe_request")
+    @patch("apps.common.credential_vault.get_credential_vault")
+    def test_connection_test_uses_posted_credentials_not_vault(self, mock_get_vault, mock_safe_request):
+        """Warning 2: the staff 'test these credentials' flow must probe the OPERATOR-ENTERED
+        password (use_credential_vault=False), NOT the vault entry for that hostname — otherwise
+        testing an existing host would silently authenticate with the stored vault credential and
+        report a misleading result."""
+        # A vault entry EXISTS for this hostname and would win if the flow were vault-first.
+        vault = MagicMock()
+        vault.get_credential.return_value = Ok(("vault-user", "vault-pw", {}))
+        mock_get_vault.return_value = vault
+        mock_safe_request.return_value = self._ok_info_response()
+
+        temp_server = VirtualminServer(
+            hostname="existing-host.example.com",
+            api_port=10000,
+            api_username="posted-user",
+            use_ssl=True,
+            ssl_verify=False,
+            ssl_cert_fingerprint="ab" * 32,
+            status="active",
+        )
+        temp_server.set_api_password("posted-pw")
+
+        from apps.provisioning.virtualmin_service import (  # noqa: PLC0415  # local: test-only path
+            VirtualminProvisioningService,
+        )
+
+        result = VirtualminProvisioningService().test_server_connection(temp_server, use_credential_vault=False)
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        _args, kwargs = mock_safe_request.call_args
+        self.assertEqual(
+            kwargs["auth"],
+            ("posted-user", "posted-pw"),
+            "connection test must use the operator-entered credentials, not the vault entry",
+        )
+
+    def test_vault_write_key_and_resolver_read_key_resolve_the_same_row(self):
+        """Round-trip (write/read key coupling, Med 2): a credential stored under
+        service_identifier=hostname — the key register_node writes (service_identifier=server.hostname)
+        — must be readable by the production resolver, which reads by server.hostname. Proves the
+        write key and the read key resolve the SAME vault row through the REAL vault (no mock)."""
+        hostname = "roundtrip-node.example.com"
+        CredentialVault().store_credential(
+            CredentialData(
+                service_type="virtualmin",
+                service_identifier=hostname,
+                username="praho-api",
+                password="stored-pw",
+            )
+        )
+        # A deploy-path server: empty encrypted field, hostname is the ONLY link to the vault row.
+        server = VirtualminServer(hostname=hostname, api_username="field-user-ignored", status="active")
+
+        result = resolve_server_credentials(server, vault=CredentialVault(), reason="round-trip test")
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        self.assertEqual(result.unwrap(), ("praho-api", "stored-pw"))
 
 
 class VirtualminServerTLSFormTest(TestCase):

--- a/services/platform/tests/provisioning/test_virtualmin_retry_contract.py
+++ b/services/platform/tests/provisioning/test_virtualmin_retry_contract.py
@@ -16,8 +16,14 @@ from apps.provisioning.virtualmin_models import VirtualminServer
 
 
 def _gateway() -> VirtualminGateway:
-    server = VirtualminServer(hostname="retry.example.com", status="active", use_ssl=False)
-    return VirtualminGateway(VirtualminConfig(server=server, verify_ssl=False))
+    server = VirtualminServer(
+        hostname="retry.example.com", status="active", use_ssl=False, api_username="retry-api"
+    )
+    server.set_api_password("retry-pw")
+    # use_credential_vault=False: these tests exercise the RETRY contract with _execute_http_request
+    # mocked, so the credential must resolve from the server field (no vault/DB) — call() now resolves
+    # auth fail-closed BEFORE the retry loop, and SimpleTestCase has no DB for a vault lookup.
+    return VirtualminGateway(VirtualminConfig(server=server, verify_ssl=False, use_credential_vault=False))
 
 
 def _response(status_code: int) -> requests.Response:
@@ -88,7 +94,9 @@ class VirtualminRetryContractTests(SimpleTestCase):
 
         with (
             patch.object(gateway, "_check_rate_limit", return_value=True),
-            patch.object(gateway, "_execute_http_request", side_effect=lambda _params: _response(503)) as request_mock,
+            patch.object(
+                gateway, "_execute_http_request", side_effect=lambda _params, auth=None: _response(503)
+            ) as request_mock,
             patch("apps.provisioning.virtualmin_gateway.time.sleep"),
         ):
             result = gateway.call("delete-domain", {"domain": "example.com"})
@@ -102,7 +110,9 @@ class VirtualminRetryContractTests(SimpleTestCase):
 
         with (
             patch.object(gateway, "_check_rate_limit", return_value=True),
-            patch.object(gateway, "_execute_http_request", side_effect=lambda _params: _response(503)) as request_mock,
+            patch.object(
+                gateway, "_execute_http_request", side_effect=lambda _params, auth=None: _response(503)
+            ) as request_mock,
             patch("apps.provisioning.virtualmin_gateway.time.sleep"),
         ):
             result = gateway.call("list-domains")


### PR DESCRIPTION
## Summary

Closes the credential seam so a deployed node becomes **customer-ready with no manual step** — the blocker identified in #347. Before this, `deploy_node` created the VM and Ansible installed Virtualmin, but nothing ever put a PRAHO-controlled API credential on the node, so it registered `disabled` and needed a human to configure + activate it.

Closes #347 (GAP 1 + GAP 2). GAP 3 (DNS) and the real-node acceptance drill remain — see below.

## What changed (3 commits)

- **GAP 2 — activation bridge** (`verify_and_activate`): after registration, do a real credential handshake (`gateway.test_connection`) and transition the server `disabled → active` **only on affirmative health**, CAS-guarded to a still-`disabled` row. A failed check leaves it `disabled` (safe — never customer-routed). 4 unit tests.
- **Secure secret transport**: `run_playbook` passed all vars via `-e <json>` on the ansible command line — a password there would leak into the PRAHO host's process list. Now written to a **0600 temp file** (`-e @file`), cleaned up in `finally`. Regression test asserts no secret reaches argv.
- **GAP 1 — provision + activate**: generate a dedicated Virtualmin API credential **before** the Ansible stages, hand it to the panel playbook via the secure vars file, add a `virtualmin.yml` task that creates the ACL user (`no_log`, "dedicated ACL user, never master admin"), register with the ACL username (not `root`), then `verify_and_activate`. The deployment still completes even if activation fails (node stays `disabled`).

## Testing

- Python coordination fully unit-tested: `TestCredentialSeamWiring` (credential generated → threaded via `extra_vars` → registered with ACL user → `verify_and_activate` called), `VerifyAndActivateTests` (4), the secret-not-on-argv regression, all under mocked gateway/ansible/SSH.
- `virtualmin.yml` passes `ansible-playbook --syntax-check`.
- Full infrastructure suite green (513 tests); lint + mypy clean on every changed file.

## What this PR does NOT do (honest boundaries)

- **The `virtualmin create-admin` capability flags are best-effort and need real-node validation** (marked inline in the playbook). They govern what PRAHO can do via the API.
- **GAP 3 (DNS)** — the imperative pipeline still doesn't configure the node's DNS (`cloudflare_api_token` is threaded but unused; `configuring_dns` is a pass-through). A separate terraform path has real DNS. This is a smaller, follow-up piece.
- **No CI can prove this end-to-end** — there's no live Virtualmin here; every test is mocked. The definition of done is a **real-Hetzner drill**: deploy from an API key → node comes up `active` + credentialed with zero manual steps → provision a real customer domain and confirm it serves. That drill is the acceptance gate and needs a live node.

Stacked on #341 (the fixed deploy path); GitHub will retarget to `master` when #341 merges.
