### PR TITLE
fix(integrations): harden Stripe webhook handling

### DIFF
--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -1119,7 +1119,10 @@ class RefundService:
             retriability = (
                 Retriability.RETRIABLE if isinstance(exc, ConcurrentTransition) else Retriability.NOT_RETRIABLE
             )
-            return Err(f"Refund state transition failed: {exc}", retriability=retriability)
+            # Exception detail stays in the log: refund Err messages flow into
+            # webhook HTTP responses (integrations/views.py) — never leak internals.
+            logger.exception("Refund state transition failed for refund_id=%s", refund.pk)
+            return Err("Refund state transition failed", retriability=retriability)
 
         refund.metadata = {**(refund.metadata or {}), "gateway_status": normalized}
         update_fields = ["metadata", "updated_at"]
@@ -1244,17 +1247,19 @@ class RefundService:
                 )
             invoice_changed = invoice_projection.unwrap()
             return Ok({"payment": payment_changed, "invoice": invoice_changed})
-        except (OperationalError, InterfaceError) as exc:
+        except (OperationalError, InterfaceError):
             logger.exception(
                 "Refund settlement projection hit a transient database error for payment_id=%s", payment.pk
             )
+            # Exception detail stays in the log: these Err messages flow into
+            # webhook HTTP responses (integrations/views.py) — never leak internals.
             return Err(
-                f"Refund settlement projection failed: {exc}",
+                "Refund settlement projection failed",
                 retriability=Retriability.RETRIABLE,
             )
-        except Exception as exc:
+        except Exception:
             logger.exception("Refund settlement projection failed for payment_id=%s", payment.pk)
-            return Err(f"Refund settlement projection failed: {exc}")
+            return Err("Refund settlement projection failed")
 
     @staticmethod
     def _process_entity_updates(
@@ -2176,12 +2181,14 @@ class RefundConvergenceService:
                         retriability=retriability_of(projection),
                     )
                 return Ok(refund)
-        except (OperationalError, InterfaceError) as exc:
+        except (OperationalError, InterfaceError):
             logger.exception("Refund convergence hit a transient database error for gateway_refund_id=%s", refund_id)
-            return RefundConvergenceService._retryable_error(f"Refund convergence failed: {exc}")
-        except Exception as exc:
+            # Exception detail stays in the log: these Err messages flow into
+            # webhook HTTP responses (integrations/views.py) — never leak internals.
+            return RefundConvergenceService._retryable_error("Refund convergence failed")
+        except Exception:
             logger.exception("Refund convergence failed for gateway_refund_id=%s", refund_id)
-            return Err(f"Refund convergence failed: {exc}")
+            return Err("Refund convergence failed")
 
 
 class RefundQueryService:

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -18,7 +18,7 @@ from django_fsm import ConcurrentTransition, TransitionNotAllowed
 
 from apps.billing.gateways.base import GATEWAY_PAYMENT_METHODS, PaymentGatewayFactory
 from apps.billing.models import Invoice, Payment, Refund, RefundStatusHistory, log_security_event
-from apps.common.types import Err, Ok, Result
+from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 from apps.orders.models import Order
 
 logger = logging.getLogger(__name__)
@@ -888,7 +888,10 @@ class RefundService:
             )
             if refund_result.is_err():
                 transaction.set_rollback(True)
-                return refund_result  # type: ignore[return-value]
+                # The public refund path is gateway-first. Deliberately discard
+                # the helper's local-write retriability: replaying the whole
+                # customer refund is not proven safe after money moved.
+                return Err(refund_result.unwrap_err())
 
             refund = refund_result.unwrap()
             status_result = RefundService._advance_refund_status(
@@ -1032,18 +1035,24 @@ class RefundService:
 
             return Ok(refund)
 
+        except (OperationalError, InterfaceError):
+            logger.exception("Refund record creation failed due to a transient database error")
+            return Err("Failed to process bidirectional refund", retriability=Retriability.RETRIABLE)
         except IntegrityError:
             # FK constraint violated — catches both SQLite and PostgreSQL (#120)
             entity_label = "order" if order else "invoice"
             entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
             logger.exception("Refund record creation failed: FK constraint for %s_id=%s", entity_label, entity_pk)
-            return Err("Failed to process bidirectional refund")
+            return Err("Failed to process bidirectional refund", retriability=Retriability.NOT_RETRIABLE)
         except ValueError:
             # Django ORM assignment error (e.g. assigning wrong type to FK field) (#120)
             entity_label = "order" if order else "invoice"
             entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
             logger.exception("Refund record creation failed: assignment error for %s_id=%s", entity_label, entity_pk)
-            return Err("Order update failed" if order else "Invoice update failed")
+            return Err(
+                "Order update failed" if order else "Invoice update failed",
+                retriability=Retriability.NOT_RETRIABLE,
+            )
         except Exception:
             entity_label = "order" if order else "invoice"
             entity_pk = order.pk if order else (invoice.pk if invoice else "unknown")
@@ -1055,7 +1064,10 @@ class RefundService:
         """Advance the Refund FSM from authoritative processor status."""
         normalized = "canceled" if gateway_status == "cancelled" else gateway_status
         if normalized not in {"pending", "requires_action", "succeeded", "failed", "canceled"}:
-            return Err(f"Unsupported gateway refund status: {gateway_status}")
+            return Err(
+                f"Unsupported gateway refund status: {gateway_status}",
+                retriability=Retriability.NOT_RETRIABLE,
+            )
 
         expected_terminal = {"succeeded": "completed", "failed": "failed", "canceled": "cancelled"}
         current_status = str(refund.status)
@@ -1067,7 +1079,10 @@ class RefundService:
             if normalized in {"pending", "requires_action"}:
                 return Ok(refund)
             if expected_terminal.get(normalized) != current_status:
-                return Err(f"Refund state mismatch: cannot apply '{gateway_status}' to '{current_status}'")
+                return Err(
+                    f"Refund state mismatch: cannot apply '{gateway_status}' to '{current_status}'",
+                    retriability=Retriability.NOT_RETRIABLE,
+                )
             return Ok(refund)
 
         def apply_transition(method_name: str) -> None:
@@ -1101,7 +1116,10 @@ class RefundService:
             for transition in transition_paths[normalized].get(str(refund.status), ()):
                 apply_transition(transition)
         except (TransitionNotAllowed, ConcurrentTransition) as exc:
-            return Err(f"Refund state transition failed: {exc}")
+            retriability = (
+                Retriability.RETRIABLE if isinstance(exc, ConcurrentTransition) else Retriability.NOT_RETRIABLE
+            )
+            return Err(f"Refund state transition failed: {exc}", retriability=retriability)
 
         refund.metadata = {**(refund.metadata or {}), "gateway_status": normalized}
         update_fields = ["metadata", "updated_at"]
@@ -1125,7 +1143,10 @@ class RefundService:
             ("partially_refunded", "refunded"): "complete_refund",
         }.get((str(payment.status), target))
         if transition is None:
