### PR TITLE
fix(billing): make refund commands durable and unify projection

### DIFF
--- a/docs/domain/REFUND_SERVICE.md
+++ b/docs/domain/REFUND_SERVICE.md
@@ -10,9 +10,11 @@ funds have settled.
 
 ## 🚨 Critical Safety Features
 
-- **Atomic Transactions**: All refund operations use `@transaction.atomic` to prevent partial refunds
+- **Durable Commands**: PRAHO commits a Refund intent before calling Stripe, then settles local state in a separate atomic phase
 - **Canonical Lock Order**: Refund paths lock Payment → Invoice → Order → Refund to avoid cross-flow deadlocks
 - **Double Refund Prevention**: Pending and settled refund reservations both reduce the available refundable amount
+- **Stable Gateway Idempotency**: Stripe keys use `refund:{refund_uuid}`, never mutable payment-ledger totals
+- **Fail-Closed Gateway Boundary**: Gateway refunds without a durable Refund intent are rejected
 - **Amount Validation**: Ensures refund amounts don't exceed available amounts
 - **Gateway Convergence**: Stripe webhooks and the scheduled sweep share one idempotent convergence service
 - **Gateway Identity Integrity**: A non-empty gateway refund ID is unique in the PRAHO ledger
@@ -74,6 +76,10 @@ The only service allowed to project Stripe refund facts into PRAHO:
 - ignores stale gateway events using an event-time watermark
 - treats duplicate webhook delivery and scheduled discovery as idempotent
 - projects only completed refund totals onto Payment and Invoice
+
+`RefundService._project_settled_refunds()` is the sole owner of coarse Payment
+and Invoice refund-state projection. The Payment `post_save` signal sends
+notifications only; it never derives Invoice status from Payment rows.
 
 Stripe `refund.created`, `refund.updated`, `refund.failed`,
 `charge.refund.updated`, and legacy `charge.refunded` events route through
@@ -187,10 +193,10 @@ Refund status is tracked on Invoice (not Order). The table below reflects Invoic
 When refunding an **order**:
 1. Resolve the authoritative Payment and its invoice/proforma linkage
 2. Lock Payment, then Invoice, then Order
-3. Reserve the amount against pending and settled refunds
-4. Submit the exact cent amount and currency to the gateway with an idempotency key
-5. Create a Refund ledger row with the gateway refund ID
-6. Project Payment and Invoice status only when the gateway status is `succeeded`
+3. Create and commit a pending Refund row that reserves the exact amount
+4. Submit that command to the gateway with `refund:{refund_uuid}` as its idempotency key
+5. Atomically attach the gateway refund ID and advance the Refund FSM
+6. Project Payment and Invoice status from completed Refund rows only
 
 When refunding an **invoice**:
 1. Resolve and lock its authoritative Payment before the Invoice
@@ -200,7 +206,12 @@ Gateway `pending` and `requires_action` results remain non-terminal and do
 not reduce the settled Payment or Invoice balance. Gateway `failed`,
 `canceled`, and locally rejected refunds release the reservation. A later
 webhook or reconciliation sweep can advance the same Refund without creating a
-second ledger entry.
+second ledger entry. If PRAHO loses the gateway response or rolls back local
+settlement, the committed blank-ID intent remains reserved. A retry reuses its
+UUID and Stripe key; gateway discovery attaches matching facts to that same row.
+Ambiguous matches fail closed for manual reconciliation. PRAHO also refuses to
+resubmit an unknown outcome after 23 hours, before Stripe may prune the
+idempotency record; reconciliation must establish its gateway state first.
 
 ## Error Handling
 

--- a/services/platform/apps/billing/gateways/stripe_gateway.py
+++ b/services/platform/apps/billing/gateways/stripe_gateway.py
@@ -419,8 +419,8 @@ class StripeGateway(BasePaymentGateway):
                 params["amount"] = amount_cents
             if idempotency_key:
                 # A retry after an uncertain outcome (timeout) must replay the SAME refund,
-                # not create a second one — the key is derived from the payment's ledger
-                # state, so it is stable across retries of the same logical refund.
+                # not create a second one. RefundService derives this from the committed
+                # PRAHO Refund UUID, independent of later ledger changes.
                 params["idempotency_key"] = idempotency_key
 
             refund = self._stripe.Refund.create(**params)

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -283,7 +283,23 @@ class RefundService:
 
             with transaction.atomic(durable=True):
                 payment = Payment.objects.select_for_update(of=("self",)).get(pk=snapshot.payment_id)
