### PR TITLE
fix(settings): isolate audit failures from the settings write transaction

### DIFF
--- a/services/platform/apps/settings/signals.py
+++ b/services/platform/apps/settings/signals.py
@@ -70,21 +70,27 @@ def handle_setting_saved(sender: Any, instance: SystemSetting, created: bool, **
             old_values = {"value": context.get("old_value")}
             new_values = {"value": context.get("new_value")}
 
-        AuditService.log_simple_event(
-            event_type=action,
-            user=user,
-            content_object=instance,
-            description=f"System setting {action}: {instance.key}",
-            old_values=old_values,
-            new_values=new_values,
-            metadata=metadata,
-        )
+        # Savepoint isolation (customers/signals.py pattern): a DB-level audit failure
+        # must not poison the caller's transaction — catching the Python exception alone
+        # does not recover the connection.
+        with transaction.atomic():
+            AuditService.log_simple_event(
+                event_type=action,
+                user=user,
+                content_object=instance,
+                description=f"System setting {action}: {instance.key}",
+                old_values=old_values,
+                new_values=new_values,
+                metadata=metadata,
+            )
 
-        logger.info(
-            "✅ [Settings Signal] Setting %s %s: %s",
-            instance.key,
-            action,
-            instance.get_display_value() if not instance.is_sensitive else "(hidden)",
+        transaction.on_commit(
+            lambda: logger.info(
+                "✅ [Settings Signal] Setting %s %s: %s",
+                instance.key,
+                action,
+                instance.get_display_value() if not instance.is_sensitive else "(hidden)",
+            )
         )
 
         # Notify only after the surrounding transaction commits — a later failure
@@ -109,17 +115,18 @@ def handle_setting_deleted(sender: Any, instance: SystemSetting, **kwargs: Any) 
         transaction.on_commit(lambda key=instance.key: SettingsService._clear_setting_cache(key))
 
         # Log audit event
-        AuditService.log_simple_event(
-            event_type="delete",
-            user=None,
-            content_object=instance,
-            description=f"System setting deleted: {instance.key}",
-            metadata={
-                "setting_key": instance.key,
-                "category": instance.category,
-                "data_type": instance.data_type,
-            },
-        )
+        with transaction.atomic():
+            AuditService.log_simple_event(
+                event_type="delete",
+                user=None,
+                content_object=instance,
+                description=f"System setting deleted: {instance.key}",
+                metadata={
+                    "setting_key": instance.key,
+                    "category": instance.category,
+                    "data_type": instance.data_type,
+                },
+            )
 
         logger.warning("⚠️ [Settings Signal] Setting %s deleted", instance.key)
 

--- a/services/platform/tests/settings/test_settings_service_hardening.py
+++ b/services/platform/tests/settings/test_settings_service_hardening.py
@@ -394,3 +394,60 @@ class AuditFailureIsolationTests(TestCase):
 
         row = SystemSetting.objects.get(key="billing.proforma_validity_days")
         self.assertEqual(row.get_typed_value(), 45)
+
+
+class AuditFailureResilienceTests(TransactionTestCase):
+    """A DB-level audit failure must not take the settings write down with it.
+
+    The audit call runs inside a savepoint with the failure contained
+    (customers/signals.py pattern): blocking a staff write — e.g. the
+    maintenance-mode toggle during an incident — because the audit INSERT
+    failed would turn an observability problem into an availability one.
+    The failure is still screamed to the log.
+    """
+
+    def test_setting_write_survives_audit_database_failure(self) -> None:
+        with patch(
+            "apps.settings.signals.AuditService.log_simple_event",
+            side_effect=DatabaseError("audit table unavailable"),
+        ):
+            result = SettingsService.update_setting("audit.compliant_score_threshold", 77)
+
+        self.assertTrue(result.is_ok(), f"the write must survive an audit failure: {result}")
+        self.assertEqual(
+            SettingsService.get_setting("audit.compliant_score_threshold"),
+            77,
+            "the value must be persisted and readable after the audit failure",
+        )
+
+    def test_setting_delete_survives_audit_database_failure(self) -> None:
+        SettingsService.update_setting("audit.compliant_score_threshold", 66)
+        with patch(
+            "apps.settings.signals.AuditService.log_simple_event",
+            side_effect=DatabaseError("audit table unavailable"),
+        ):
+            deleted, _ = SystemSetting.objects.filter(key="audit.compliant_score_threshold").delete()
+
+        self.assertEqual(deleted, 1, "the delete must survive an audit failure")
+
+    def test_audit_db_failure_does_not_poison_the_callers_transaction(self) -> None:
+        """PostgreSQL-only discriminator: without the savepoint around the audit
+        call, a DB-level failure there puts the connection in
+        InFailedSqlTransaction and the CALLER's next query explodes even though
+        the signal handler caught the Python exception."""
+        if connection.vendor != "postgresql":
+            self.skipTest("connection poisoning is a PostgreSQL transaction behavior")
+
+        def broken_audit(**kwargs: Any) -> None:
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT * FROM praho_no_such_table")
+
+        with (
+            patch("apps.settings.signals.AuditService.log_simple_event", side_effect=broken_audit),
+            transaction.atomic(),
+        ):
+            result = SettingsService.update_setting("audit.compliant_score_threshold", 55)
+            # Without savepoint isolation this next query raises InFailedSqlTransaction.
+            SystemSetting.objects.filter(key="audit.compliant_score_threshold").exists()
+
+        self.assertTrue(result.is_ok())


### PR DESCRIPTION
## Summary

- wrap both settings-signal audit calls in a savepoint so a DB-level audit failure rolls back only itself instead of poisoning the caller's transaction
- defer the success log to on_commit so a rolled-back change set never logs success
- lock with a PostgreSQL-gated regression test (connection poisoning is invisible on SQLite) plus backend-agnostic survive-behavior tests

## The defect

The signal handlers call AuditService inside the caller's write transaction with only a Python-level except around them. That catch is not enough on PostgreSQL: a failed audit INSERT leaves the connection in InFailedSqlTransaction, so the caller's next query explodes and the whole settings write is doomed — turning an observability failure into an availability one. The concrete bad day: the audit table has an outage, and the maintenance-mode toggle stops working during an incident.

This is the same failure mode customers/signals.py already documents and guards with the atomic-savepoint pattern; the settings module predated that lesson.

## Verification

- The PostgreSQL-gated discriminator executes broken SQL from inside the mocked audit call and proves the caller's follow-up query survives; it skips on SQLite where the semantics cannot reproduce
- Backend-agnostic tests pin that a write and a delete both survive an audit DatabaseError
- settings suite 181 green, audit suite 910 green, full platform 7,533 green; lint and mypy clean