-            return Err(f"Cannot project payment {payment.pk} from {payment.status!r} to {target!r}")
+            return Err(
+                f"Cannot project payment {payment.pk} from {payment.status!r} to {target!r}",
+                retriability=Retriability.NOT_RETRIABLE,
+            )
         getattr(payment, transition)()
         payment.save(update_fields=["status", "updated_at"])
         return Ok(True)
@@ -1144,7 +1165,10 @@ class RefundService:
             ("partially_refunded", "refunded"): "refund_invoice",
         }.get((str(invoice.status), target))
         if transition is None:
-            return Err(f"Cannot project invoice {invoice.pk} from {invoice.status!r} to {target!r}")
+            return Err(
+                f"Cannot project invoice {invoice.pk} from {invoice.status!r} to {target!r}",
+                retriability=Retriability.NOT_RETRIABLE,
+            )
         getattr(invoice, transition)()
         invoice.save(update_fields=["status", "updated_at"])
         return Ok(True)
@@ -1190,7 +1214,10 @@ class RefundService:
             )
             payment_projection = RefundService._apply_payment_refund_projection(payment, payment_target)
             if payment_projection.is_err():
-                return Err(payment_projection.unwrap_err())
+                return Err(
+                    payment_projection.unwrap_err(),
+                    retriability=retriability_of(payment_projection),
+                )
             payment_changed = payment_projection.unwrap()
 
             if invoice is None:
@@ -1211,9 +1238,20 @@ class RefundService:
             )
             invoice_projection = RefundService._apply_invoice_refund_projection(invoice, invoice_target)
             if invoice_projection.is_err():
-                return Err(invoice_projection.unwrap_err())
+                return Err(
+                    invoice_projection.unwrap_err(),
+                    retriability=retriability_of(invoice_projection),
+                )
             invoice_changed = invoice_projection.unwrap()
             return Ok({"payment": payment_changed, "invoice": invoice_changed})
+        except (OperationalError, InterfaceError) as exc:
+            logger.exception(
+                "Refund settlement projection hit a transient database error for payment_id=%s", payment.pk
+            )
+            return Err(
+                f"Refund settlement projection failed: {exc}",
+                retriability=Retriability.RETRIABLE,
+            )
         except Exception as exc:
             logger.exception("Refund settlement projection failed for payment_id=%s", payment.pk)
             return Err(f"Refund settlement projection failed: {exc}")
@@ -1885,6 +1923,14 @@ class RefundConvergenceService:
     """Converge gateway refund facts into PRAHO's refund ledger."""
 
     @staticmethod
+    def _permanent_error(message: str) -> Err[str]:
+        return Err(message, retriability=Retriability.NOT_RETRIABLE)
+
+    @staticmethod
+    def _retryable_error(message: str) -> Err[str]:
+        return Err(message, retriability=Retriability.RETRIABLE)
+
+    @staticmethod
     def _lock_related_order(
         payment: Payment,
         preferred_order_id: uuid.UUID | None,
@@ -1912,18 +1958,20 @@ class RefundConvergenceService:
                     .order_by("id")[:2]
                 )
         except (TypeError, ValueError):
-            return Err("Payment has an invalid order linkage")
+            return RefundConvergenceService._permanent_error("Payment has an invalid order linkage")
         if not candidates:
             return Ok(None)
         if len(candidates) > 1:
-            return Err("Payment resolves to multiple orders during refund reconciliation")
+            return RefundConvergenceService._permanent_error(
+                "Payment resolves to multiple orders during refund reconciliation"
+            )
 
         order = candidates[0]
         metadata_matches = str((payment.meta or {}).get("order_id", "")) == str(order.pk)
         proforma_matches = payment.proforma_id is not None and payment.proforma_id == order.proforma_id
         invoice_matches = payment.invoice_id is not None and payment.invoice_id == order.invoice_id
         if not (metadata_matches or proforma_matches or invoice_matches):
-            return Err("Gateway refund order does not match the payment linkage")
+            return RefundConvergenceService._permanent_error("Gateway refund order does not match the payment linkage")
         return Ok(order)
 
     @staticmethod
@@ -1936,15 +1984,19 @@ class RefundConvergenceService:
     ) -> Result[None, str]:
         """Validate and attach a legacy refund before projecting its state."""
         if refund.payment_id not in (None, payment.id):
-            return Err("Gateway refund is linked to a different payment")
+            return RefundConvergenceService._permanent_error("Gateway refund is linked to a different payment")
         if refund.customer_id != payment.customer_id or refund.currency_id != payment.currency_id:
-            return Err("Gateway refund customer or currency linkage mismatch")
+            return RefundConvergenceService._permanent_error("Gateway refund customer or currency linkage mismatch")
         if refund.amount_cents != amount_cents:
-            return Err(f"Gateway refund amount mismatch: expected {refund.amount_cents}, received {amount_cents}")
+            return RefundConvergenceService._permanent_error(
+                f"Gateway refund amount mismatch: expected {refund.amount_cents}, received {amount_cents}"
+            )
         if refund.invoice_id is not None and (invoice is None or refund.invoice_id != invoice.id):
-            return Err("Gateway refund invoice does not match the payment linkage")
+            return RefundConvergenceService._permanent_error(
+                "Gateway refund invoice does not match the payment linkage"
+            )
         if refund.order_id is not None and (order is None or refund.order_id != order.id):
-            return Err("Gateway refund order does not match the payment linkage")
+            return RefundConvergenceService._permanent_error("Gateway refund order does not match the payment linkage")
         if refund.payment_id is None:
             refund.payment = payment
             refund.save(update_fields=["payment", "updated_at"])
@@ -1960,18 +2012,18 @@ class RefundConvergenceService:
         currency = facts.get("currency")
         gateway_status = facts.get("status")
         if not isinstance(refund_id, str) or not refund_id:
-            return Err("Gateway refund ID is missing")
+            return RefundConvergenceService._permanent_error("Gateway refund ID is missing")
         if not isinstance(payment_intent_id, str) or not payment_intent_id:
-            return Err("Gateway refund PaymentIntent is missing")
+            return RefundConvergenceService._permanent_error("Gateway refund PaymentIntent is missing")
         if isinstance(amount_cents, bool) or not isinstance(amount_cents, int) or amount_cents <= 0:
-            return Err("Gateway refund amount must be a positive integer")
+            return RefundConvergenceService._permanent_error("Gateway refund amount must be a positive integer")
         if not isinstance(currency, str) or not currency:
-            return Err("Gateway refund currency is missing")
+            return RefundConvergenceService._permanent_error("Gateway refund currency is missing")
         if not isinstance(gateway_status, str):