-                invoice_id = payment.invoice_id or snapshot.invoice_id
+                # An order refund settles the ORDER-linked invoice (mirroring
+                # _lock_related_invoice_for_refund). A payment matched via
+                # meta["order_id"] can legally carry a DIFFERENT invoice_id —
+                # refunding then has no unambiguous document to project, so the
+                # command fails closed to manual reconciliation instead of
+                # marking an arbitrary invoice refunded (review of #388). The
+                # unlocked read keeps the canonical Payment → Invoice → Order
+                # lock order; the order is re-locked and re-read below.
+                if snapshot.order_id is not None:
+                    invoice_id = Order.objects.filter(pk=snapshot.order_id).values_list("invoice_id", flat=True).first()
+                    if payment.invoice_id is not None and payment.invoice_id != invoice_id:
+                        return Err(
+                            "Failed to process refund: payment and order invoice linkage mismatch; "
+                            "manual reconciliation required"
+                        )
+                else:
+                    invoice_id = snapshot.invoice_id or payment.invoice_id
                 invoice = (
                     Invoice.objects.select_for_update(of=("self",)).get(pk=invoice_id)
                     if invoice_id is not None

--- a/services/platform/apps/billing/refund_service.py
+++ b/services/platform/apps/billing/refund_service.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import enum
 import logging
 import uuid
+from datetime import timedelta
 from decimal import Decimal
 from typing import Any, TypedDict
 
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 _FALLBACK_ORDER_TOTAL_CENTS = 15_000  # 150 EUR — safe fallback for missing order total
 _FALLBACK_INVOICE_TOTAL_CENTS = 11_900  # 119 EUR — safe fallback for missing invoice total
 _REFUND_RESERVING_STATUSES = ("pending", "processing", "approved", "completed")
+_REFUND_IDEMPOTENCY_RETRY_WINDOW = timedelta(hours=23)
 
 
 class RefundType(enum.Enum):
@@ -56,7 +58,7 @@ class RefundData(TypedDict, total=False):
     amount: int  # Legacy field support
     reason: str
     reference: str
-    refund_type: str
+    refund_type: RefundType | str
     notes: str
     user_id: str
     user_email: str
@@ -78,7 +80,7 @@ class RefundResult(TypedDict, total=False):
     amount_refunded_cents: int
     success: bool
     refund_type: RefundType | str
-    order_id: int | None
+    order_id: uuid.UUID | None
     invoice_id: int | None
     order_status_updated: bool
     invoice_status_updated: bool
@@ -140,9 +142,11 @@ class RefundService:
         try:
             # Normalize refund data
             RefundService._normalize_refund_data(refund_data)
+            requested_refund_type = refund_data.get("refund_type", RefundType.FULL)
 
-            # Execute entire refund process within atomic block to prevent race conditions
-            with transaction.atomic():
+            # The Refund row is the durable gateway command. This block must commit
+            # before Stripe is called so a response-loss retry can reuse its UUID.
+            with transaction.atomic(durable=True):
                 # Read the payment relation before acquiring any document lock.
                 try:
                     order_snapshot = Order.objects.select_related("customer").get(id=order_id)
@@ -160,7 +164,6 @@ class RefundService:
                 invoice_result = RefundService._lock_related_invoice_for_refund(order_snapshot, None)
                 if invoice_result.is_err():
                     return Err(f"Failed to process refund: {invoice_result.unwrap_err()}")
-                processing_invoice = invoice_result.unwrap()
 
                 order = Order.objects.select_for_update(of=("self",)).select_related("customer").get(id=order_id)
                 if (
@@ -170,24 +173,33 @@ class RefundService:
                 ):
                     return Err("Failed to process refund: Order payment linkage changed; retry refund")
 
-                # Validate eligibility INSIDE the atomic block with lock held
-                validation_result = RefundService._validate_order_refund(order, refund_data)
-                if validation_result.is_err():
-                    return Err(validation_result.unwrap_err())
-
-                # Process refund (already inside atomic block)
-                return RefundService._execute_order_refund_internal(
-                    order,
-                    refund_data,
-                    payment=payment,
-                    processing_invoice=processing_invoice,
+                matching_intent = RefundService._find_matching_active_intent(
+                    payment,
+                    order=order,
+                    invoice=None,
+                    refund_data=refund_data,
                 )
+                if matching_intent.is_err():
+                    return Err(matching_intent.unwrap_err())
+                intent = matching_intent.unwrap()
+                if intent is None:
+                    validation_result = RefundService._validate_order_refund(order, refund_data)
+                    if validation_result.is_err():
+                        return Err(validation_result.unwrap_err())
+                    reservation = RefundService._create_refund_intent(
+                        order=order,
+                        invoice=None,
+                        payment=payment,
+                        refund_data=refund_data,
+                    )
+                    if reservation.is_err():
+                        return Err(f"Failed to process refund: {reservation.unwrap_err()}")
+                    intent = reservation.unwrap()
+                refund_id = intent.id
+
+            return RefundService._submit_reserved_refund(refund_id, requested_refund_type)
 
         except Exception:
-            # Deliberately NOT RETRIABLE (UNKNOWN default): the refund flow is
-            # gateway-first (it calls the external gateway to refund the customer
-            # BEFORE the local DB writes), so a transient DB error here may occur
-            # AFTER the customer was already refunded. Replaying would double-refund.
             logger.exception("Order refund processing failed for order_id=%s", order_id)
             return Err("Failed to process refund: internal error")
 
@@ -196,6 +208,159 @@ class RefundService:
         """Normalize refund data by handling missing amount_cents"""
         if "amount_cents" not in refund_data and "amount" in refund_data:
             refund_data["amount_cents"] = refund_data["amount"]
+
+    @staticmethod
+    def _find_matching_active_intent(
+        payment: Payment,
+        *,
+        order: Order | None,
+        invoice: Invoice | None,
+        refund_data: RefundData,
+    ) -> Result[Refund | None, str]:
+        """Find the one in-flight command that represents a repeated request."""
+        raw_refund_type = refund_data.get("refund_type", "full")
+        refund_type = raw_refund_type.value if isinstance(raw_refund_type, RefundType) else str(raw_refund_type)
+        candidates = Refund.objects.select_for_update(of=("self",)).filter(
+            payment=payment,
+            order=order,
+            invoice=invoice,
+            gateway_refund_id="",
+            status__in=("pending", "processing", "approved"),
+            refund_type=refund_type,
+        )
+        if refund_type == "partial":
+            requested_amount = refund_data.get("amount_cents", refund_data.get("amount"))
+            if isinstance(requested_amount, bool) or not isinstance(requested_amount, int):
+                return Ok(None)
+            candidates = candidates.filter(amount_cents=requested_amount)
+        matches = list(candidates.order_by("created_at")[:2])
+        if len(matches) > 1:
+            return Err("Multiple matching refund intents are in progress; manual reconciliation required")
+        return Ok(matches[0] if matches else None)
+
+    @staticmethod
+    def _create_refund_intent(
+        *,
+        order: Order | None,
+        invoice: Invoice | None,
+        payment: Payment,
+        refund_data: RefundData,
+    ) -> Result[Refund, str]:
+        """Reserve one exact amount before making the external gateway request."""
+        amount_result = RefundService._resolve_effective_refund_amount(payment, refund_data, None)
+        if amount_result.is_err():
+            return Err(amount_result.unwrap_err())
+        amount_cents = amount_result.unwrap()
+        effective_data = refund_data.copy()
+        effective_data["amount_cents"] = amount_cents
+        raw_refund_type = effective_data.get("refund_type", "full")
+        effective_data["refund_type"] = (
+            raw_refund_type.value if isinstance(raw_refund_type, RefundType) else str(raw_refund_type)
+        )
+        return RefundService._create_refund_record(
+            RefundRecordParams(
+                refund_id=uuid.uuid4(),
+                order=order,
+                invoice=invoice,
+                refund_amount_cents=amount_cents,
+                original_cents=RefundService._calculate_original_amount(order, invoice, amount_cents),
+                refund_data=effective_data,
+                payment=payment,
+                gateway_refund_id="",
+            )
+        )
+
+    @staticmethod
+    def _submit_reserved_refund(  # noqa: PLR0911
+        refund_id: uuid.UUID,
+        requested_refund_type: RefundType | str,
+    ) -> Result[RefundResult, str]:
+        """Submit and settle one committed Refund intent using canonical lock order."""
+        try:
+            snapshot = Refund.objects.only("payment_id", "invoice_id", "order_id").filter(pk=refund_id).first()
+            if snapshot is None or snapshot.payment_id is None:
+                return Err("Failed to process refund: Refund intent or payment linkage not found")
+
+            with transaction.atomic(durable=True):
+                payment = Payment.objects.select_for_update(of=("self",)).get(pk=snapshot.payment_id)
+                invoice_id = payment.invoice_id or snapshot.invoice_id
+                invoice = (
+                    Invoice.objects.select_for_update(of=("self",)).get(pk=invoice_id)
+                    if invoice_id is not None
+                    else None
+                )
+                order = (
+                    Order.objects.select_for_update(of=("self",)).get(pk=snapshot.order_id)
+                    if snapshot.order_id is not None
+                    else None
+                )
+                refund = Refund.objects.select_for_update(of=("self",)).get(pk=refund_id)
+                if refund.payment_id != payment.id:
+                    return Err("Failed to process refund: Refund payment linkage changed")
+
+                refund_data = RefundData(
+                    refund_type=requested_refund_type,
+                    amount_cents=refund.amount_cents,
+                    reason=refund.reason,
+                    notes=refund.reason_description,
+                )
+                if refund.gateway_refund_id:
+                    return RefundService._build_reserved_refund_result(
+                        refund, order, invoice, False, requested_refund_type
+                    )
+                if refund.created_at <= timezone.now() - _REFUND_IDEMPOTENCY_RETRY_WINDOW:
+                    return Err("Refund outcome is stale and requires manual reconciliation before retry")
+                if refund.status not in {"pending", "processing", "approved"}:
+                    return Err(f"Gateway refund ended in terminal '{refund.status}' status")
+
+                if order is not None:
+                    return RefundService._execute_order_refund_internal(
+                        order,
+                        refund_data,
+                        payment=payment,
+                        processing_invoice=invoice,
+                        refund_id=refund.id,
+                        reserved_refund=refund,
+                    )
+                if invoice is None:
+                    return Err("Failed to process refund: Refund intent has no financial document")
+                return RefundService._execute_invoice_refund_internal(
+                    invoice,
+                    refund_data,
+                    payment=payment,
+                    refund_id=refund.id,
+                    reserved_refund=refund,
+                )
+        except Exception:
+            logger.exception("Reserved refund submission failed for refund_id=%s", refund_id)
+            return Err("Failed to process refund: internal error")
+
+    @staticmethod
+    def _build_reserved_refund_result(
+        refund: Refund,
+        order: Order | None,
+        invoice: Invoice | None,
+        invoice_status_updated: bool,
+        requested_refund_type: RefundType | str,
+    ) -> Result[RefundResult, str]:
+        """Return the public result contract for a durable Refund command."""
+        if refund.status in {"failed", "cancelled", "rejected"}:
+            return Err(f"Gateway refund ended in terminal '{refund.status}' status")
+        return Ok(
+            RefundResult(
+                success=True,
+                refund_id=str(refund.id),
+                amount_refunded_cents=refund.amount_cents,
+                refund_type=requested_refund_type,
+                order_id=order.id if order else None,
+                invoice_id=invoice.id if invoice else None,
+                order_status_updated=False,
+                invoice_status_updated=invoice_status_updated,
+                payment_refund_processed=refund.status == "completed",
+                refund_status=str(refund.status),
+                audit_entries_created=1,
+            )
+        )
 
     @staticmethod
     def _get_order(order_id: Any) -> Result[Any, str]:
@@ -211,9 +376,8 @@ class RefundService:
         except Order.DoesNotExist:
             return Err("Failed to process refund: Order not found")
         except (OperationalError, InterfaceError):
-            # Left UNKNOWN, not RETRIABLE: this helper feeds the gateway-first refund
-            # flow, which is non-idempotent — asserting "safe to replay" anywhere in
-            # that path risks a double customer refund. Fail closed (do not retry).
+            # This low-level helper cannot tell whether a caller has committed a
+            # durable Refund command, so it must not independently retry.
             logger.exception("Order lookup for refund hit a transient DB error for order_id=%s", order_id)
             return Err("Failed to process refund: database error")
         except Exception:
@@ -269,12 +433,14 @@ class RefundService:
             return RefundService._execute_order_refund_internal(order, refund_data)
 
     @staticmethod
-    def _execute_order_refund_internal(
+    def _execute_order_refund_internal(  # noqa: PLR0913  # Locked entities plus durable command context
         order: Any,
         refund_data: RefundData,
         *,
         payment: Payment | None = None,
         processing_invoice: Invoice | None = None,
+        refund_id: uuid.UUID | None = None,
+        reserved_refund: Refund | None = None,
     ) -> Result[RefundResult, str]:
         """Execute the order refund - must be called within an existing atomic block.
 
@@ -282,7 +448,7 @@ class RefundService:
         to wrap both validation and execution in a single atomic block with
         select_for_update to prevent race conditions.
         """
-        refund_id = uuid.uuid4()
+        refund_id = refund_id or uuid.uuid4()
         process_result = RefundService._process_bidirectional_refund(
             order=order,
             invoice=None,
@@ -290,6 +456,7 @@ class RefundService:
             refund_data=refund_data,
             locked_payment=payment,
             locked_invoice=processing_invoice,
+            reserved_refund=reserved_refund,
         )
 
         if process_result.is_err():
@@ -354,9 +521,10 @@ class RefundService:
         try:
             # Normalize refund data
             RefundService._normalize_refund_data(refund_data)
+            requested_refund_type = refund_data.get("refund_type", RefundType.FULL)
 
-            # Execute entire refund process within atomic block to prevent race conditions
-            with transaction.atomic():
+            # Commit the Refund command before crossing the gateway boundary.
+            with transaction.atomic(durable=True):
                 # Discover and lock the authoritative Payment before Invoice.
                 try:
                     invoice_snapshot = Invoice.objects.select_related("customer").get(id=invoice_id)
@@ -377,17 +545,33 @@ class RefundService:
                 if invoice.customer_id != invoice_snapshot.customer_id:
                     return Err("Failed to process refund: Invoice payment linkage changed; retry refund")
 
-                # Validate eligibility INSIDE the atomic block with lock held
-                validation_result = RefundService._validate_invoice_refund(invoice, refund_data)
-                if validation_result.is_err():
-                    return Err(validation_result.unwrap_err())
+                matching_intent = RefundService._find_matching_active_intent(
+                    payment,
+                    order=None,
+                    invoice=invoice,
+                    refund_data=refund_data,
+                )
+                if matching_intent.is_err():
+                    return Err(matching_intent.unwrap_err())
+                intent = matching_intent.unwrap()
+                if intent is None:
+                    validation_result = RefundService._validate_invoice_refund(invoice, refund_data)
+                    if validation_result.is_err():
+                        return Err(validation_result.unwrap_err())
+                    reservation = RefundService._create_refund_intent(
+                        order=None,
+                        invoice=invoice,
+                        payment=payment,
+                        refund_data=refund_data,
+                    )
+                    if reservation.is_err():
+                        return Err(f"Failed to process refund: {reservation.unwrap_err()}")
+                    intent = reservation.unwrap()
+                refund_id = intent.id
 
-                # Process refund (already inside atomic block)
-                return RefundService._execute_invoice_refund_internal(invoice, refund_data, payment=payment)
+            return RefundService._submit_reserved_refund(refund_id, requested_refund_type)
 
         except Exception:
-            # NOT RETRIABLE (UNKNOWN): gateway-first refund — a DB error may follow a
-            # completed external refund, so a replay could double-refund the customer.
             logger.exception("Invoice refund processing failed for invoice_id=%s", invoice_id)
             return Err("Failed to process refund: internal error")
 
@@ -405,8 +589,8 @@ class RefundService:
         except Invoice.DoesNotExist:
             return Err("Failed to process refund: Invoice not found")
         except (OperationalError, InterfaceError):
-            # Left UNKNOWN, not RETRIABLE: the gateway-first refund flow is
-            # non-idempotent, so a retry could double-refund. Fail closed.
+            # This low-level helper cannot tell whether a caller has committed a
+            # durable Refund command, so it must not independently retry.
             logger.exception("Invoice lookup for refund hit a transient DB error for invoice_id=%s", invoice_id)
             return Err("Failed to process refund: database error")
         except Exception:
@@ -459,6 +643,8 @@ class RefundService:
         refund_data: RefundData,
         *,
         payment: Payment | None = None,
+        refund_id: uuid.UUID | None = None,
+        reserved_refund: Refund | None = None,
     ) -> Result[RefundResult, str]:
         """Execute the invoice refund - must be called within an existing atomic block.
 
@@ -466,7 +652,7 @@ class RefundService:
         to wrap both validation and execution in a single atomic block with
         select_for_update to prevent race conditions.
         """
-        refund_id = uuid.uuid4()
+        refund_id = refund_id or uuid.uuid4()
         process_result = RefundService._process_bidirectional_refund(
             order=None,
             invoice=invoice,
@@ -474,6 +660,7 @@ class RefundService:
             refund_data=refund_data,
             locked_payment=payment,
             locked_invoice=invoice if payment else None,
+            reserved_refund=reserved_refund,
         )
 
         if process_result.is_err():
@@ -808,13 +995,22 @@ class RefundService:
         refund_data: RefundData | None = None,
         locked_payment: Payment | None = None,
         locked_invoice: Invoice | None = None,
+        reserved_refund: Refund | None = None,
         **kwargs: Any,
     ) -> Result[dict[str, Any], str]:
         """Process bidirectional refund for order and/or invoice"""
         try:
             # Normalize refund data
-            refund_amount_cents = RefundService._extract_refund_amount(refund_data, kwargs)
-            original_cents = RefundService._calculate_original_amount(order, invoice, refund_amount_cents)
+            refund_amount_cents = (
+                reserved_refund.amount_cents
+                if reserved_refund is not None
+                else RefundService._extract_refund_amount(refund_data, kwargs)
+            )
+            original_cents = (
+                reserved_refund.original_amount_cents
+                if reserved_refund is not None
+                else RefundService._calculate_original_amount(order, invoice, refund_amount_cents)
+            )
 
             # Resolve Payment before acquiring Invoice so refund initiation and
             # payment convergence share one canonical lock order.
@@ -826,13 +1022,10 @@ class RefundService:
                     return Err(payment_lookup.unwrap_err())
                 payment = payment_lookup.unwrap()
 
-            # Contract: every Err exit below marks the caller's transaction for
-            # rollback. Pre-gateway exits have no pending writes (no-op); the
-            # post-gateway exits MUST NOT commit — the payment status update
-            # cascades the invoice to refunded via post_save signal BEFORE the
-            # Refund row exists, and a plain return Err would commit that
-            # half-written state (#319 convention). The gateway idempotency key
-            # makes the rolled-back attempt safe to retry.
+            # Contract: every Err exit below rolls back this settlement phase.
+            # The Refund intent was committed in the earlier reservation phase,
+            # so it survives with a stable UUID while gateway ID, FSM history,
+            # Payment, and Invoice projection remain all-or-nothing here.
             invoice_result = (
                 Ok(locked_invoice)
                 if locked_invoice is not None
@@ -843,13 +1036,13 @@ class RefundService:
                 return Err(invoice_result.unwrap_err())
             invoice_for_processing = invoice_result.unwrap()
 
-            # Resolve and refund the authoritative payment before any durable
-            # Refund or Invoice mutation. This helper also locks the Payment row.
+            # Submit the already-durable command before settlement mutations.
             payment_result = RefundService._process_payment_refund_if_exists(
                 order,
                 invoice_for_processing,
                 refund_data,
                 payment=payment,
+                refund_intent_id=reserved_refund.id if reserved_refund is not None else refund_id,
             )
             if payment_result.is_err():
                 transaction.set_rollback(True)
@@ -867,33 +1060,35 @@ class RefundService:
             effective_refund_data = refund_data.copy() if refund_data else RefundData()
             effective_refund_data["amount_cents"] = refund_amount_cents
 
-            # Create the local audit record only after the monetary operation
-            # succeeds. Refund already has the required linkage fields, so no
-            # schema change is needed.
-            refund_result = RefundService._create_refund_record(
-                RefundRecordParams(
-                    refund_id=refund_id,
-                    order=order,
-                    # Deliberately the ORIGINAL invoice param (None on the order path): the
-                    # refund_order_or_invoice_not_both DB constraint enforces exactly one
-                    # document FK, so an order refund is order-linked BY SCHEMA even though
-                    # the resolved invoice's state is updated alongside.
-                    invoice=invoice,
-                    refund_amount_cents=refund_amount_cents,
-                    original_cents=original_cents,
-                    refund_data=effective_refund_data,
-                    payment=payment,
-                    gateway_refund_id=gateway_refund_id,
+            if reserved_refund is None:
+                refund_result = RefundService._create_refund_record(
+                    RefundRecordParams(
+                        refund_id=refund_id,
+                        order=order,
+                        # Deliberately the ORIGINAL invoice param (None on the order path): the
+                        # refund_order_or_invoice_not_both DB constraint enforces exactly one
+                        # document FK, so an order refund is order-linked BY SCHEMA even though
+                        # the resolved invoice's state is updated alongside.
+                        invoice=invoice,
+                        refund_amount_cents=refund_amount_cents,
+                        original_cents=original_cents,
+                        refund_data=effective_refund_data,
+                        payment=payment,
+                        gateway_refund_id=gateway_refund_id,
+                    )
                 )
-            )
-            if refund_result.is_err():
-                transaction.set_rollback(True)
-                # The public refund path is gateway-first. Deliberately discard
-                # the helper's local-write retriability: replaying the whole
-                # customer refund is not proven safe after money moved.
-                return Err(refund_result.unwrap_err())
-
-            refund = refund_result.unwrap()
+                if refund_result.is_err():
+                    transaction.set_rollback(True)
+                    # The public refund path is gateway-first. Deliberately discard
+                    # the helper's local-write retriability: replaying the whole
+                    # customer refund is not proven safe after money moved.
+                    return Err(refund_result.unwrap_err())
+                refund = refund_result.unwrap()
+            else:
+                refund = reserved_refund
+                refund.amount_cents = refund_amount_cents
+                refund.gateway_refund_id = gateway_refund_id
+                refund.save(update_fields=["amount_cents", "gateway_refund_id", "updated_at"])
             status_result = RefundService._advance_refund_status(
                 refund,
                 str(payment_data.get("gateway_status") or "succeeded"),
@@ -1018,9 +1213,8 @@ class RefundService:
             )
 
             # Create status history (ADR-0016: audit trail must not be silently dropped).
-            # The savepoint is what makes this catch real: a failed statement inside the
-            # outer atomic marks the connection needs_rollback, and without the savepoint
-            # the whole refund's local evidence would roll back AFTER gateway money moved.
+            # The savepoint keeps a caught history-write error from poisoning the caller's
+            # transaction; this helper serves both pre-gateway intents and convergence.
             try:
                 with transaction.atomic():
                     RefundStatusHistory.objects.create(
@@ -1262,71 +1456,13 @@ class RefundService:
             return Err("Refund settlement projection failed")
 
     @staticmethod
-    def _process_entity_updates(
-        order: Any, invoice: Any, refund_id: Any, refund_data: RefundData | None
-    ) -> Result[dict[str, Any], str]:
-        """Process order and invoice updates"""
-        result = {
-            "refund_id": refund_id,
-            "order_status_updated": False,
-            "invoice_status_updated": False,
-            "order_id": None,
-            "invoice_id": None,
-            "refund_record_created": True,
-        }
-
-        # Process order updates
-        if order:
-            order_result = RefundService._update_order_refund_status(order, refund_data=refund_data)
-            if order_result.is_err():
-                logger.warning(
-                    "⚠️ [Refund] Order refund recording failed for order %s: %s",
-                    order.id,
-                    order_result.unwrap_err(),
-                )
-            # Phase A: order status is never changed on refund — always False
-            result["order_status_updated"] = False
-            result["order_id"] = order.id
-
-        # The orchestrator passes the already-locked financial document. Do not
-        # follow order.invoice here: a lazy relation fetch would be unlocked and
-        # would happen after the external gateway call.
-        invoice_to_update = invoice
-
-        # Process invoice updates
-        if invoice_to_update:
-            invoice_result = RefundService._update_invoice_refund_status(invoice_to_update, refund_data=refund_data)
-            if invoice_result.is_ok():
-                result["invoice_status_updated"] = True
-            else:
-                # Money has already moved at the gateway: a failed invoice transition is a
-                # reconciliation incident, not a log line — the API otherwise reports refund
-                # success while the invoice still says paid.
-                log_security_event(
-                    event_type="refund_reconciliation_required",
-                    details={
-                        "invoice_id": str(invoice_to_update.id),
-                        "error": invoice_result.unwrap_err(),
-                        "critical_financial_operation": True,
-                    },
-                )
-                logger.warning(
-                    "⚠️ [Refund] Invoice status update failed for invoice %s: %s",
-                    invoice_to_update.id,
-                    invoice_result.unwrap_err() if invoice_result.is_err() else "unknown",
-                )
-                result["invoice_status_updated"] = False
-            result["invoice_id"] = invoice_to_update.id
-
-        return Ok(result)
-
-    @staticmethod
     def _process_payment_refund_if_exists(
         order: Any,
         invoice: Any,
         refund_data: RefundData | None,
         *,
         payment: Payment | None = None,
+        refund_intent_id: uuid.UUID | None = None,
     ) -> Result[dict[str, Any], str]:
         """Resolve and refund the single authoritative payment for an entity."""
         if payment is None:
@@ -1340,11 +1476,27 @@ class RefundService:
             refund_data,
             payment_locked=True,
             defer_settlement=True,
+            refund_intent_id=refund_intent_id,
         )
         if gateway_result.is_err():
             return Err(gateway_result.unwrap_err())
 
         return Ok({**gateway_result.unwrap(), "payment": payment})
+
+    @staticmethod
+    def _resolve_submitted_refund_amount(
+        payment: Payment,
+        refund_data: RefundData | None,
+        refund_amount_cents: int | None,
+        refund_intent_id: uuid.UUID | None,
+    ) -> Result[int, str]:
+        """Use the committed intent amount, or resolve a legacy caller's amount."""
+        if refund_intent_id is None:
+            return RefundService._resolve_effective_refund_amount(payment, refund_data, refund_amount_cents)
+        requested_amount = refund_data.get("amount_cents") if refund_data else refund_amount_cents
+        if isinstance(requested_amount, bool) or not isinstance(requested_amount, int) or requested_amount <= 0:
+            return Err("Failed to process payment refund: reserved amount must be positive integer cents")
+        return Ok(requested_amount)
 
     @staticmethod
     def _resolve_refundable_payment(order: Any, invoice: Any) -> Result[Payment, str]:
@@ -1493,47 +1645,6 @@ class RefundService:
         except Exception:
             logger.exception("Order refund status update failed for order_id=%s", getattr(order, "pk", "unknown"))
             return Err("Failed to update order status")
-
-    @staticmethod
-    def _update_invoice_refund_status(
-        invoice: Any, refund_amount_cents: int | None = None, refund_data: RefundData | None = None
-    ) -> Result[None, str]:
-        """Update invoice refund status"""
-        try:
-            # Get already refunded amount
-            already_refunded = RefundService._get_invoice_refunded_amount(invoice)
-            total_amount_cents = getattr(invoice, "total_cents", _FALLBACK_INVOICE_TOTAL_CENTS)
-
-            # Update invoice status to indicate it has been refunded via FSM transitions
-            if hasattr(invoice, "status"):
-                refund_type = refund_data.get("refund_type", "full") if refund_data else "full"
-
-                # Check if this refund makes it fully refunded
-                try:
-                    # The Refund row is created before this method runs, so the
-                    # aggregate already includes the current operation. Adding
-                    # current_amount again would turn a 50% refund into a full one.
-                    if already_refunded >= total_amount_cents or refund_type == "full":
-                        invoice.refund_invoice()
-                    else:
-                        invoice.mark_partially_refunded()
-                except TransitionNotAllowed:
-                    logger.warning(
-                        "⚠️ [Refund] FSM transition blocked for invoice %s (status=%s, refund_type=%s)",
-                        getattr(invoice, "invoice_number", "unknown"),
-                        getattr(invoice, "status", "unknown"),
-                        refund_type,
-                    )
-                    return Err(
-                        f"Cannot transition invoice from '{getattr(invoice, 'status', 'unknown')}' to refund status"
-                    )
-                invoice.save()
-                return Ok(None)
-
-            return Err("Invoice update failed")
-        except Exception:
-            logger.exception("Invoice refund status update failed for invoice_id=%s", getattr(invoice, "pk", "unknown"))
-            return Err("Invoice update failed")
 
     @staticmethod
     def _create_audit_entry(refund_id: Any, entity_type: str, entity_id: Any, refund_data: RefundData | None) -> None:
@@ -1718,6 +1829,7 @@ class RefundService:
         refund_amount_cents = kwargs.get("refund_amount_cents")
         payment_locked = bool(kwargs.get("payment_locked", False))
         defer_settlement = bool(kwargs.get("defer_settlement", False))
+        refund_intent_id = kwargs.get("refund_intent_id")
 
         # If payment not passed directly, resolve it through the same
         # authoritative document relations used by the public refund flow.
@@ -1737,7 +1849,9 @@ class RefundService:
                 if payment.status not in {"succeeded", "partially_refunded"}:
                     return Err(f"Payment is not refundable from status '{payment.status}'")
 
-            amount_result = RefundService._resolve_effective_refund_amount(payment, refund_data, refund_amount_cents)
+            amount_result = RefundService._resolve_submitted_refund_amount(
+                payment, refund_data, refund_amount_cents, refund_intent_id
+            )
             if amount_result.is_err():
                 return Err(amount_result.unwrap_err())
             effective_amount = amount_result.unwrap()
@@ -1760,8 +1874,13 @@ class RefundService:
                 },
             )
 
-            # GATEWAY-FIRST: call gateway before updating local state to prevent accounting drift
-            gateway_result = RefundService._execute_gateway_refund(payment, effective_amount, effective_amount)
+            # The intent exists already; gateway submission precedes settlement projection.
+            gateway_result = RefundService._execute_gateway_refund(
+                payment,
+                effective_amount,
+                effective_amount,
+                refund_intent_id=refund_intent_id,
+            )
             if gateway_result.is_err():
                 return gateway_result
 
@@ -1794,7 +1913,11 @@ class RefundService:
             return Err("Failed to process payment refund")
 
     @staticmethod
-    def _update_payment_status_after_refund(payment: Any, refund_type: str, refund_amount_cents: int) -> None:
+    def _update_payment_status_after_refund(
+        payment: Any,
+        refund_type: RefundType | str,
+        refund_amount_cents: int,
+    ) -> None:
         """Apply the coarse Payment FSM state after a successful gateway refund."""
         try:
             is_fully_refunded = refund_type in (RefundType.FULL, "full")
@@ -1843,7 +1966,11 @@ class RefundService:
 
     @staticmethod
     def _execute_gateway_refund(
-        payment: Any, refund_amount_cents: int | None, effective_amount: int
+        payment: Any,
+        refund_amount_cents: int | None,
+        effective_amount: int,
+        *,
+        refund_intent_id: uuid.UUID | None = None,
     ) -> Result[dict[str, Any], str]:
         """Execute refund via payment gateway or return local success for non-gateway payments."""
         payment_method = getattr(payment, "payment_method", "")
@@ -1875,21 +2002,20 @@ class RefundService:
                 }
             )
 
