### PR TITLE
fix(settings): deferred success log captures its own save's value

### DIFF
--- a/services/platform/apps/settings/signals.py
+++ b/services/platform/apps/settings/signals.py
@@ -84,12 +84,13 @@ def handle_setting_saved(sender: Any, instance: SystemSetting, created: bool, **
                 metadata=metadata,
             )
 
+        # Capture primitives NOW: the instance may be saved again before commit
+        # (multi-key change sets), and a closure over it would log the FINAL
+        # value for every deferred line instead of this save's value.
+        logged_display = instance.get_display_value() if not instance.is_sensitive else "(hidden)"
         transaction.on_commit(
-            lambda: logger.info(
-                "✅ [Settings Signal] Setting %s %s: %s",
-                instance.key,
-                action,
-                instance.get_display_value() if not instance.is_sensitive else "(hidden)",
+            lambda key=instance.key, act=action, val=logged_display: logger.info(
+                "✅ [Settings Signal] Setting %s %s: %s", key, act, val
             )
         )
 

--- a/services/platform/tests/settings/test_settings_service_hardening.py
+++ b/services/platform/tests/settings/test_settings_service_hardening.py
@@ -451,3 +451,29 @@ class AuditFailureResilienceTests(TransactionTestCase):
             SystemSetting.objects.filter(key="audit.compliant_score_threshold").exists()
 
         self.assertTrue(result.is_ok())
+
+
+class DeferredLogCaptureTests(TestCase):
+    """The on_commit success log must report the value of the save that
+    scheduled it, not whatever the instance holds at commit time (two saves of
+    one key in a single transaction previously both logged the final value)."""
+
+    def test_each_save_logs_its_own_value(self) -> None:
+        setting = SettingsService.update_setting("audit.compliant_score_threshold", 41).unwrap()
+
+        with (
+            self.assertLogs("apps.settings.signals", level="INFO") as logs,
+            self.captureOnCommitCallbacks(execute=True),
+            transaction.atomic(),
+        ):
+            # The SAME instance saved twice in one transaction: a closure
+            # over the instance would log the final value for BOTH lines.
+            setting.value = 43
+            setting.save()
+            setting.value = 44
+            setting.save()
+
+        setting_lines = [line for line in logs.output if "audit.compliant_score_threshold" in line]
+        self.assertEqual(len(setting_lines), 2)
+        self.assertIn("43", setting_lines[0], "the first save must log ITS value, not the final one")
+        self.assertIn("44", setting_lines[1])


### PR DESCRIPTION
Follow-up to #392's on_commit deferral: the closure re-read the instance at commit time, so the same instance saved twice inside one transaction logged the final value for both deferred lines — per-save attribution was lost. Primitives (key, action, display value) are captured at registration time. Audit rows were never affected; this is the operator log line only. Proven failing first with a double-save of one instance; settings suite 182 green.