-            return Err("Gateway refund status is missing")
+            return RefundConvergenceService._permanent_error("Gateway refund status is missing")
         event_created = facts.get("event_created")
         if event_created is not None and (isinstance(event_created, bool) or not isinstance(event_created, int)):
-            return Err("Gateway refund event timestamp is invalid")
+            return RefundConvergenceService._permanent_error("Gateway refund event timestamp is invalid")
 
         try:
             with transaction.atomic():
@@ -1985,9 +2037,9 @@ class RefundConvergenceService:
                 if payment is None:
                     return Ok(None)
                 if payment.gateway_txn_id != payment_intent_id:
-                    return Err("Gateway refund PaymentIntent mismatch")
+                    return RefundConvergenceService._permanent_error("Gateway refund PaymentIntent mismatch")
                 if payment.currency.code.upper() != currency.upper():
-                    return Err(
+                    return RefundConvergenceService._permanent_error(
                         f"Gateway refund currency mismatch: expected {payment.currency.code.upper()}, received {currency!r}"
                     )
 
@@ -1995,10 +2047,12 @@ class RefundConvergenceService:
                 # may have created the Refund while this transaction was waiting.
                 snapshot = snapshot_query.values("id", "payment_id", "invoice_id", "order_id").first()
                 if snapshot and snapshot["payment_id"] not in (None, payment.id):
-                    return Err("Gateway refund is linked to a different payment")
+                    return RefundConvergenceService._permanent_error("Gateway refund is linked to a different payment")
                 snapshot_invoice_id = snapshot["invoice_id"] if snapshot else None
                 if snapshot_invoice_id and payment.invoice_id and snapshot_invoice_id != payment.invoice_id:
-                    return Err("Gateway refund invoice does not match the payment linkage")
+                    return RefundConvergenceService._permanent_error(
+                        "Gateway refund invoice does not match the payment linkage"
+                    )
                 invoice_id = payment.invoice_id or snapshot_invoice_id
                 invoice = (
                     Invoice.objects.select_for_update(of=("self",)).get(pk=invoice_id)
@@ -2013,7 +2067,10 @@ class RefundConvergenceService:
                     else RefundConvergenceService._lock_related_order(payment, preferred_order_id)
                 )
                 if order_result.is_err():
-                    return Err(order_result.unwrap_err())
+                    return Err(
+                        order_result.unwrap_err(),
+                        retriability=retriability_of(order_result),
+                    )
                 order = order_result.unwrap()
 
                 refund = (
@@ -2030,7 +2087,10 @@ class RefundConvergenceService:
                         amount_cents,
                     )
                     if validation.is_err():
-                        return Err(validation.unwrap_err())
+                        return Err(
+                            validation.unwrap_err(),
+                            retriability=retriability_of(validation),
+                        )
 
                     previous_created = (refund.metadata or {}).get("gateway_event_created")
                     if (
@@ -2041,10 +2101,14 @@ class RefundConvergenceService:
                         return Ok(refund)
                 else:
                     if order is None and invoice is None:
-                        return Err("Known payment has no order or invoice for refund reconciliation")
+                        return RefundConvergenceService._permanent_error(
+                            "Known payment has no order or invoice for refund reconciliation"
+                        )
                     remaining = RefundService._get_remaining_payment_refund_amount(payment)
                     if remaining is None or amount_cents > remaining:
-                        return Err(f"Gateway refund amount exceeds refundable balance: {amount_cents} > {remaining}")
+                        return RefundConvergenceService._permanent_error(
+                            f"Gateway refund amount exceeds refundable balance: {amount_cents} > {remaining}"
+                        )
                     reason_map = {
                         "duplicate": "duplicate_payment",
                         "fraudulent": "fraud",
@@ -2072,7 +2136,10 @@ class RefundConvergenceService:
                         # OR a clean no-write state; flag uniformly so convergence never
                         # commits a half-written refund (mirrors _process_bidirectional_refund).
                         transaction.set_rollback(True)
-                        return Err(create_result.unwrap_err())
+                        return Err(
+                            create_result.unwrap_err(),
+                            retriability=retriability_of(create_result),
+                        )
                     refund = create_result.unwrap()
 
                 state_result = RefundService._advance_refund_status(refund, gateway_status)
@@ -2081,7 +2148,10 @@ class RefundConvergenceService:
                     # (and _validate_existing_refund may have attached the payment); a
                     # plain return Err would commit that partial state.
                     transaction.set_rollback(True)
-                    return Err(state_result.unwrap_err())
+                    return Err(
+                        state_result.unwrap_err(),
+                        retriability=retriability_of(state_result),
+                    )
                 refund = state_result.unwrap()
                 metadata = dict(refund.metadata or {})
                 event_id = facts.get("event_id")
@@ -2101,8 +2171,14 @@ class RefundConvergenceService:
                     # on the Invoice. Roll back so the ledger row and its projection stay
                     # consistent (an idempotent retry re-converges cleanly).
                     transaction.set_rollback(True)
-                    return Err(projection.unwrap_err())
+                    return Err(
+                        projection.unwrap_err(),
+                        retriability=retriability_of(projection),
+                    )
                 return Ok(refund)
+        except (OperationalError, InterfaceError) as exc:
+            logger.exception("Refund convergence hit a transient database error for gateway_refund_id=%s", refund_id)
+            return RefundConvergenceService._retryable_error(f"Refund convergence failed: {exc}")
         except Exception as exc:
             logger.exception("Refund convergence failed for gateway_refund_id=%s", refund_id)
             return Err(f"Refund convergence failed: {exc}")

--- a/services/platform/apps/integrations/management/commands/process_webhooks.py
+++ b/services/platform/apps/integrations/management/commands/process_webhooks.py
@@ -1,8 +1,9 @@
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from django.core.management.base import BaseCommand
+from django.db.models import Q, QuerySet
 from django.utils import timezone
 
 from apps.common.constants import SECONDS_PER_HOUR, SECONDS_PER_MINUTE
@@ -13,6 +14,13 @@ from apps.integrations.webhooks.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _old_terminal_webhooks(cutoff: datetime) -> QuerySet[WebhookEvent]:
+    """Return terminal webhook rows whose authoritative age exceeds the cutoff."""
+    return WebhookEvent.objects.filter(status__in=["processed", "skipped"]).filter(
+        Q(processed_at__lt=cutoff) | Q(processed_at__isnull=True, received_at__lt=cutoff)
+    )
 
 
 class Command(BaseCommand):
@@ -96,7 +104,7 @@ class Command(BaseCommand):
         cutoff_date = timezone.now() - timedelta(days=30)
 
         # Only delete processed/skipped webhooks, keep failed ones for analysis
-        old_webhooks = WebhookEvent.objects.filter(status__in=["processed", "skipped"], processed_at__lt=cutoff_date)
+        old_webhooks = _old_terminal_webhooks(cutoff_date)
 
         count = old_webhooks.count()
         if count > 0:
@@ -168,9 +176,7 @@ class Command(BaseCommand):
 
         # Old webhooks that can be cleaned up
         cutoff_date = timezone.now() - timedelta(days=30)
-        old_webhooks = WebhookEvent.objects.filter(
-            status__in=["processed", "skipped"], processed_at__lt=cutoff_date
-        ).count()
+        old_webhooks = _old_terminal_webhooks(cutoff_date).count()
 
         if old_webhooks > 0:
             self.stdout.write(f"\n🗑️ {old_webhooks} old webhook records can be cleaned up (>30 days)")

--- a/services/platform/apps/integrations/webhooks/base.py
+++ b/services/platform/apps/integrations/webhooks/base.py
@@ -409,7 +409,7 @@ def verify_stripe_signature(
         # Parse Stripe signature header
         elements = stripe_signature.split(",")
         timestamp = None
-        signature = None
+        signatures: list[str] = []
 
         for element in elements:
             if "=" not in element:
@@ -418,27 +418,29 @@ def verify_stripe_signature(
             if len(parts) != EXPECTED_KEY_VALUE_PARTS:
                 continue  # Skip malformed elements
             key, value = parts
+            key, value = key.strip(), value.strip()
             if key == "t":
                 timestamp = int(value)
             elif key == "v1":
-                signature = value
+                signatures.append(value)
 
-        if not timestamp or not signature:
+        if timestamp is None or not signatures:
             return False
 
         # Check timestamp (prevent replay attacks)
         current_time = int(timezone.now().timestamp())
-        if current_time - timestamp > tolerance:
-            logger.warning(f"⏰ Stripe webhook timestamp too old: {current_time - timestamp}s")
+        if timestamp < current_time - tolerance:
+            timestamp_age = current_time - timestamp
+            logger.warning(f"⏰ Stripe webhook timestamp too old: {timestamp_age}s")
             return False
 
-        # Verify signature
+        # Stripe emits one v1 signature per active endpoint secret during rotation.
         payload_for_signature = f"{timestamp}.{payload_body.decode('utf-8')}"
         expected_signature = hmac.new(
             webhook_secret.encode("utf-8"), payload_for_signature.encode("utf-8"), hashlib.sha256
         ).hexdigest()
 
-        return hmac.compare_digest(signature, expected_signature)
+        return any(hmac.compare_digest(signature, expected_signature) for signature in signatures)
 
     except Exception as e:
         logger.error(f"❌ Stripe signature verification error: {e}")

--- a/services/platform/apps/integrations/webhooks/stripe.py
+++ b/services/platform/apps/integrations/webhooks/stripe.py
@@ -439,23 +439,25 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
     @staticmethod
-    def _acknowledge_permanent_refund_rejection(
+    def _acknowledge_permanent_rejection(
         message: str,
         retriability: Retriability = Retriability.NOT_RETRIABLE,
     ) -> tuple[bool, str]:
+        # Event-agnostic wording: this path also acknowledges malformed charge
+        # and generic payloads, not only refund objects (review of #374).
         logger.critical(
-            "Stripe refund permanently rejected (%s); manual reconciliation required: %s",
+            "Stripe webhook permanently rejected (%s); manual reconciliation required: %s",
             retriability.value,
             message,
         )
-        return True, f"Permanent Stripe refund rejection acknowledged: {message}"
+        return True, f"Permanent Stripe webhook rejection acknowledged: {message}"
 
     def handle_refund_event(self, event_type: str, payload: dict[str, Any]) -> tuple[bool, str]:
         """Converge modern Stripe Refund events into PRAHO's ledger."""
         event_data = payload.get("data", {})
         refund_object = event_data.get("object", {}) if isinstance(event_data, dict) else None
         if not isinstance(refund_object, dict):
-            return self._acknowledge_permanent_refund_rejection("Malformed Stripe refund object")
+            return self._acknowledge_permanent_rejection("Malformed Stripe refund object")
         from apps.billing.refund_service import (  # noqa: PLC0415
             RefundConvergenceService,
             RefundGatewayFacts,
@@ -477,7 +479,7 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
             error = result.unwrap_err()
             retriability = retriability_of(result)
             if retriability is Retriability.NOT_RETRIABLE:
-                return self._acknowledge_permanent_refund_rejection(error, retriability)
+                return self._acknowledge_permanent_rejection(error, retriability)
             if retriability is Retriability.UNKNOWN:
                 logger.critical(
                     "Stripe refund convergence violated its typed error contract; rejecting for safe replay: %s",
@@ -500,16 +502,16 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         """Converge the embedded refunds from the legacy charge event."""
         refund_collection = charge.get("refunds", {})
         if not isinstance(refund_collection, dict):
-            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge refunds")
+            return self._acknowledge_permanent_rejection("Malformed Stripe charge refunds")
         refund_list = refund_collection.get("data", [])
         if not isinstance(refund_list, list):
-            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge refunds")
+            return self._acknowledge_permanent_rejection("Malformed Stripe charge refunds")
         failures: list[str] = []
         for refund_object in refund_list:
             if not isinstance(refund_object, dict):
                 # Do NOT short-circuit: a bad sibling here would starve every later valid
                 # embedded refund. Alert and acknowledge it, then continue with valid siblings.
-                self._acknowledge_permanent_refund_rejection("Malformed embedded Stripe refund")
+                self._acknowledge_permanent_rejection("Malformed embedded Stripe refund")
                 continue
             normalized_refund = {
                 **refund_object,
@@ -600,7 +602,7 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         event_data = payload.get("data", {})
         charge = event_data.get("object", {}) if isinstance(event_data, dict) else None
         if not isinstance(charge, dict):
-            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge object")
+            return self._acknowledge_permanent_rejection("Malformed Stripe charge object")
         charge_id = charge.get("id")
         if event_type == "charge.refunded":
             result = self._handle_charge_refunded(event_type, payload, charge)

--- a/services/platform/apps/integrations/webhooks/stripe.py
+++ b/services/platform/apps/integrations/webhooks/stripe.py
@@ -13,6 +13,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from apps.billing.models import Payment
+from apps.common.types import Retriability, retriability_of
 from apps.customers.models import Customer
 from apps.integrations.models import WebhookEvent
 
@@ -384,32 +385,44 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
             customer_email = stripe_customer.get("email")
 
             if customer_email:
-                try:
-                    with transaction.atomic():
-                        customer = Customer.objects.select_for_update(of=("self",)).get(primary_email=customer_email)
-                        customer_meta = dict(customer.meta or {})
-                        existing_customer_id = customer_meta.get("stripe_customer_id")
+                with transaction.atomic():
+                    customers = list(
+                        Customer.objects.select_for_update(of=("self",))
+                        .filter(primary_email=customer_email)
+                        .order_by("id")[:2]
+                    )
+                    if not customers:
+                        logger.warning(f"⚠️ Customer not found for Stripe customer: {customer_email}")
+                        return True, f"Customer not found: {customer_email}"
+                    if len(customers) > 1:
+                        logger.critical(
+                            "🔥 [Stripe] Ambiguous customer.created email %s for Stripe customer %s; "
+                            "refusing to link an arbitrary PRAHO customer",
+                            customer_email,
+                            stripe_customer_id,
+                        )
+                        return True, f"Ambiguous customer email; not linked: {customer_email}"
 
-                        if existing_customer_id and stripe_customer_id and existing_customer_id != stripe_customer_id:
-                            logger.warning(
-                                "⚠️ [Stripe] Ignoring customer.created ID %s for %s; already linked to %s",
-                                stripe_customer_id,
-                                customer.id,
-                                existing_customer_id,
-                            )
-                        elif stripe_customer_id:
-                            customer_meta["stripe_customer_id"] = stripe_customer_id
+                    customer = customers[0]
+                    customer_meta = dict(customer.meta or {})
+                    existing_customer_id = customer_meta.get("stripe_customer_id")
 
-                        customer_meta["stripe_linked_at"] = timezone.now().isoformat()
-                        customer.meta = customer_meta
-                        customer.save(update_fields=["meta", "updated_at"])
+                    if existing_customer_id and stripe_customer_id and existing_customer_id != stripe_customer_id:
+                        logger.warning(
+                            "⚠️ [Stripe] Ignoring customer.created ID %s for %s; already linked to %s",
+                            stripe_customer_id,
+                            customer.id,
+                            existing_customer_id,
+                        )
+                    elif stripe_customer_id:
+                        customer_meta["stripe_customer_id"] = stripe_customer_id
 
-                    logger.info(f"🔗 Linked Stripe customer {stripe_customer_id} to {customer}")
-                    return True, f"Customer linked: {customer}"
+                    customer_meta["stripe_linked_at"] = timezone.now().isoformat()
+                    customer.meta = customer_meta
+                    customer.save(update_fields=["meta", "updated_at"])
 
-                except Customer.DoesNotExist:
-                    logger.warning(f"⚠️ Customer not found for Stripe customer: {customer_email}")
-                    return True, f"Customer not found: {customer_email}"
+                logger.info(f"🔗 Linked Stripe customer {stripe_customer_id} to {customer}")
+                return True, f"Customer linked: {customer}"
 
         return True, f"Skipped Customer event: {event_type}"
 
@@ -425,11 +438,24 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         """Normalize a Stripe integer while rejecting bool's int subtype."""
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
+    @staticmethod
+    def _acknowledge_permanent_refund_rejection(
+        message: str,
+        retriability: Retriability = Retriability.NOT_RETRIABLE,
+    ) -> tuple[bool, str]:
+        logger.critical(
+            "Stripe refund permanently rejected (%s); manual reconciliation required: %s",
+            retriability.value,
+            message,
+        )
+        return True, f"Permanent Stripe refund rejection acknowledged: {message}"
+
     def handle_refund_event(self, event_type: str, payload: dict[str, Any]) -> tuple[bool, str]:
         """Converge modern Stripe Refund events into PRAHO's ledger."""
-        refund_object = payload.get("data", {}).get("object", {})
+        event_data = payload.get("data", {})
+        refund_object = event_data.get("object", {}) if isinstance(event_data, dict) else None
         if not isinstance(refund_object, dict):
-            return False, "Malformed Stripe refund object"
+            return self._acknowledge_permanent_refund_rejection("Malformed Stripe refund object")
         from apps.billing.refund_service import (  # noqa: PLC0415
             RefundConvergenceService,
             RefundGatewayFacts,
@@ -449,7 +475,16 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         result = RefundConvergenceService.converge_gateway_refund(facts)
         if result.is_err():
             error = result.unwrap_err()
-            logger.critical("Stripe refund convergence rejected: %s", error)
+            retriability = retriability_of(result)
+            if retriability is Retriability.NOT_RETRIABLE:
+                return self._acknowledge_permanent_refund_rejection(error, retriability)
+            if retriability is Retriability.UNKNOWN:
+                logger.critical(
+                    "Stripe refund convergence violated its typed error contract; rejecting for safe replay: %s",
+                    error,
+                )
+            else:
+                logger.error("Stripe refund convergence failed retryably: %s", error)
             return False, error
         refund = result.unwrap()
         if refund is None:
@@ -463,17 +498,18 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         charge: dict[str, Any],
     ) -> tuple[bool, str]:
         """Converge the embedded refunds from the legacy charge event."""
-        refund_list = charge.get("refunds", {}).get("data", [])
+        refund_collection = charge.get("refunds", {})
+        if not isinstance(refund_collection, dict):
+            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge refunds")
+        refund_list = refund_collection.get("data", [])
         if not isinstance(refund_list, list):
-            return False, "Malformed Stripe charge refunds"
+            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge refunds")
         failures: list[str] = []
         for refund_object in refund_list:
             if not isinstance(refund_object, dict):
                 # Do NOT short-circuit: a bad sibling here would starve every later valid
-                # embedded refund, and each Stripe retry would stop at the same bad item.
-                # Record it and keep going — convergence is idempotent, so re-processing the
-                # already-converged siblings on the whole-event retry is safe.
-                failures.append("Malformed embedded Stripe refund")
+                # embedded refund. Alert and acknowledge it, then continue with valid siblings.
+                self._acknowledge_permanent_refund_rejection("Malformed embedded Stripe refund")
                 continue
             normalized_refund = {
                 **refund_object,
@@ -487,7 +523,7 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         if failures:
             converged_count = len(refund_list) - len(failures)
             return False, f"Charge refunds: {converged_count} converged, {len(failures)} failed: {'; '.join(failures)}"
-        return True, f"Charge refunds converged: {len(refund_list)}"
+        return True, f"Charge refunds handled: {len(refund_list)}"
 
     @staticmethod
     def _handle_charge_dispute(charge: dict[str, Any], charge_id: Any) -> tuple[bool, str]:
@@ -561,20 +597,25 @@ class StripeWebhookProcessor(BaseWebhookProcessor):
         if event_type == "charge.refund.updated":
             return self.handle_refund_event(event_type, payload)
 
-        charge = payload.get("data", {}).get("object", {})
+        event_data = payload.get("data", {})
+        charge = event_data.get("object", {}) if isinstance(event_data, dict) else None
+        if not isinstance(charge, dict):
+            return self._acknowledge_permanent_refund_rejection("Malformed Stripe charge object")
         charge_id = charge.get("id")
         if event_type == "charge.refunded":
-            return self._handle_charge_refunded(event_type, payload, charge)
-        if event_type == "charge.dispute.created":
-            return self._handle_charge_dispute(charge, charge_id)
-        if event_type == "charge.succeeded":
+            result = self._handle_charge_refunded(event_type, payload, charge)
+        elif event_type == "charge.dispute.created":
+            result = self._handle_charge_dispute(charge, charge_id)
+        elif event_type == "charge.succeeded":
             logger.info(f"✅ Stripe charge succeeded: {charge_id}")
-            return True, f"Charge succeeded: {charge_id}"
-        if event_type == "charge.failed":
+            result = (True, f"Charge succeeded: {charge_id}")
+        elif event_type == "charge.failed":
             failure_reason = charge.get("failure_message", "Unknown error")
             logger.warning(f"❌ Stripe charge failed: {charge_id} - {failure_reason}")
-            return True, f"Charge failed: {charge_id}"
-        return True, f"Skipped Charge event: {event_type}"
+            result = (True, f"Charge failed: {charge_id}")
+        else:
+            result = (True, f"Skipped Charge event: {event_type}")
+        return result
 
     def handle_setup_intent_event(self, event_type: str, payload: dict[str, Any]) -> tuple[bool, str]:
         """🔧 Handle SetupIntent events (for saved payment methods)"""

--- a/services/platform/tests/billing/test_refund_gateway_integrity.py
+++ b/services/platform/tests/billing/test_refund_gateway_integrity.py
@@ -8,12 +8,13 @@ from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, OperationalError, transaction
 from django.test import TestCase
 from django.utils import timezone
 
 from apps.billing.models import Currency, Invoice, Payment, ProformaInvoice, Refund, RefundStatusHistory
 from apps.billing.refund_service import Err, RefundData, RefundService
+from apps.common.types import Retriability
 from apps.customers.models import Customer
 from apps.orders.models import Order
 
@@ -535,7 +536,7 @@ class RefundGatewayIntegrityTests(TestCase):
         self.assertEqual(refund.metadata["gateway_event_id"], "evt_refund_newer")
         self.assertEqual(refund.metadata["gateway_event_created"], 200)
 
-    def test_refund_webhook_rejects_amount_mismatch_without_mutation(self) -> None:
+    def test_refund_webhook_acknowledges_amount_mismatch_without_mutation(self) -> None:
         invoice = self._make_invoice()
         payment = self._make_payment(invoice, transaction_id="pi_refund_mismatch")
         refund = Refund.objects.create(
@@ -562,10 +563,12 @@ class RefundGatewayIntegrityTests(TestCase):
         }
         from apps.integrations.webhooks.stripe import StripeWebhookProcessor  # noqa: PLC0415
 
-        accepted, message = StripeWebhookProcessor().handle_refund_event("refund.updated", payload)
+        with self.assertLogs("apps.integrations.webhooks.stripe", level="CRITICAL") as logs:
+            accepted, message = StripeWebhookProcessor().handle_refund_event("refund.updated", payload)
 
-        self.assertFalse(accepted)
+        self.assertTrue(accepted)
         self.assertIn("amount mismatch", message.lower())
+        self.assertIn("manual reconciliation required", logs.output[0])
         refund.refresh_from_db()
         payment.refresh_from_db()
         invoice.refresh_from_db()
@@ -1519,5 +1522,149 @@ class RefundConvergenceHardeningTests(TestCase):
 
         # Both valid siblings are processed even though the middle entry is malformed.
         self.assertEqual(seen, ["re_ok_1", "re_ok_2"])
+        self.assertTrue(accepted)
+        self.assertIn("handled", message)
+
+    def test_convergence_marks_validation_failure_not_retriable(self) -> None:
+        from apps.billing.refund_service import RefundConvergenceService  # noqa: PLC0415
+
+        result = RefundConvergenceService.converge_gateway_refund({})
+
+        self.assertIsInstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.NOT_RETRIABLE)
+
+    def test_convergence_marks_transactional_failure_retriable(self) -> None:
+        from apps.billing.refund_service import RefundConvergenceService  # noqa: PLC0415
+
+        with patch(
+            "apps.billing.refund_service.Payment.objects.select_for_update",
+            side_effect=OperationalError("deadlock detected"),
+        ):
+            result = RefundConvergenceService.converge_gateway_refund(
+                {
+                    "refund_id": "re_retryable_failure",
+                    "payment_intent_id": "pi_retryable_failure",
+                    "amount_cents": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            )
+
+        self.assertIsInstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_convergence_leaves_unexpected_failure_unclassified_for_safe_replay(self) -> None:
+        from apps.billing.refund_service import RefundConvergenceService  # noqa: PLC0415
+
+        with patch(
+            "apps.billing.refund_service.Payment.objects.select_for_update",
+            side_effect=RuntimeError("unexpected convergence failure"),
+        ):
+            result = RefundConvergenceService.converge_gateway_refund(
+                {
+                    "refund_id": "re_unknown_failure",
+                    "payment_intent_id": "pi_unknown_failure",
+                    "amount_cents": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            )
+
+        self.assertIsInstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+
+    def test_refund_webhook_rejects_retryable_convergence_failure(self) -> None:
+        from apps.integrations.webhooks.stripe import StripeWebhookProcessor  # noqa: PLC0415
+
+        payload = {
+            "id": "evt_retryable_failure",
+            "created": 1_700_000_000,
+            "data": {
+                "object": {
+                    "id": "re_retryable_failure",
+                    "payment_intent": "pi_retryable_failure",
+                    "amount": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            },
+        }
+        with patch(
+            "apps.billing.refund_service.RefundConvergenceService.converge_gateway_refund",
+            return_value=Err("deadlock detected", retriability=Retriability.RETRIABLE),
+        ):
+            accepted, message = StripeWebhookProcessor().handle_refund_event("refund.updated", payload)
+
         self.assertFalse(accepted)
-        self.assertIn("failed", message)
+        self.assertIn("deadlock", message)
+
+    def test_refund_webhook_acknowledges_malformed_object(self) -> None:
+        from apps.integrations.webhooks.stripe import StripeWebhookProcessor  # noqa: PLC0415
+
+        malformed_payloads: tuple[dict[str, Any], ...] = (
+            {"data": {"object": "not-a-refund"}},
+            {"data": "not-an-event-data-object"},
+        )
+        for payload in malformed_payloads:
+            with self.subTest(payload=payload), self.assertLogs(
+                "apps.integrations.webhooks.stripe", level="CRITICAL"
+            ) as logs:
+                accepted, message = StripeWebhookProcessor().handle_refund_event("refund.updated", payload)
+
+            self.assertTrue(accepted)
+            self.assertIn("permanent", message.lower())
+            self.assertIn("manual reconciliation required", logs.output[0])
+
+    def test_refund_webhook_rejects_unclassified_convergence_failure(self) -> None:
+        from apps.integrations.webhooks.stripe import StripeWebhookProcessor  # noqa: PLC0415
+
+        payload = {
+            "data": {
+                "object": {
+                    "id": "re_unknown_failure",
+                    "payment_intent": "pi_unknown_failure",
+                    "amount": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            }
+        }
+        with patch(
+            "apps.billing.refund_service.RefundConvergenceService.converge_gateway_refund",
+            return_value=Err("unclassified failure"),
+        ):
+            accepted, message = StripeWebhookProcessor().handle_refund_event("refund.updated", payload)
+
+        self.assertFalse(accepted)
+        self.assertIn("unclassified", message)
+
+    def test_concurrent_refund_transition_is_retriable(self) -> None:
+        from django_fsm import ConcurrentTransition  # noqa: PLC0415
+
+        invoice = self._make_invoice()
+        payment = self._make_payment(invoice, transaction_id="pi_concurrent_transition")
+        refund = Refund.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=1_000,
+            currency=self.currency,
+            original_amount_cents=10_000,
+            status="pending",
+            reference_number="REF-CONCURRENT-TRANSITION",
+        )
+        with patch.object(refund, "start_processing", side_effect=ConcurrentTransition("stale refund")):
+            result = RefundService._advance_refund_status(refund, "pending")
+
+        self.assertIsInstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)
+
+    def test_charge_refunded_acknowledges_malformed_charge_object(self) -> None:
+        from apps.integrations.webhooks.stripe import StripeWebhookProcessor  # noqa: PLC0415
+
+        with self.assertLogs("apps.integrations.webhooks.stripe", level="CRITICAL") as logs:
+            accepted, message = StripeWebhookProcessor().handle_charge_event("charge.refunded", {"data": "bad"})
+
+        self.assertTrue(accepted)
+        self.assertIn("permanent", message.lower())
+        self.assertIn("manual reconciliation required", logs.output[0])

--- a/services/platform/tests/billing/test_refund_gateway_integrity.py
+++ b/services/platform/tests/billing/test_refund_gateway_integrity.py
@@ -1668,3 +1668,85 @@ class RefundConvergenceHardeningTests(TestCase):
         self.assertTrue(accepted)
         self.assertIn("permanent", message.lower())
         self.assertIn("manual reconciliation required", logs.output[0])
+
+
+class RefundErrorMessageHygieneTests(TestCase):
+    """Err messages from refund convergence flow into webhook HTTP responses
+    (integrations/views.py), so raw exception text — DB internals included —
+    must stay in the logs, never in the returned message (review of #374)."""
+
+    def setUp(self) -> None:
+        self.currency, _ = Currency.objects.get_or_create(
+            code="RON",
+            defaults={"name": "Romanian Leu", "symbol": "lei", "decimals": 2},
+        )
+        self.customer = Customer.objects.create(
+            name="Message Hygiene SRL",
+            customer_type="company",
+            company_name="Message Hygiene SRL",
+            status="active",
+        )
+        invoice = Invoice.objects.create(
+            customer=self.customer,
+            currency=self.currency,
+            number=f"INV-{uuid.uuid4().hex[:10]}",
+            status="paid",
+            subtotal_cents=1_000,
+            tax_cents=0,
+            total_cents=1_000,
+            due_at=timezone.now() + timedelta(days=14),
+            bill_to_name=self.customer.company_name,
+        )
+        Payment.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            currency=self.currency,
+            status="succeeded",
+            payment_method="stripe",
+            amount_cents=1_000,
+            gateway_txn_id="pi_leak_check",
+        )
+
+    def test_transient_db_failure_message_carries_no_exception_detail(self) -> None:
+        from apps.billing.refund_service import RefundConvergenceService  # noqa: PLC0415
+
+        with patch.object(
+            RefundConvergenceService,
+            "_lock_related_order",
+            side_effect=OperationalError("connection reset by peer at 10.0.0.5:5432"),
+        ):
+            result = RefundConvergenceService.converge_gateway_refund(
+                {
+                    "refund_id": "re_leak_check",
+                    "payment_intent_id": "pi_leak_check",
+                    "amount_cents": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            )
+
+        self.assertTrue(result.is_err())
+        message = result.unwrap_err()
+        self.assertNotIn("10.0.0.5", message, "DB exception detail must not reach the webhook response")
+        self.assertNotIn("connection reset", message)
+
+    def test_unexpected_failure_message_carries_no_exception_detail(self) -> None:
+        from apps.billing.refund_service import RefundConvergenceService  # noqa: PLC0415
+
+        with patch.object(
+            RefundConvergenceService,
+            "_lock_related_order",
+            side_effect=RuntimeError("secret internal state: /etc/praho/key"),
+        ):
+            result = RefundConvergenceService.converge_gateway_refund(
+                {
+                    "refund_id": "re_leak_check_2",
+                    "payment_intent_id": "pi_leak_check",
+                    "amount_cents": 1_000,
+                    "currency": "ron",
+                    "status": "succeeded",
+                }
+            )
+
+        self.assertTrue(result.is_err())
+        self.assertNotIn("/etc/praho/key", result.unwrap_err())

--- a/services/platform/tests/integrations/test_webhook_regressions.py
+++ b/services/platform/tests/integrations/test_webhook_regressions.py
@@ -1,0 +1,151 @@
+"""Regression coverage for webhook authentication, retention, and identity handling."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+from django.utils import timezone
+
+from apps.customers.models import Customer
+from apps.integrations.models import WebhookEvent
+from apps.integrations.webhooks.base import verify_stripe_signature
+from apps.integrations.webhooks.stripe import StripeWebhookProcessor
+
+
+class StripeSignatureRotationTests(SimpleTestCase):
+    """Stripe signs once per active secret while a webhook secret is rotating."""
+
+    payload = b'{"id":"evt_rotation"}'
+    secret = "whsec_active"
+    now = datetime(2026, 7, 22, 10, 0, tzinfo=UTC)
+
+    def _signature(self, timestamp: int, secret: str | None = None) -> str:
+        signed_payload = f"{timestamp}.{self.payload.decode('utf-8')}".encode()
+        return hmac.new((secret or self.secret).encode(), signed_payload, hashlib.sha256).hexdigest()
+
+    def _verify(self, header: str, *, tolerance: int = 300) -> bool:
+        with patch("apps.integrations.webhooks.base.timezone.now", return_value=self.now):
+            return verify_stripe_signature(self.payload, header, self.secret, tolerance=tolerance)
+
+    def test_accepts_matching_signature_when_it_is_not_the_last_v1(self) -> None:
+        timestamp = int(self.now.timestamp())
+        valid = self._signature(timestamp)
+
+        self.assertTrue(self._verify(f"t={timestamp},v1={valid},v1=invalid"))
+
+    def test_accepts_matching_signature_when_it_is_the_last_v1(self) -> None:
+        timestamp = int(self.now.timestamp())
+        valid = self._signature(timestamp)
+
+        self.assertTrue(self._verify(f"t={timestamp},v1=invalid,v1={valid}"))
+
+    def test_rejects_header_when_no_v1_signature_matches(self) -> None:
+        timestamp = int(self.now.timestamp())
+
+        self.assertFalse(self._verify(f"t={timestamp},v1=invalid,v1=also-invalid"))
+
+    def test_accepts_timestamp_exactly_at_tolerance_boundary(self) -> None:
+        timestamp = int(self.now.timestamp()) - 300
+
+        self.assertTrue(self._verify(f"t={timestamp},v1={self._signature(timestamp)}"))
+
+    def test_rejects_timestamp_older_than_tolerance(self) -> None:
+        timestamp = int(self.now.timestamp()) - 301
+
+        self.assertFalse(self._verify(f"t={timestamp},v1={self._signature(timestamp)}"))
+
+
+class WebhookRetentionTests(TestCase):
+    def _event(
+        self,
+        event_id: str,
+        *,
+        status: str,
+        received_at: datetime,
+        processed_at: datetime | None = None,
+    ) -> WebhookEvent:
+        return WebhookEvent.objects.create(
+            source="stripe",
+            event_id=event_id,
+            event_type="test.event",
+            status=status,
+            payload={},
+            received_at=received_at,
+            processed_at=processed_at,
+        )
+
+    def test_cleanup_uses_received_at_only_when_terminal_processed_at_is_null(self) -> None:
+        old = timezone.now() - timedelta(days=31)
+        recent = timezone.now() - timedelta(days=29)
+        old_processed = self._event("evt_processed", status="processed", received_at=old, processed_at=old)
+        old_null_processed = self._event("evt_anaf", status="processed", received_at=old)
+        old_null_skipped = self._event("evt_rate_limit", status="skipped", received_at=old)
+        recent_null_skipped = self._event("evt_recent", status="skipped", received_at=recent)
+        old_failed = self._event("evt_failed", status="failed", received_at=old)
+
+        call_command("process_webhooks", "--cleanup", stdout=StringIO())
+
+        self.assertFalse(WebhookEvent.objects.filter(pk=old_processed.pk).exists())
+        self.assertFalse(WebhookEvent.objects.filter(pk=old_null_processed.pk).exists())
+        self.assertFalse(WebhookEvent.objects.filter(pk=old_null_skipped.pk).exists())
+        self.assertTrue(WebhookEvent.objects.filter(pk=recent_null_skipped.pk).exists())
+        self.assertTrue(WebhookEvent.objects.filter(pk=old_failed.pk).exists())
+
+    def test_stats_uses_the_same_terminal_retention_boundary_as_cleanup(self) -> None:
+        old = timezone.now() - timedelta(days=31)
+        self._event("evt_old_null", status="processed", received_at=old)
+        output = StringIO()
+
+        call_command("process_webhooks", "--stats", stdout=output)
+
+        self.assertIn("1 old webhook records can be cleaned up", output.getvalue())
+
+
+class StripeCustomerIdentityTests(TestCase):
+    def setUp(self) -> None:
+        self.processor = StripeWebhookProcessor()
+
+    @staticmethod
+    def _customer(name: str, email: str) -> Customer:
+        return Customer.objects.create(
+            name=name,
+            customer_type="company",
+            status="active",
+            primary_email=email,
+        )
+
+    @staticmethod
+    def _payload(email: str) -> dict[str, object]:
+        return {"data": {"object": {"id": "cus_shared", "email": email}}}
+
+    def test_customer_created_links_a_unique_email_match(self) -> None:
+        customer = self._customer("Unique SRL", "unique@example.com")
+
+        accepted, message = self.processor.handle_customer_event(
+            "customer.created", self._payload(customer.primary_email)
+        )
+
+        self.assertTrue(accepted, message)
+        customer.refresh_from_db()
+        self.assertEqual(customer.meta["stripe_customer_id"], "cus_shared")
+
+    def test_customer_created_acknowledges_ambiguous_email_without_linking_either_customer(self) -> None:
+        first = self._customer("First SRL", "shared@example.com")
+        second = self._customer("Second SRL", "shared@example.com")
+
+        accepted, message = self.processor.handle_customer_event(
+            "customer.created", self._payload("shared@example.com")
+        )
+
+        self.assertTrue(accepted, message)
+        self.assertIn("ambiguous", message.lower())
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertNotIn("stripe_customer_id", first.meta)
+        self.assertNotIn("stripe_customer_id", second.meta)

--- a/services/platform/tests/integrations/test_webhook_regressions.py
+++ b/services/platform/tests/integrations/test_webhook_regressions.py
@@ -149,3 +149,20 @@ class StripeCustomerIdentityTests(TestCase):
         second.refresh_from_db()
         self.assertNotIn("stripe_customer_id", first.meta)
         self.assertNotIn("stripe_customer_id", second.meta)
+
+
+class PermanentRejectionWordingTests(TestCase):
+    """The permanent-rejection acknowledgement is used for charge and generic
+    payload malformations too — its alert/response wording must be
+    event-agnostic, not claim a 'refund rejection' (review of #374)."""
+
+    def test_malformed_charge_acknowledgement_is_event_agnostic(self) -> None:
+        processor = StripeWebhookProcessor()
+
+        success, message = processor.handle_refund_event(
+            "refund.updated", {"data": {"object": "not-a-dict"}}
+        )
+
+        self.assertTrue(success, "a permanently malformed payload is acknowledged, not retried")
+        self.assertNotIn("refund rejection", message.lower())
+        self.assertIn("Malformed", message)


### PR DESCRIPTION
## Summary

- accept any matching Stripe v1 signature during webhook-secret rotation while preserving the documented timestamp tolerance behavior
- clean old terminal webhook rows even when legacy or skipped events have no processed timestamp, and make cleanup statistics use the same rule
- fail safely when customer.created matches multiple PRAHO customers instead of linking an arbitrary duplicate email
- give refund convergence a typed permanent, retryable, or unknown error contract so permanent validation failures are acknowledged and alerted while transient or unclassified failures remain replayable
- harden modern and legacy refund payload handling so malformed data cannot starve valid sibling refunds or trigger indefinite Stripe retries

## Root cause and impact

Signature parsing retained only the final v1 value, terminal-row retention relied exclusively on processed_at, and customer linking assumed email uniqueness that the model does not enforce. Refund convergence returned unclassified errors, so the webhook layer rejected deterministic validation failures and Stripe retried them for days.

Permanent refund validation failures now emit a critical manual-reconciliation alert and acknowledge the webhook. Proven transient failures and unknown contract violations continue to reject delivery for safe replay. PRAHO refund ledger writes remain transactional and idempotent.

## Verification

- make test-file with 313 refund, webhook, signature, retention, identity, and redelivery regression tests
- make lint
- make test with all platform, portal, integration, cache, and security-isolation phases successful; platform discovered 7,421 tests
- pre-commit hooks passed
- rebased onto master at 77af719d, including the merged #355 webhook-redelivery fix

## Migration notes

No database migration or historical backfill is required.

Closes #235
Closes #343