+        if refund_intent_id is None:
+            return Err("Gateway refund requires a durable Refund intent")
+        intent_exists = Refund.objects.filter(
+            pk=refund_intent_id,
+            payment_id=payment.id,
+            amount_cents=effective_amount,
+            gateway_refund_id="",
+            status__in=("pending", "processing", "approved"),
+        ).exists()
+        if not intent_exists:
+            return Err("Gateway refund requires a matching durable Refund intent")
+
         gateway = PaymentGatewayFactory.create_gateway(payment.payment_method)
-        # Reconstructible idempotency key: the same logical refund derives the same key so a
-        # retry replays the same gateway refund, while a distinct partial gets a fresh key.
-        # LIMITATION: the key is derived from the payment's CURRENT refunded balance and
-        # terminal-attempt count, so it is stable only while no OTHER refund on this payment
-        # commits between the original attempt and the retry — intervening activity shifts
-        # already_refunded and mints a new key, which can re-execute the refund at the gateway.
-        # A fully stable key needs a persisted pre-gateway refund intent (tracked as a
-        # follow-up). The webhook + reconciliation convergence backstop the residual window.
-        remaining = RefundService._get_remaining_payment_refund_amount(payment)
-        already_refunded = (payment.amount_cents - remaining) if remaining is not None else 0
-        terminal_attempts = payment.refunds.filter(status__in=("failed", "cancelled", "rejected")).count()
-        # No length slice: the readable key is ~81 chars max (well under Stripe's 255 limit);
-        # a [:64] slice could truncate away amount/terminal_attempts and collide distinct refunds.
-        refund_idempotency_key = f"refund:{payment.id}:{already_refunded}:{effective_amount}:{terminal_attempts}"
+        refund_idempotency_key = f"refund:{refund_intent_id}"
         refund_result = gateway.refund_payment(
             gateway_txn_id=payment.gateway_txn_id,
             amount_cents=refund_amount_cents,
@@ -2083,6 +2209,24 @@ class RefundConvergenceService:
                     if snapshot
                     else None
                 )
