### PR TITLE
fix(security): restore unsafe-eval on platform CSP for Alpine and htmx

### DIFF
--- a/deploy/nginx/nginx-ssl.conf
+++ b/deploy/nginx/nginx-ssl.conf
@@ -178,8 +178,13 @@ http {
         add_header Cross-Origin-Opener-Policy "same-origin" always;
         add_header Cross-Origin-Resource-Policy "same-origin" always;
 
-        # Content Security Policy (customize per your needs)
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none'; form-action 'self'; base-uri 'self'; object-src 'none'" always;
+        # Content-Security-Policy is deliberately NOT set here. Each service's
+        # Django middleware owns its CSP (platform SecurityHeadersMiddleware,
+        # portal equivalent). Browsers enforce the INTERSECTION of multiple CSP
+        # headers, so a proxy-level policy silently overrides the apps — this
+        # copy had drifted (stale unpkg/cdn.tailwindcss whitelists, missing
+        # 'unsafe-eval' and js.stripe.com), breaking Alpine and Stripe in SSL
+        # deployments. See #206 / #284 for the CSP hardening roadmap.
 
         # ===============================================================================
         # ADMIN/PLATFORM ROUTES (Staff access)

--- a/services/platform/apps/common/middleware.py
+++ b/services/platform/apps/common/middleware.py
@@ -117,7 +117,8 @@ class SecurityHeadersMiddleware:
         # Content Security Policy.
         # 'unsafe-inline' AND 'unsafe-eval' are both required until the CSP-hardening
         # migration (#206 / #284) lands. Do NOT drop either in isolation:
-        #   - 'unsafe-inline': inline <script>/<style> not yet fully nonce-migrated (#104 [M7]).
+        #   - 'unsafe-inline': nonce attributes landed (#104 [M7] step 1), but inline event
+        #     handlers (onclick=, onkeydown=) cannot carry nonces and remain in templates.
         #   - 'unsafe-eval': Alpine.js (standard build) compiles directive expressions via
         #     new Function(), and htmx hx-on:: handlers eval their bodies. Removing it needs
         #     BOTH frameworks refactored (Alpine CSP build + htmx hx-on -> nonce'd scripts) —

--- a/services/platform/apps/common/middleware.py
+++ b/services/platform/apps/common/middleware.py
@@ -114,16 +114,23 @@ class SecurityHeadersMiddleware:
     def __call__(self, request: HttpRequest) -> HttpResponse:
         response = self.get_response(request)
 
-        # Content Security Policy — unsafe-inline until templates are migrated
-        # to nonce attributes (see #104 [M7]). CSPNonceMiddleware + context
-        # processor are deployed; nonce injection into CSP deferred until all
-        # inline <script>/<style> tags carry nonce="{{ csp_nonce }}".
+        # Content Security Policy.
+        # 'unsafe-inline' AND 'unsafe-eval' are both required until the CSP-hardening
+        # migration (#206 / #284) lands. Do NOT drop either in isolation:
+        #   - 'unsafe-inline': inline <script>/<style> not yet fully nonce-migrated (#104 [M7]).
+        #   - 'unsafe-eval': Alpine.js (standard build) compiles directive expressions via
+        #     new Function(), and htmx hx-on:: handlers eval their bodies. Removing it needs
+        #     BOTH frameworks refactored (Alpine CSP build + htmx hx-on -> nonce'd scripts) —
+        #     tracked in #206/#284. Dropping it alone silently breaks ALL admin-UI interactivity
+        #     (deploy form, modals, dropdowns) with only a console CSP error to show for it.
+        # The customer portal already serves the same 'unsafe-eval' policy for its Stripe/Alpine
+        # flows; this keeps the (VPN-gated) internal platform at parity, not silently broken.
         if not response.get("Content-Security-Policy"):
             csp = (
                 "default-src 'self'; "
                 "style-src 'self' 'unsafe-inline' fonts.googleapis.com; "
                 "font-src 'self' fonts.gstatic.com; "
-                "script-src 'self' 'unsafe-inline'; "
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
                 "img-src 'self' data: https:; "
                 "connect-src 'self'; "
                 "object-src 'none'; "

--- a/services/platform/tests/common/test_csp_header.py
+++ b/services/platform/tests/common/test_csp_header.py
@@ -1,28 +1,47 @@
-"""H11: CSP header must not contain unsafe-eval."""
+"""Platform CSP script-src contract.
+
+History: the comprehensive security audit (H11) removed 'unsafe-eval', which
+silently broke ALL Alpine.js interactivity (standard Alpine compiles directive
+expressions via new Function()) and htmx hx-on:: handlers — the only symptom
+was a console CSP error. 'unsafe-eval' is restored deliberately until the
+CSP-hardening migration (#206 / #284) replaces both framework usages; only
+then may this contract flip back.
+"""
 from django.http import HttpRequest, HttpResponse
 from django.test import SimpleTestCase
 
 from apps.common.middleware import SecurityHeadersMiddleware
 
 
-class CSPNoUnsafeEvalTests(SimpleTestCase):
-    """H11: Content-Security-Policy must not include 'unsafe-eval'."""
+def _served_csp() -> str:
+    mw = SecurityHeadersMiddleware(lambda r: HttpResponse("ok"))
+    request = HttpRequest()
+    request.method = "GET"
+    request.path = "/"
+    response = mw(request)
+    return response.get("Content-Security-Policy", "")
 
-    def test_csp_does_not_contain_unsafe_eval(self) -> None:
-        mw = SecurityHeadersMiddleware(lambda r: HttpResponse("ok"))
-        request = HttpRequest()
-        request.method = "GET"
-        request.path = "/"
-        response = mw(request)
-        csp = response.get("Content-Security-Policy", "")
-        self.assertNotIn("unsafe-eval", csp)
+
+class CSPScriptSrcContractTests(SimpleTestCase):
+    """script-src must keep Alpine/htmx working until #206/#284 land."""
+
+    def test_csp_contains_unsafe_eval_for_alpine_and_htmx(self) -> None:
+        """Regression: dropping 'unsafe-eval' kills every Alpine directive and
+        hx-on:: handler in the admin UI (deploy form, modals, dropdowns)."""
+        self.assertIn("'unsafe-eval'", _served_csp())
+
+    def test_csp_contains_unsafe_inline_until_nonce_migration(self) -> None:
+        """Inline event handlers (onclick=...) cannot carry nonces; removal is
+        gated on the #206 migration."""
+        self.assertIn("'unsafe-inline'", _served_csp())
 
     def test_csp_still_contains_self(self) -> None:
         """Sanity check: CSP should still have 'self' directive."""
-        mw = SecurityHeadersMiddleware(lambda r: HttpResponse("ok"))
-        request = HttpRequest()
-        request.method = "GET"
-        request.path = "/"
-        response = mw(request)
-        csp = response.get("Content-Security-Policy", "")
-        self.assertIn("'self'", csp)
+        self.assertIn("'self'", _served_csp())
+
+    def test_csp_keeps_hardened_directives(self) -> None:
+        """Restoring eval must not regress the directives that stay strict."""
+        csp = _served_csp()
+        self.assertIn("object-src 'none'", csp)
+        self.assertNotIn("unpkg.com", csp)
+        self.assertNotIn("cdn.tailwindcss.com", csp)

--- a/tests/integration/test_security_hardening.py
+++ b/tests/integration/test_security_hardening.py
@@ -545,3 +545,31 @@ class TestTokenRevocationLogic:
         assert "request.auth" in body, (
             "revoke_token should use request.auth (already resolved by TokenAuthentication)"
         )
+
+
+# ---------------------------------------------------------------------------
+# 6. CSP has exactly one owner per service — never the nginx proxy
+# ---------------------------------------------------------------------------
+
+
+class TestProxyCSPOwnership:
+    """The SSL proxy must not serve its own Content-Security-Policy.
+
+    Browsers enforce the INTERSECTION of multiple CSP headers, so a proxy-level
+    policy silently overrides the per-service Django middlewares. The nginx
+    copy demonstrably drifted (stale CDN whitelists, missing 'unsafe-eval' and
+    js.stripe.com), breaking Alpine on the platform and Stripe on the portal
+    in the documented SSL deployment. CSP is owned by each service's
+    middleware; the proxy owns transport-level headers only (#206 / #284).
+    """
+
+    @pytest.mark.integration
+    @pytest.mark.security
+    def test_nginx_ssl_conf_does_not_set_csp(self):
+        nginx_conf = PROJECT_ROOT / "deploy" / "nginx" / "nginx-ssl.conf"
+        content = nginx_conf.read_text()
+        assert "add_header Content-Security-Policy" not in content, (
+            "nginx-ssl.conf must not add a Content-Security-Policy header: "
+            "browsers enforce the intersection with the Django-served CSP, and "
+            "the proxy copy has repeatedly drifted from the app policies"
+        )


### PR DESCRIPTION
## Summary
The platform CSP served `script-src 'self' 'unsafe-inline'` with **no** `'unsafe-eval'`, which silently broke **all** Alpine.js interactivity (the node deploy form cascade, modals, dropdowns) and htmx `hx-on::` handlers. Standard Alpine compiles directive expressions via `new Function()`, and htmx evaluates `hx-on` bodies — both require `unsafe-eval`. The only symptom was a console CSP error.

Restores `unsafe-eval` on the platform, reaching parity with the customer portal (which already serves the same policy for its Stripe/Alpine flows).

## Why not remove unsafe-eval instead
Dropping it requires migrating both frameworks (Alpine CSP build + moving htmx `hx-on::` to nonce'd scripts) — tracked under #206 / #284. This unblocks the admin UI in the meantime.

## Validation
Verified live: with the fix the platform web UI works; without it Alpine throws CSP `unsafe-eval` errors and the deploy form is dead.

## Follow-up
Add a regression test asserting the served CSP `script-src` includes `unsafe-eval`.

Refs #206, #284.
