### PR TITLE
fix(notifications): repair delivery and campaign targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Notification delivery and targeting** — requests-compatible transport options now reach the DNS-pinned send path without weakening TLS, redirect, or timeout policy, so SNS certificate verification no longer fails on its timeout override; inactive and all-customer campaign audiences now select what their names promise, while the undefined trial-expiry audience fails closed instead of broadcasting (#215, #216)
 - **VAT quote and evidence integrity** — cart and preflight calculations now use the same customer tax profile and billing country as issued documents, incomplete VAT contexts fail closed, VIES checks retain attributable consultation references and fresh timestamps, expired validations are fully scheduled and drained, and PDF/e-Factura reverse-charge notices share the Article 196 legal basis (#404)
 - **PostgreSQL order billing fixtures** — persistence-reaching order transition tests now use ISO country codes that fit the billing document schema (#315)
 - **Billing document completeness and e-Factura R051 validation** — the portal now searches, filters, counts, and paginates invoices and proformas against the customer's complete server-side document set instead of two independently truncated 20-row slices; CIUS-RO validation now rejects every R051 amount context that omits or mismatches the document currency while preserving the BT-111 accounting-currency exception (#227, #371)

--- a/docs/security/SECURITY_CONFIGURATION.md
+++ b/docs/security/SECURITY_CONFIGURATION.md
@@ -332,6 +332,13 @@ All outbound HTTP requests **must** use the helpers in `apps.common.outbound_htt
 3. Add tests verifying private IP rejection and redirect blocking
 4. Never use raw `requests.get/post` or `urllib.request.urlopen` outside the helper module
 
+`safe_request()` accepts normal request-construction options plus the transport
+options `timeout`, `stream`, and `cert`. Transport options are applied only after
+DNS pinning. A caller timeout may tighten the policy timeout but cannot increase
+it; caller-supplied `verify` and `allow_redirects` values never override the
+selected `OutboundPolicy`. Caller-supplied proxies are rejected because they
+would bypass the DNS-pinned connection guarantee.
+
 ---
 
 ## 9. Production Validation

--- a/services/platform/apps/common/outbound_http.py
+++ b/services/platform/apps/common/outbound_http.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import http.client
 import ipaddress
 import logging
+import math
 import re
 import socket
 import ssl
@@ -499,14 +500,97 @@ class PinnedIPAdapter(HTTPAdapter):
 _REDIRECT_STATUSES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
 
 
+@dataclass(frozen=True)
+class _TransportOptions:
+    """Requests transport options separated from Request-construction kwargs."""
+
+    timeout: tuple[float, float]
+    stream: bool
+    cert: str | tuple[str, str] | None
+
+
+def _bounded_timeout_part(value: object, upper_bound: float) -> float:
+    """Validate one timeout component and cap it at the policy maximum."""
+    if value is None:
+        return upper_bound
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("timeout values must be positive numbers or None")
+
+    numeric_value = float(value)
+    if not math.isfinite(numeric_value) or numeric_value <= 0:
+        raise ValueError("timeout values must be finite positive numbers")
+    return min(numeric_value, upper_bound)
+
+
+def _extract_transport_options(kwargs: dict[str, object], policy: OutboundPolicy) -> _TransportOptions:
+    """Remove Session.send options from request kwargs without weakening policy."""
+    timeout_override = kwargs.pop("timeout", None)
+    if isinstance(timeout_override, tuple):
+        try:
+            connect_override, read_override = timeout_override
+        except ValueError:
+            raise ValueError("timeout tuple must contain connect and read values") from None
+        connect_timeout = _bounded_timeout_part(connect_override, policy.connect_timeout_seconds)
+        read_timeout = _bounded_timeout_part(read_override, policy.timeout_seconds)
+    else:
+        connect_timeout = _bounded_timeout_part(timeout_override, policy.connect_timeout_seconds)
+        read_timeout = _bounded_timeout_part(timeout_override, policy.timeout_seconds)
+
+    stream = kwargs.pop("stream", False)
+    if not isinstance(stream, bool):
+        raise TypeError("stream must be a boolean")
+
+    cert_value = kwargs.pop("cert", None)
+    cert: str | tuple[str, str] | None
+    match cert_value:
+        case None | str():
+            cert = cert_value
+        case (str() as certificate_path, str() as key_path):
+            cert = (certificate_path, key_path)
+        case _:
+            raise TypeError("cert must be a path or a (certificate, key) path tuple")
+
+    if kwargs.pop("proxies", None) is not None:
+        raise OutboundSecurityError("Caller-supplied proxies are not supported by DNS-pinned requests")
+
+    # These controls are policy-owned. Pop caller values so they cannot either
+    # reach requests.Request (which rejects them) or weaken the outbound policy.
+    kwargs.pop("verify", None)
+    kwargs.pop("allow_redirects", None)
+
+    return _TransportOptions(
+        timeout=(connect_timeout, read_timeout),
+        stream=stream,
+        cert=cert,
+    )
+
+
+def _send_prepared_request(
+    session: requests.Session,
+    request: requests.PreparedRequest,
+    policy: OutboundPolicy,
+    transport: _TransportOptions,
+) -> requests.Response:
+    """Send one prepared request with policy-owned security controls."""
+    return session.send(
+        request,
+        allow_redirects=False,
+        verify=policy.verify_tls,
+        timeout=transport.timeout,
+        stream=transport.stream,
+        cert=transport.cert,
+    )
+
+
 def _follow_redirects(
     session: requests.Session,
     response: requests.Response,
     policy: OutboundPolicy,
     remaining: int,
-    method: str,
+    transport: _TransportOptions,
 ) -> requests.Response:
     """Manually follow redirects, re-validating each hop."""
+    method = response.request.method or "GET"
     while response.status_code in _REDIRECT_STATUSES and remaining > 0:
         location = response.headers.get("Location")
         if not location:
@@ -531,12 +615,7 @@ def _follow_redirects(
             method = "GET"
 
         prepared = session.prepare_request(requests.Request(method=method, url=location))
-        response = session.send(
-            prepared,
-            allow_redirects=False,
-            verify=policy.verify_tls,
-            timeout=(policy.connect_timeout_seconds, policy.timeout_seconds),
-        )
+        response = _send_prepared_request(session, prepared, policy, transport)
         remaining -= 1
 
     return response
@@ -558,7 +637,9 @@ def safe_request(
         method: HTTP method (GET, POST, etc.)
         url: Target URL
         policy: Security policy to enforce (default: STRICT_EXTERNAL)
-        **kwargs: Additional arguments passed to requests.Request constructor
+        **kwargs: Requests-compatible request and transport options. Caller
+            timeouts may tighten but never exceed policy bounds; TLS and
+            redirect behavior always remain policy-owned.
 
     Returns:
         requests.Response
@@ -604,18 +685,13 @@ def _execute_pinned_request(
             ),
         )
 
-    # Strip transport kwargs from Request constructor kwargs
+    transport = _extract_transport_options(kwargs, policy)
     req = requests.Request(method=method.upper(), url=url, **kwargs)
     prepared = session.prepare_request(req)
-    response = session.send(
-        prepared,
-        verify=policy.verify_tls,
-        timeout=(policy.connect_timeout_seconds, policy.timeout_seconds),
-        allow_redirects=False,
-    )
+    response = _send_prepared_request(session, prepared, policy, transport)
 
     if policy.allow_redirects and policy.max_redirects > 0:
-        response = _follow_redirects(session, response, policy, policy.max_redirects, method.upper())
+        response = _follow_redirects(session, response, policy, policy.max_redirects, transport)
 
     logger.info(
         "✅ [OutboundHTTP] Allow: policy=%s url=%s ip=%s status=%s",

--- a/services/platform/apps/common/outbound_http.py
+++ b/services/platform/apps/common/outbound_http.py
@@ -656,6 +656,10 @@ def safe_request(
         raise
 
     session = requests.Session()
+    # The worker environment must not inject transport policy: HTTPS_PROXY/HTTP_PROXY
+    # would reroute the pinned connection through a proxy, and REQUESTS_CA_BUNDLE or
+    # ~/.netrc would override policy-owned TLS and auth. Policy owns all of it.
+    session.trust_env = False
     session.headers["User-Agent"] = DEFAULT_USER_AGENT
     try:
         return _execute_pinned_request(session, target, method, url, policy, **kwargs)

--- a/services/platform/apps/notifications/tasks.py
+++ b/services/platform/apps/notifications/tasks.py
@@ -618,15 +618,16 @@ def _get_campaign_recipients(campaign: object) -> list[tuple[str, dict[str, Any]
     audience = campaign.audience
     recipients = []
 
-    # Base queryset
-    customers = Customer.objects.filter(status="active")
+    # Default manager already excludes soft-deleted customers. Apply status
+    # constraints per audience so names and query semantics cannot contradict.
+    customers = Customer.objects.all()
 
     if audience == "all_customers":
         pass  # No additional filter
     elif audience == "active_customers":
-        customers = customers.filter(status="active")
+        customers = customers.filter(status=Customer.CustomerStatus.ACTIVE)
     elif audience == "inactive_customers":
-        customers = customers.filter(status="inactive")
+        customers = customers.filter(status=Customer.CustomerStatus.INACTIVE)
     elif audience == "overdue_payments":
         # Customers with overdue invoices
         from apps.billing.models import (  # noqa: PLC0415  # Deferred: avoids circular import
@@ -635,11 +636,19 @@ def _get_campaign_recipients(campaign: object) -> list[tuple[str, dict[str, Any]
 
         overdue_customer_ids = Invoice.objects.filter(status="overdue").values_list("customer_id", flat=True).distinct()
         customers = customers.filter(id__in=overdue_customer_ids)
+    elif audience == "trial_expiring":
+        # The model exposes this future audience, but no expiry window has been
+        # defined. Fail closed rather than silently broadcasting to all customers.
+        logger.warning("Campaign audience 'trial_expiring' is not implemented; selecting no recipients")
+        customers = customers.none()
     elif audience == "custom_filter":
         # Apply custom filter from audience_filter JSON with WHITELIST validation
         custom_filter = campaign.audience_filter or {}
         if custom_filter:
             customers = _apply_safe_customer_filter(customers, custom_filter)
+    else:
+        logger.error("Unknown campaign audience %r; selecting no recipients", audience)
+        customers = customers.none()
 
     # Check consent for non-transactional campaigns
     if not campaign.is_transactional and campaign.requires_consent:

--- a/services/platform/tests/common/test_outbound_http_transport.py
+++ b/services/platform/tests/common/test_outbound_http_transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import socket
 from unittest.mock import MagicMock, patch
 
@@ -77,6 +78,31 @@ class TestSafeRequest(TestCase):
     def test_rejects_private_ip_target(self):
         with self.assertRaises(OutboundSecurityError):
             safe_request("GET", "https://evil.example.com/")
+
+    @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
+    def test_environment_proxies_cannot_bypass_dns_pinning(self):
+        """HTTPS_PROXY in the worker environment must not reroute a pinned request."""
+        captured: dict = {}
+
+        def _capture_send(request, **kwargs):
+            captured.update(kwargs)
+            response = MagicMock()
+            response.status_code = 200
+            response.headers = {}
+            response.is_redirect = False
+            response.history = []
+            return response
+
+        with (
+            patch.dict(os.environ, {"HTTPS_PROXY": "http://127.0.0.1:9"}),
+            patch.object(PinnedIPAdapter, "send", side_effect=_capture_send),
+        ):
+            safe_request("GET", "https://example.com/")
+
+        self.assertFalse(
+            captured.get("proxies"),
+            f"pinned send must ignore environment proxies, got {captured.get('proxies')!r}",
+        )
 
     @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
     @patch("apps.common.outbound_http.requests.Session")

--- a/services/platform/tests/common/test_outbound_http_transport.py
+++ b/services/platform/tests/common/test_outbound_http_transport.py
@@ -123,6 +123,69 @@ class TestSafeRequest(TestCase):
 
     @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
     @patch("apps.common.outbound_http.requests.Session")
+    def test_routes_transport_kwargs_to_send_without_weakening_policy(self, mock_session_cls):
+        """Transport options belong to Session.send; policy still owns security controls."""
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_response = MagicMock(status_code=200)
+        mock_session.send.return_value = mock_response
+        mock_session.prepare_request.return_value = MagicMock()
+
+        safe_request(
+            "GET",
+            "https://example.com/",
+            timeout=5,
+            stream=True,
+            cert="client.pem",
+            verify=False,
+            allow_redirects=True,
+        )
+
+        send_kwargs = mock_session.send.call_args.kwargs
+        self.assertEqual(send_kwargs["timeout"], (5.0, 5.0))
+        self.assertTrue(send_kwargs["stream"])
+        self.assertEqual(send_kwargs["cert"], "client.pem")
+        self.assertTrue(send_kwargs["verify"])
+        self.assertFalse(send_kwargs["allow_redirects"])
+
+    @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
+    @patch("apps.common.outbound_http.requests.Session")
+    def test_rejects_caller_proxy_before_send(self, mock_session_cls):
+        """A caller proxy would bypass the DNS-pinned connection guarantee."""
+        with self.assertRaises(OutboundSecurityError):
+            safe_request(
+                "GET",
+                "https://example.com/",
+                proxies={"https": "https://proxy.example.com"},
+            )
+
+        mock_session_cls.return_value.send.assert_not_called()
+
+    @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
+    @patch("apps.common.outbound_http.requests.Session")
+    def test_caller_timeout_cannot_exceed_policy_bounds(self, mock_session_cls):
+        """A requests-compatible timeout override may tighten, never loosen, policy."""
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+        mock_session.send.return_value = MagicMock(status_code=200)
+        mock_session.prepare_request.return_value = MagicMock()
+
+        safe_request("GET", "https://example.com/", timeout=(120, None))
+
+        self.assertEqual(mock_session.send.call_args.kwargs["timeout"], (10.0, 30.0))
+
+    @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
+    @patch("apps.common.outbound_http.requests.Session")
+    def test_invalid_timeout_rejected_before_send(self, mock_session_cls):
+        """Invalid timeout overrides fail locally instead of reaching requests."""
+        for timeout in (0, -1, float("inf"), "fast", (1, 2, 3)):
+            with self.subTest(timeout=timeout), self.assertRaises((TypeError, ValueError)):
+                safe_request("GET", "https://example.com/", timeout=timeout)
+
+        mock_session_cls.return_value.send.assert_not_called()
+
+    @patch("apps.common.outbound_http.socket.getaddrinfo", _mock_getaddrinfo_public)
+    @patch("apps.common.outbound_http.requests.Session")
     def test_mounts_pinned_adapter(self, mock_session_cls):
         mock_session = MagicMock()
         mock_session_cls.return_value = mock_session
@@ -156,6 +219,7 @@ class TestSafeRequest(TestCase):
         redirect_response.status_code = 302
         redirect_response.headers = {"Location": "https://other.example.com/final"}
         redirect_response.url = "https://example.com/"
+        redirect_response.request.method = "GET"
 
         # Final response: 200
         final_response = MagicMock()
@@ -163,8 +227,12 @@ class TestSafeRequest(TestCase):
 
         mock_session.send.side_effect = [redirect_response, final_response]
 
-        resp = safe_request("GET", "https://example.com/", policy=policy)
+        resp = safe_request("GET", "https://example.com/", policy=policy, timeout=5, stream=True)
         self.assertEqual(resp.status_code, 200)
+        initial_send, redirected_send = mock_session.send.call_args_list
+        for send_call in (initial_send, redirected_send):
+            self.assertEqual(send_call.kwargs["timeout"], (5.0, 5.0))
+            self.assertTrue(send_call.kwargs["stream"])
 
     @patch("apps.common.outbound_http.socket.getaddrinfo")
     @patch("apps.common.outbound_http.requests.Session")
@@ -190,6 +258,7 @@ class TestSafeRequest(TestCase):
         redirect_response.status_code = 302
         redirect_response.headers = {"Location": "https://evil-internal.example.com/steal"}
         redirect_response.url = "https://example.com/"
+        redirect_response.request.method = "GET"
         mock_session.send.return_value = redirect_response
 
         with self.assertRaises(OutboundSecurityError):

--- a/services/platform/tests/notifications/test_campaign_tasks.py
+++ b/services/platform/tests/notifications/test_campaign_tasks.py
@@ -1,0 +1,60 @@
+"""Regression tests for notification campaign audience selection."""
+
+from django.test import TestCase
+
+from apps.notifications.models import EmailCampaign, EmailTemplate
+from apps.notifications.tasks import _get_campaign_recipients
+from tests.factories import CustomerFactory
+
+
+class CampaignAudienceRecipientTests(TestCase):
+    """Campaign audience names must describe the queryset they actually select."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.template = EmailTemplate.objects.create(
+            key="campaign-audience-regression",
+            locale="en",
+            subject="Campaign",
+            body_html="<p>Campaign</p>",
+            body_text="Campaign",
+            is_active=True,
+            category="marketing",
+        )
+        cls.active_customer = CustomerFactory(
+            company_name="Active Customer",
+            primary_email="active@example.com",
+            status="active",
+            marketing_consent=True,
+        )
+        cls.inactive_customer = CustomerFactory(
+            company_name="Inactive Customer",
+            primary_email="inactive@example.com",
+            status="inactive",
+            marketing_consent=True,
+        )
+
+    def _recipient_emails(self, audience: str) -> set[str]:
+        campaign = EmailCampaign.objects.create(
+            name=f"{audience} campaign",
+            template=self.template,
+            audience=audience,
+            requires_consent=True,
+        )
+        return {email for email, _context in _get_campaign_recipients(campaign)}
+
+    def test_inactive_audience_selects_only_inactive_customers(self) -> None:
+        self.assertEqual(self._recipient_emails("inactive_customers"), {"inactive@example.com"})
+
+    def test_all_customers_audience_includes_active_and_inactive_customers(self) -> None:
+        self.assertEqual(
+            self._recipient_emails("all_customers"),
+            {"active@example.com", "inactive@example.com"},
+        )
+
+    def test_active_audience_selects_only_active_customers(self) -> None:
+        self.assertEqual(self._recipient_emails("active_customers"), {"active@example.com"})
+
+    def test_unimplemented_trial_expiring_audience_fails_closed(self) -> None:
+        """Never turn an unsupported audience into an accidental broadcast."""
+        self.assertEqual(self._recipient_emails("trial_expiring"), set())


### PR DESCRIPTION
## Summary

- route Requests transport options to the DNS-pinned send path so SES/SNS certificate verification can use its timeout without failing before network I/O
- bound caller timeouts by `OutboundPolicy`, preserve transport settings across validated redirects, and keep TLS/redirect behavior policy-owned
- reject caller proxies because they would bypass the DNS-pinned connection guarantee
- repair `inactive_customers`, `active_customers`, and `all_customers` campaign audience semantics
- fail closed for the declared-but-undefined `trial_expiring` audience and unknown audience values instead of accidentally broadcasting

## Root cause

`safe_request()` forwarded `Session.send()`-only options such as `timeout` into `requests.Request`, which raises `TypeError` before the protected request is sent. The campaign selector also started every audience from an active-only queryset, making the inactive audience impossible and making “all customers” active-only.

## Behavior and safety

- caller timeouts may tighten, but never exceed, policy connect/read limits
- caller `verify` and `allow_redirects` values cannot weaken policy
- redirect hops retain transport settings and are still DNS-resolved and revalidated independently
- caller proxies fail closed instead of bypassing DNS pinning
- Django’s default customer manager continues to exclude soft-deleted rows
- campaign consent filtering is unchanged
- `trial_expiring` remains intentionally unavailable until a real expiry-window rule exists; it now selects nobody rather than all active customers
- no database migration is required

## Testing

- TDD red phase: 5 targeted failures reproduced the two defects and adjacent fail-open audience behavior
- `make test-file FILE='tests.common.test_outbound_http tests.common.test_outbound_http_transport tests.notifications'` — 237 passed
- `make test` — all repository test phases passed
- `make lint` — passed; zero new Ruff violations, MyPy clean
- `make lint-security` — credentials checks passed; Semgrep reports the existing 52-finding repository baseline, with no finding in this patch
- `git diff --check` — passed
- DCO sign-off verified on `a560dc896c0a525e7b8511809eff0821719db16d`

Closes #215
Closes #216