+                if refund is None:
+                    # The gateway may have created the refund while PRAHO lost the
+                    # response and rolled back settlement. The durable blank-ID
+                    # intent is still reserved; attach the discovered gateway fact
+                    # instead of creating a second ledger row.
+                    intent_candidates = list(
+                        Refund.objects.select_for_update(of=("self",))
+                        .filter(
+                            payment=payment,
+                            gateway_refund_id="",
+                            status__in=("pending", "processing", "approved"),
+                            amount_cents=amount_cents,
+                        )
+                        .order_by("created_at")[:2]
+                    )
+                    if len(intent_candidates) > 1:
+                        return Err("Multiple local refund intents match the gateway refund")
+                    refund = intent_candidates[0] if intent_candidates else None
                 if refund is not None:
                     validation = RefundConvergenceService._validate_existing_refund(
                         refund,
@@ -2096,6 +2240,10 @@ class RefundConvergenceService:
                             validation.unwrap_err(),
                             retriability=retriability_of(validation),
                         )
+
+                    if not refund.gateway_refund_id:
+                        refund.gateway_refund_id = refund_id
+                        refund.save(update_fields=["gateway_refund_id", "updated_at"])
 
                     previous_created = (refund.metadata or {}).get("gateway_event_created")
                     if (

--- a/services/platform/apps/billing/signals.py
+++ b/services/platform/apps/billing/signals.py
@@ -22,7 +22,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.core.files.storage import default_storage
 from django.db import transaction
-from django.db.models import Sum
 from django.db.models.signals import post_delete, post_save, pre_delete, pre_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -1276,24 +1275,8 @@ def _handle_payment_failure(payment: Payment) -> None:
 
 
 def _handle_payment_refund(payment: Payment) -> None:
-    """Handle payment refund completion"""
+    """Send Payment-level side effects; RefundService owns Invoice projection."""
     try:
-        if payment.invoice:
-            refunded_amount = payment.invoice.payments.filter(status="refunded").aggregate(
-                total=Sum("amount_cents", default=0)
-            )["total"]
-            if refunded_amount >= payment.invoice.total_cents:
-                try:
-                    payment.invoice.refund_invoice()
-                except TransitionNotAllowed:
-                    logger.warning(
-                        "⚠️ [Invoice Signal] Cannot mark invoice %s as refunded from status '%s'",
-                        payment.invoice.number,
-                        payment.invoice.status,
-                    )
-                else:
-                    payment.invoice.save(update_fields=["status"])
-
         # Email deferred to post-commit
         transaction.on_commit(lambda p=payment: _send_payment_refund_email(p))
 

--- a/services/platform/tests/billing/test_billing_refund_and_efactura_regressions.py
+++ b/services/platform/tests/billing/test_billing_refund_and_efactura_regressions.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 from apps.billing.gateways.stripe_gateway import StripeGateway
-from apps.billing.models import Payment
+from apps.billing.models import Payment, Refund
 from apps.billing.proforma_service import generate_proforma_pdf, send_proforma_email
 from apps.billing.refund_service import RefundService
 from tests.factories.billing_factories import create_currency, create_customer, create_invoice
@@ -360,6 +360,19 @@ class GatewayFirstRefundTests(TestCase):
         self.currency = create_currency("USD")
         self.invoice = create_invoice(self.customer, self.currency, number="INV-REFUND-001", total_cents=5000)
 
+    def _create_refund_intent(self, payment: Payment, amount_cents: int = 5000) -> Refund:
+        return Refund.objects.create(
+            customer=self.customer,
+            invoice=self.invoice,
+            payment=payment,
+            amount_cents=amount_cents,
+            currency=self.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="full" if amount_cents == payment.amount_cents else "partial",
+            status="pending",
+            gateway_refund_id="",
+        )
+
     def test_gateway_failure_does_not_update_payment_status(self):
         """When Stripe refund fails, payment.status must remain 'succeeded'."""
         payment = Payment.objects.create(
@@ -371,6 +384,7 @@ class GatewayFirstRefundTests(TestCase):
             payment_method="stripe",
             gateway_txn_id="pi_test_fail",
         )
+        refund_intent = self._create_refund_intent(payment)
 
         mock_gateway = MagicMock()
         mock_gateway.refund_payment.return_value = {
@@ -385,7 +399,7 @@ class GatewayFirstRefundTests(TestCase):
             patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=mock_gateway),
             patch("apps.common.validators.log_security_event"),
         ):
-            result = RefundService._process_payment_refund(payment)
+            result = RefundService._process_payment_refund(payment, refund_intent_id=refund_intent.id)
 
         self.assertTrue(result.is_err())
         payment.refresh_from_db()
@@ -402,6 +416,7 @@ class GatewayFirstRefundTests(TestCase):
             payment_method="stripe",
             gateway_txn_id="pi_test_success",
         )
+        refund_intent = self._create_refund_intent(payment)
 
         mock_gateway = MagicMock()
         mock_gateway.refund_payment.return_value = {
@@ -420,6 +435,7 @@ class GatewayFirstRefundTests(TestCase):
                 payment,
                 refund_data={"refund_type": "full", "amount_cents": 5000},
                 refund_amount_cents=5000,
+                refund_intent_id=refund_intent.id,
             )
 
         self.assertTrue(result.is_ok())

--- a/services/platform/tests/billing/test_billing_refund_and_efactura_regressions.py
+++ b/services/platform/tests/billing/test_billing_refund_and_efactura_regressions.py
@@ -399,9 +399,16 @@ class GatewayFirstRefundTests(TestCase):
             patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=mock_gateway),
             patch("apps.common.validators.log_security_event"),
         ):
-            result = RefundService._process_payment_refund(payment, refund_intent_id=refund_intent.id)
+            result = RefundService._process_payment_refund(
+                payment,
+                {"refund_type": "full", "amount_cents": 5000, "reason": "requested_by_customer"},
+                refund_intent_id=refund_intent.id,
+            )
 
         self.assertTrue(result.is_err())
+        # The failure must be a GATEWAY failure, not an earlier validation exit —
+        # otherwise this test stops verifying its named scenario (review of #388).
+        mock_gateway.refund_payment.assert_called_once()
         payment.refresh_from_db()
         self.assertEqual(payment.status, "succeeded")  # NOT "refunded"
 

--- a/services/platform/tests/billing/test_billing_signals_regressions.py
+++ b/services/platform/tests/billing/test_billing_signals_regressions.py
@@ -29,6 +29,7 @@ from apps.billing.models import (
     VATValidation,
 )
 from apps.billing.recurring_authorization_service import RecurringPaymentAuthorizationService
+from apps.billing.refund_service import RefundService
 from apps.billing.signals import (
     LARGE_REFUND_THRESHOLD_CENTS,
     _activate_payment_services,
@@ -1455,14 +1456,15 @@ class TestHandlePaymentFailure(TestCase):
 
 class TestHandlePaymentRefund(TestCase):
     @patch("apps.billing.signals._send_payment_refund_email")
-    def test_fully_refunded_invoice(self, mock_email):
+    def test_coarse_payment_status_does_not_mutate_invoice(self, mock_email):
         payment = MagicMock()
         payment.invoice.total_cents = 1000
         payment.invoice.payments.filter.return_value.aggregate.return_value = {"total": 1000}
         with self.captureOnCommitCallbacks(execute=True):
             _handle_payment_refund(payment)
-        payment.invoice.save.assert_called_once()
-        payment.invoice.refund_invoice.assert_called_once()
+        payment.invoice.save.assert_not_called()
+        payment.invoice.refund_invoice.assert_not_called()
+        mock_email.assert_called_once_with(payment)
 
     @patch("apps.billing.signals._send_payment_refund_email")
     def test_partial_refund(self, mock_email):
@@ -1480,6 +1482,43 @@ class TestHandlePaymentRefund(TestCase):
         with self.captureOnCommitCallbacks(execute=True):
             _handle_payment_refund(payment)
         mock_email.assert_called_once()
+
+    @patch("apps.billing.signals._send_payment_refund_email")
+    def test_invoice_status_is_owned_by_completed_refund_projection(self, mock_email):
+        customer = CustomerFactory(company_name="Refund Projection SRL")
+        currency = _get_or_create_currency()
+        invoice = InvoiceFactory(
+            customer=customer,
+            currency=currency,
+            status="paid",
+            subtotal_cents=1_000,
+            tax_cents=0,
+            total_cents=1_000,
+        )
+        payment = _make_payment(customer, invoice=invoice, currency=currency, amount_cents=1_000)
+        Refund.objects.create(
+            customer=customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=400,
+            currency=currency,
+            original_amount_cents=1_000,
+            status="completed",
+            gateway_refund_id="re_partial_ledger_truth",
+            reference_number="REF-PARTIAL-LEDGER-TRUTH",
+        )
+        Payment.objects.filter(pk=payment.pk).update(status="refunded")
+        payment.refresh_from_db()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            _handle_payment_refund(payment)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.status, "paid")
+        projection = RefundService._project_settled_refunds(payment, invoice)
+        self.assertTrue(projection.is_ok(), projection.unwrap_err() if projection.is_err() else "")
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.status, "partially_refunded")
 
 
 class TestHandleRetryCompletion(TestCase):

--- a/services/platform/tests/billing/test_refund_gateway_integrity.py
+++ b/services/platform/tests/billing/test_refund_gateway_integrity.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from apps.billing.models import Currency, Invoice, Payment, ProformaInvoice, Refund, RefundStatusHistory
-from apps.billing.refund_service import Err, RefundData, RefundService
+from apps.billing.refund_service import Err, RefundConvergenceService, RefundData, RefundService
 from apps.common.types import Retriability
 from apps.customers.models import Customer
 from apps.orders.models import Order
@@ -81,7 +81,7 @@ class RefundGatewayIntegrityTests(TestCase):
             "notes": "Issue #212 regression",
         }
 
-    def test_invoice_gateway_failure_rolls_back_every_local_refund_change(self) -> None:
+    def test_invoice_gateway_failure_preserves_durable_refund_intent(self) -> None:
         invoice = self._make_invoice()
         payment = self._make_payment(invoice, transaction_id="pi_gateway_failure")
         gateway = MagicMock()
@@ -109,7 +109,11 @@ class RefundGatewayIntegrityTests(TestCase):
         self.assertEqual(invoice.status, "paid")
         self.assertEqual(payment.status, "succeeded")
         self.assertEqual(payment.meta, {})
-        self.assertFalse(Refund.objects.filter(invoice=invoice).exists())
+        refund = Refund.objects.get(invoice=invoice, payment=payment)
+        self.assertEqual(refund.status, "pending")
+        self.assertEqual(refund.amount_cents, 10_000)
+        self.assertEqual(refund.gateway_refund_id, "")
+        self.assertEqual(gateway.refund_payment.call_args.kwargs["idempotency_key"], f"refund:{refund.id}")
 
     def test_immediate_terminal_gateway_failure_is_persisted_but_reported_as_failure(self) -> None:
         invoice = self._make_invoice()
@@ -205,7 +209,18 @@ class RefundGatewayIntegrityTests(TestCase):
     def test_direct_order_orchestration_locks_linked_invoice_before_gateway(self) -> None:
         invoice = self._make_invoice()
         order = self._make_order(invoice)
-        self._make_payment(invoice, transaction_id="pi_direct_order_lock")
+        payment = self._make_payment(invoice, transaction_id="pi_direct_order_lock")
+        refund_intent = Refund.objects.create(
+            customer=self.customer,
+            order=order,
+            payment=payment,
+            amount_cents=10_000,
+            currency=self.currency,
+            original_amount_cents=10_000,
+            refund_type="full",
+            status="pending",
+            gateway_refund_id="",
+        )
         order._state.fields_cache.pop("invoice", None)
         gateway = MagicMock()
         gateway_response = {
@@ -227,8 +242,9 @@ class RefundGatewayIntegrityTests(TestCase):
             gateway.refund_payment.side_effect = refund_after_invoice_lock
             result = RefundService._process_bidirectional_refund(
                 order=order,
-                refund_id=uuid.uuid4(),
+                refund_id=refund_intent.id,
                 refund_data=self._refund_data(),
+                reserved_refund=refund_intent,
             )
 
         self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
@@ -926,7 +942,7 @@ class RefundGatewayIntegrityTests(TestCase):
                 reference_number="REF-GATEWAY-TWO",
             )
 
-    def test_failed_refund_gets_a_new_idempotency_key_but_unknown_outcome_reuses_key(self) -> None:
+    def test_gateway_refund_requires_and_reuses_durable_intent_identity(self) -> None:
         invoice = self._make_invoice()
         payment = self._make_payment(invoice, transaction_id="pi_retry_keys")
         gateway = MagicMock()
@@ -937,29 +953,175 @@ class RefundGatewayIntegrityTests(TestCase):
             "status": "pending",
             "error": None,
         }
+        first_intent = Refund.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=1_000,
+            currency=self.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="partial",
+            status="pending",
+            gateway_refund_id="",
+            reference_number="REF-FIRST-INTENT",
+        )
+        second_intent = Refund.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=1_000,
+            currency=self.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="partial",
+            status="pending",
+            gateway_refund_id="",
+            reference_number="REF-SECOND-INTENT",
+        )
+        unpersisted_intent_id = uuid.uuid4()
 
         with patch("apps.billing.refund_service.PaymentGatewayFactory.create_gateway", return_value=gateway):
-            first = RefundService._execute_gateway_refund(payment, 1_000, 1_000)
-            unknown_retry = RefundService._execute_gateway_refund(payment, 1_000, 1_000)
+            missing_intent = RefundService._execute_gateway_refund(payment, 1_000, 1_000)
+            unpersisted_intent = RefundService._execute_gateway_refund(
+                payment, 1_000, 1_000, refund_intent_id=unpersisted_intent_id
+            )
+            first = RefundService._execute_gateway_refund(
+                payment, 1_000, 1_000, refund_intent_id=first_intent.id
+            )
+            unknown_retry = RefundService._execute_gateway_refund(
+                payment, 1_000, 1_000, refund_intent_id=first_intent.id
+            )
+            distinct_refund = RefundService._execute_gateway_refund(
+                payment, 1_000, 1_000, refund_intent_id=second_intent.id
+            )
+
+        self.assertTrue(missing_intent.is_err())
+        self.assertIn("durable Refund intent", missing_intent.unwrap_err())
+        self.assertTrue(unpersisted_intent.is_err())
+        self.assertIn("durable Refund intent", unpersisted_intent.unwrap_err())
+        self.assertTrue(first.is_ok())
+        self.assertTrue(unknown_retry.is_ok())
+        self.assertTrue(distinct_refund.is_ok())
+        keys = [call.kwargs["idempotency_key"] for call in gateway.refund_payment.call_args_list]
+        self.assertEqual(
+            keys,
+            [f"refund:{first_intent.id}", f"refund:{first_intent.id}", f"refund:{second_intent.id}"],
+        )
+
+    def test_retry_after_local_rollback_reuses_durable_intent_despite_intervening_refund(self) -> None:
+        """A response-loss retry must keep A's identity after refund B changes the ledger."""
+        invoice = self._make_invoice(total_cents=10_000)
+        payment = self._make_payment(invoice, transaction_id="pi_durable_refund_intent")
+        gateway = MagicMock()
+        gateway.refund_payment.return_value = {
+            "success": True,
+            "refund_id": "re_durable_refund_a",
+            "amount_refunded_cents": 5_000,
+            "status": "succeeded",
+            "error": None,
+        }
+        partial: RefundData = {
+            "refund_type": "partial",
+            "amount_cents": 5_000,
+            "reason": "customer_request",
+        }
+
+        with patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=gateway):
+            with patch.object(RefundService, "_advance_refund_status", return_value=Err("local settlement failed")):
+                first = RefundService.refund_invoice(invoice.id, dict(partial))
+
+            self.assertTrue(first.is_err())
+            intent = Refund.objects.get(
+                invoice=invoice,
+                payment=payment,
+                amount_cents=5_000,
+                gateway_refund_id="",
+                status="pending",
+            )
+
             Refund.objects.create(
                 customer=self.customer,
                 invoice=invoice,
                 payment=payment,
-                amount_cents=1_000,
+                amount_cents=2_500,
                 currency=self.currency,
                 original_amount_cents=payment.amount_cents,
-                status="failed",
-                gateway_refund_id="re_failed_attempt",
-                reference_number="REF-FAILED-ATTEMPT",
+                status="completed",
+                gateway_refund_id="re_intervening_refund_b",
+                reference_number="REF-INTERVENING-B",
             )
-            terminal_retry = RefundService._execute_gateway_refund(payment, 1_000, 1_000)
 
-        self.assertTrue(first.is_ok())
-        self.assertTrue(unknown_retry.is_ok())
-        self.assertTrue(terminal_retry.is_ok())
+            retried = RefundService.refund_invoice(invoice.id, dict(partial))
+
+        self.assertTrue(retried.is_ok(), retried.unwrap_err() if retried.is_err() else "")
+        self.assertEqual(Refund.objects.get(gateway_refund_id="re_durable_refund_a").id, intent.id)
         keys = [call.kwargs["idempotency_key"] for call in gateway.refund_payment.call_args_list]
-        self.assertEqual(keys[0], keys[1])
-        self.assertNotEqual(keys[1], keys[2])
+        self.assertEqual(keys, [f"refund:{intent.id}", f"refund:{intent.id}"])
+
+    def test_gateway_discovery_attaches_response_loss_fact_to_durable_intent(self) -> None:
+        invoice = self._make_invoice(total_cents=10_000)
+        payment = self._make_payment(invoice, transaction_id="pi_discovered_intent")
+        intent = Refund.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=4_000,
+            currency=self.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="partial",
+            status="pending",
+            gateway_refund_id="",
+            reference_number="REF-DISCOVERED-INTENT",
+        )
+
+        result = RefundConvergenceService.converge_gateway_refund(
+            {
+                "refund_id": "re_discovered_intent",
+                "payment_intent_id": "pi_discovered_intent",
+                "amount_cents": 4_000,
+                "currency": "ron",
+                "status": "succeeded",
+            }
+        )
+
+        self.assertTrue(result.is_ok(), result.unwrap_err() if result.is_err() else "")
+        recovered = result.unwrap()
+        self.assertIsNotNone(recovered)
+        self.assertEqual(recovered.id, intent.id)
+        self.assertEqual(Refund.objects.filter(payment=payment).count(), 1)
+        intent.refresh_from_db()
+        payment.refresh_from_db()
+        invoice.refresh_from_db()
+        self.assertEqual(intent.gateway_refund_id, "re_discovered_intent")
+        self.assertEqual(intent.status, "completed")
+        self.assertEqual(payment.status, "partially_refunded")
+        self.assertEqual(invoice.status, "partially_refunded")
+
+    def test_stale_unknown_outcome_fails_closed_before_gateway_retry(self) -> None:
+        invoice = self._make_invoice(total_cents=10_000)
+        payment = self._make_payment(invoice, transaction_id="pi_stale_intent")
+        intent = Refund.objects.create(
+            customer=self.customer,
+            invoice=invoice,
+            payment=payment,
+            amount_cents=4_000,
+            currency=self.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="partial",
+            status="pending",
+            gateway_refund_id="",
+            reference_number="REF-STALE-INTENT",
+        )
+        Refund.objects.filter(pk=intent.pk).update(created_at=timezone.now() - timedelta(hours=24))
+
+        with patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway") as gateway_factory:
+            result = RefundService.refund_invoice(
+                invoice.id,
+                {"refund_type": "partial", "amount_cents": 4_000, "reason": "customer_request"},
+            )
+
+        self.assertTrue(result.is_err())
+        self.assertIn("manual reconciliation", result.unwrap_err().lower())
+        gateway_factory.assert_not_called()
 
     def test_refund_eligibility_counts_only_live_or_completed_attempts(self) -> None:
         invoice = self._make_invoice()
@@ -1163,14 +1325,7 @@ class RefundGatewayIntegrityTests(TestCase):
         self.assertFalse(Refund.objects.filter(invoice=invoice).exists())
 
     def test_post_gateway_exception_rolls_back_payment_and_invoice_status(self) -> None:
-        """A crash after gateway success must not commit a half-written refund.
-
-        The payment status update fires a post_save signal that cascades the
-        invoice to refunded BEFORE the Refund row exists. If a later step dies
-        with a non-database exception, the swallowed-exception Err return must
-        mark the surrounding transaction for rollback — otherwise both
-        documents commit as refunded with zero Refund rows and no audit trail.
-        """
+        """A settlement crash preserves the command but rolls back projections."""
         invoice = self._make_invoice()
         payment = self._make_payment(invoice, transaction_id="pi_post_gateway_crash")
         gateway = MagicMock()
@@ -1184,7 +1339,7 @@ class RefundGatewayIntegrityTests(TestCase):
 
         with (
             patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=gateway),
-            patch.object(RefundService, "_create_refund_record", side_effect=RuntimeError("post-gateway crash")),
+            patch.object(RefundService, "_advance_refund_status", side_effect=RuntimeError("post-gateway crash")),
         ):
             result = RefundService.refund_invoice(invoice.id, self._refund_data())
 
@@ -1194,7 +1349,10 @@ class RefundGatewayIntegrityTests(TestCase):
         self.assertEqual(invoice.status, "paid")
         self.assertEqual(payment.status, "succeeded")
         self.assertEqual(payment.meta, {})
-        self.assertFalse(Refund.objects.exists())
+        intent = Refund.objects.get(invoice=invoice, payment=payment)
+        self.assertEqual(intent.status, "pending")
+        self.assertEqual(intent.gateway_refund_id, "")
+        self.assertEqual(gateway.refund_payment.call_args.kwargs["idempotency_key"], f"refund:{intent.id}")
 
     def test_post_gateway_err_return_rolls_back_payment_and_invoice_status(self) -> None:
         """An Err RETURN (not an exception) after gateway success must also roll back."""
@@ -1211,9 +1369,7 @@ class RefundGatewayIntegrityTests(TestCase):
 
         with (
             patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=gateway),
-            patch.object(
-                RefundService, "_create_refund_record", return_value=Err("simulated record failure")
-            ),
+            patch.object(RefundService, "_advance_refund_status", return_value=Err("simulated status failure")),
         ):
             result = RefundService.refund_invoice(invoice.id, self._refund_data())
 
@@ -1222,7 +1378,9 @@ class RefundGatewayIntegrityTests(TestCase):
         payment.refresh_from_db()
         self.assertEqual(invoice.status, "paid")
         self.assertEqual(payment.status, "succeeded")
-        self.assertFalse(Refund.objects.exists())
+        intent = Refund.objects.get(invoice=invoice, payment=payment)
+        self.assertEqual(intent.status, "pending")
+        self.assertEqual(intent.gateway_refund_id, "")
 
 
 class RefundConvergenceHardeningTests(TestCase):

--- a/services/platform/tests/billing/test_refund_service_regressions.py
+++ b/services/platform/tests/billing/test_refund_service_regressions.py
@@ -1121,70 +1121,6 @@ class TestCreateRefundRecord(TestCase):
 
 
 # ===========================================================================
-# _process_entity_updates
-# ===========================================================================
-class TestProcessEntityUpdates(TestCase):
-    @patch.object(RefundService, "_update_order_refund_status", return_value=Ok(None))
-    def test_with_order(self, mock_update: MagicMock) -> None:
-        order = MagicMock(id=1)
-        r = RefundService._process_entity_updates(order, None, "ref-1", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["order_status_updated"] is False  # Phase A: order status not changed on refund
-        assert data["order_id"] == 1
-        assert data["invoice_id"] is None
-        mock_update.assert_called_once_with(order, refund_data=None)
-
-    @patch.object(RefundService, "_update_invoice_refund_status", return_value=Ok(None))
-    def test_with_invoice(self, mock_update: MagicMock) -> None:
-        inv = MagicMock(id=2)
-        r = RefundService._process_entity_updates(None, inv, "ref-2", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["invoice_status_updated"] is True
-        assert data["invoice_id"] == 2
-        mock_update.assert_called_once_with(inv, refund_data=None)
-
-    @patch.object(RefundService, "_update_invoice_refund_status", return_value=Ok(None))
-    @patch.object(RefundService, "_update_order_refund_status", return_value=Ok(None))
-    def test_with_both(self, mock_order: MagicMock, mock_inv: MagicMock) -> None:
-        order = MagicMock(id=1)
-        inv = MagicMock(id=2)
-        r = RefundService._process_entity_updates(order, inv, "ref-3", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["order_status_updated"] is False  # Phase A: order status not changed on refund
-        assert data["invoice_status_updated"] is True
-
-    def test_with_neither(self) -> None:
-        r = RefundService._process_entity_updates(None, None, "ref-4", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["order_status_updated"] is False
-        assert data["invoice_status_updated"] is False
-
-    @patch.object(RefundService, "_update_order_refund_status", return_value=Err("FSM blocked"))
-    def test_order_update_failure_returns_ok_with_false(self, mock_update: MagicMock) -> None:
-        """C3 regression: when order update fails, result still Ok but order_status_updated=False."""
-        order = MagicMock(id=1)
-        r = RefundService._process_entity_updates(order, None, "ref-5", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["order_status_updated"] is False
-        assert data["order_id"] == 1
-
-    @patch.object(RefundService, "_update_invoice_refund_status", return_value=Err("FSM blocked"))
-    def test_invoice_update_failure_returns_ok_with_false(self, mock_update: MagicMock) -> None:
-        """C3 regression: when invoice update fails, result still Ok but invoice_status_updated=False."""
-        inv = MagicMock(id=2)
-        r = RefundService._process_entity_updates(None, inv, "ref-6", None)
-        assert r.is_ok()
-        data = r.unwrap()
-        assert data["invoice_status_updated"] is False
-        assert data["invoice_id"] == 2
-
-
-# ===========================================================================
 # _process_payment_refund_if_exists
 # ===========================================================================
 class TestProcessPaymentRefundIfExists(TestCase):
@@ -1282,51 +1218,6 @@ class TestUpdateOrderRefundStatus(TestCase):
         o.refresh_from_db()
         # Phase A: order stays completed — refund is on Invoice/Payment
         assert o.status == "completed"
-
-
-# ===========================================================================
-# _update_invoice_refund_status
-# ===========================================================================
-class TestUpdateInvoiceRefundStatus(TestCase):
-    def test_full_refund(self):
-        c = _make_customer()
-        cur = _make_currency()
-        inv = _make_invoice(c, cur, status="paid", total_cents=10000)
-        r = RefundService._update_invoice_refund_status(inv, refund_data={"refund_type": "full"})
-        assert r.is_ok()
-        inv.refresh_from_db()
-        assert inv.status == "refunded"
-
-    def test_partial_refund(self):
-        c = _make_customer()
-        cur = _make_currency()
-        inv = _make_invoice(c, cur, status="paid", total_cents=10000)
-        r = RefundService._update_invoice_refund_status(
-            inv, refund_data={"refund_type": "partial", "amount_cents": 3000}
-        )
-        assert r.is_ok()
-        inv.refresh_from_db()
-        assert inv.status == "partially_refunded"
-
-    def test_no_status_attr(self):
-        inv = MagicMock(spec=["total_cents"])
-        inv.total_cents = 10000
-        del inv.status
-        r = RefundService._update_invoice_refund_status(inv, refund_data={"refund_type": "full"})
-        assert r.is_err()
-
-    def test_exception_path(self):
-        inv = MagicMock(status="paid", total_cents=10000)
-        inv.save.side_effect = Exception("db error")
-        r = RefundService._update_invoice_refund_status(inv, refund_data={"refund_type": "full"})
-        assert r.is_err()
-
-    def test_no_refund_data(self):
-        c = _make_customer()
-        cur = _make_currency()
-        inv = _make_invoice(c, cur, status="paid", total_cents=10000)
-        r = RefundService._update_invoice_refund_status(inv)
-        assert r.is_ok()
 
 
 # ===========================================================================
@@ -1585,13 +1476,15 @@ class TestProcessPaymentRefund(TestCase):
         }
         return patch("apps.billing.gateways.base.PaymentGatewayFactory.create_gateway", return_value=mock_gw)
 
-    def _make_succeeded_payment(self, gateway_txn_id: str = "tx_123") -> object:
+    def _make_succeeded_payment(self, gateway_txn_id: str = "tx_123") -> Payment:
         """Create a real Payment instance in 'succeeded' state for FSM-aware tests."""
 
         c = _make_customer()
         cur = _make_currency()
+        invoice = _make_invoice(c, cur, status="paid", total_cents=10_000)
         payment = Payment.objects.create(
             customer=c,
+            invoice=invoice,
             currency=cur,
             payment_method="stripe",
             amount_cents=10000,
@@ -1600,20 +1493,42 @@ class TestProcessPaymentRefund(TestCase):
         )
         return payment
 
+    @staticmethod
+    def _create_refund_intent(payment: Payment, amount_cents: int) -> uuid.UUID:
+        assert payment.invoice is not None
+        return Refund.objects.create(
+            customer=payment.customer,
+            invoice=payment.invoice,
+            payment=payment,
+            amount_cents=amount_cents,
+            currency=payment.currency,
+            original_amount_cents=payment.amount_cents,
+            refund_type="full" if amount_cents == payment.amount_cents else "partial",
+            status="pending",
+            gateway_refund_id="",
+        ).id
+
     def test_payment_full_refund(self):
         payment = self._make_succeeded_payment(gateway_txn_id="tx_full_refund")
+        refund_intent_id = self._create_refund_intent(payment, 10_000)
         with self._mock_gateway_success():
-            r = RefundService._process_payment_refund(payment, {"refund_type": "full"})
+            r = RefundService._process_payment_refund(
+                payment,
+                {"refund_type": "full", "amount_cents": 10_000},
+                refund_intent_id=refund_intent_id,
+            )
         assert r.is_ok()
         payment.refresh_from_db()
         assert payment.status == "refunded"
 
     def test_payment_partial_refund(self):
         payment = self._make_succeeded_payment(gateway_txn_id="tx_partial_refund")
+        refund_intent_id = self._create_refund_intent(payment, 5_000)
         with self._mock_gateway_success(amount=5000):
             r = RefundService._process_payment_refund(
                 payment,
                 {"refund_type": "partial", "amount_cents": 5000},
+                refund_intent_id=refund_intent_id,
             )
         assert r.is_ok()
         payment.refresh_from_db()
@@ -1637,16 +1552,22 @@ class TestProcessPaymentRefund(TestCase):
 
     def test_refund_amount_cents_kwarg_full(self):
         payment = self._make_succeeded_payment(gateway_txn_id="tx_kwarg_full")
+        refund_intent_id = self._create_refund_intent(payment, 10_000)
         with self._mock_gateway_success():
-            r = RefundService._process_payment_refund(payment, None, refund_amount_cents=10000)
+            r = RefundService._process_payment_refund(
+                payment, None, refund_amount_cents=10000, refund_intent_id=refund_intent_id
+            )
         assert r.is_ok()
         payment.refresh_from_db()
         assert payment.status == "refunded"
 
     def test_refund_amount_cents_kwarg_partial(self):
         payment = self._make_succeeded_payment(gateway_txn_id="tx_kwarg_partial")
+        refund_intent_id = self._create_refund_intent(payment, 5_000)
         with self._mock_gateway_success(amount=5000):
-            r = RefundService._process_payment_refund(payment, None, refund_amount_cents=5000)
+            r = RefundService._process_payment_refund(
+                payment, None, refund_amount_cents=5000, refund_intent_id=refund_intent_id
+            )
         assert r.is_ok()
         payment.refresh_from_db()
         assert payment.status == "partially_refunded"
@@ -1686,6 +1607,7 @@ class TestProcessPaymentRefund(TestCase):
         from apps.billing.payment_models import Payment  # noqa: PLC0415
 
         payment = self._make_succeeded_payment(gateway_txn_id="tx_concurrent_refund")
+        refund_intent_id = self._create_refund_intent(payment, 10_000)
 
         # Mock select_for_update to return the same payment instance (so our
         # patch.object on refund_payment survives the re-fetch).
@@ -1698,7 +1620,11 @@ class TestProcessPaymentRefund(TestCase):
             patch.object(payment, "refund_payment", side_effect=ConcurrentTransition("concurrent write")),
         ):
             # Must not raise — the exception is caught, logged at ERROR, and gateway_result is returned.
-            r = RefundService._process_payment_refund(payment, {"refund_type": "full"})
+            r = RefundService._process_payment_refund(
+                payment,
+                {"refund_type": "full", "amount_cents": 10_000},
+                refund_intent_id=refund_intent_id,
+            )
 
         # Gateway result is propagated even when the FSM transition fails.
         assert r.is_ok()

--- a/services/platform/tests/billing/test_refund_service_regressions.py
+++ b/services/platform/tests/billing/test_refund_service_regressions.py
@@ -1999,3 +1999,35 @@ class TestBackfillRefundsFromMeta(TestCase):
         refunds = list(Refund.objects.filter(order=order))
         assert len(refunds) == 1
         assert refunds[0].reason == "customer_request"
+
+
+class TestOrderRefundInvoiceLinkage(TestCase):
+    """Settlement of an order refund must project the ORDER-linked invoice
+    (review of #388): a payment matched via meta['order_id'] can legally carry
+    an invoice_id different from order.invoice_id, and preferring the payment's
+    invoice would refund-project the wrong document."""
+
+    def test_mismatched_payment_invoice_linkage_fails_closed(self) -> None:
+        """A refund must not guess which document to mark refunded: when the
+        payment's invoice disagrees with the order's, settlement rejects the
+        command for manual reconciliation and touches NEITHER invoice."""
+        customer = _make_customer()
+        currency = _make_currency()
+        order_invoice = _make_invoice(customer, currency)
+        other_invoice = _make_invoice(customer, currency)
+        order = _make_order(customer, currency, invoice=order_invoice)
+        payment = _make_bank_payment(customer, currency, invoice=other_invoice, order=order)
+
+        result = RefundService.refund_order(
+            order.id,
+            {"refund_type": RefundType.FULL, "reason": "customer_request", "notes": "linkage test"},
+        )
+
+        self.assertTrue(result.is_err(), "mismatched invoice linkage must fail closed")
+        self.assertIn("linkage", result.unwrap_err().lower())
+        order_invoice.refresh_from_db()
+        other_invoice.refresh_from_db()
+        payment.refresh_from_db()
+        self.assertEqual(order_invoice.status, "paid")
+        self.assertEqual(other_invoice.status, "paid")
+        self.assertEqual(payment.status, "succeeded")


### PR DESCRIPTION
## Summary

- reserve a durable local `Refund` intent before contacting Stripe
- derive Stripe idempotency from the persisted refund UUID and reuse the same intent across safe retries
- make completed `Refund` rows the single source for Payment and Invoice refund projection
- make webhook/discovery convergence attach Stripe refunds to the matching local intent
- fail closed for ambiguous or stale unknown refund attempts

## Root cause

The previous flow performed the gateway call inside the same database transaction that created the local refund record. A local rollback after Stripe succeeded erased the only stable command identity, so a retry could create a second Stripe refund. Separately, both `Payment` signals and `RefundService` projected Invoice refund state, allowing the two aggregates to diverge.

## Design and safety

- phase 1 commits a pending refund intent under the canonical Payment → Invoice → Order → Refund lock order
- phase 2 calls Stripe with `refund:{refund_uuid}`, then atomically records the gateway result and projects aggregate state
- retries reuse only an exact, unambiguous active intent for the same payment and amount
- blank-gateway intents older than 23 hours require reconciliation instead of risking resubmission after Stripe may prune an idempotency key
- the Stripe gateway boundary rejects missing, unpersisted, or mismatched refund intent IDs
- Payment refund signals remain notification-only; aggregate status is derived from completed Refund ledger rows

## Migration and rollout

No schema migration or historical backfill is required. Existing Refund rows remain compatible.

## Verification

- `make test-file FILE=tests.billing` — 2,712 tests passed, 11 skipped
- `make test` — all platform, portal, integration, cache, and security phases passed
- `make lint` — Ruff, MyPy (419 files), Django checks, audit/i18n/code-health and FSM guardrails passed
- pre-commit hooks passed
- DCO signed on the first commit

Closes #342
Closes #345

References:
- https://docs.stripe.com/api/idempotent_requests
- https://docs.stripe.com/refunds
- https://docs.djangoproject.com/en/5.2/topics/db/transactions/