### PR TITLE
fix(infrastructure): guard long-running node deployments and FQDNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Node deployment guardrails** — initial and retry deployments now receive a three-hour worker budget while the ORM broker waits four hours before redelivery, preventing duplicate execution of legitimate long-running installs; web, CLI, and orchestration paths reject missing, malformed, or oversized DNS zones before creating records, consuming retries, changing deployment state, or calling external systems (#362, #365)
 - **Notification delivery and targeting** — requests-compatible transport options now reach the DNS-pinned send path without weakening TLS, redirect, or timeout policy, so SNS certificate verification no longer fails on its timeout override; inactive and all-customer campaign audiences now select what their names promise, while the undefined trial-expiry audience fails closed instead of broadcasting (#215, #216)
 - **VAT quote and evidence integrity** — cart and preflight calculations now use the same customer tax profile and billing country as issued documents, incomplete VAT contexts fail closed, VIES checks retain attributable consultation references and fresh timestamps, expired validations are fully scheduled and drained, and PDF/e-Factura reverse-charge notices share the Article 196 legal basis (#404)
 - **PostgreSQL order billing fixtures** — persistence-reaching order transition tests now use ISO country codes that fit the billing document schema (#315)

--- a/services/platform/apps/infrastructure/deployment_preflight.py
+++ b/services/platform/apps/infrastructure/deployment_preflight.py
@@ -1,0 +1,41 @@
+"""Fail-closed validation for node deployment inputs."""
+
+from __future__ import annotations
+
+from apps.common.types import Err, Ok, Result, validate_domain_name
+
+DNS_ZONE_SETTING_KEY = "node_deployment.dns_default_zone"
+MAX_NODE_HOSTNAME_LENGTH = 23
+MAX_FQDN_LENGTH = 253
+MAX_NODE_DNS_ZONE_LENGTH = MAX_FQDN_LENGTH - MAX_NODE_HOSTNAME_LENGTH - 1
+
+
+def validate_deployment_dns_zone(dns_zone: str) -> Result[str, str]:
+    """Return a normalized DNS zone suitable for constructing node FQDNs."""
+    raw_zone = str(dns_zone or "")
+    normalized_zone = raw_zone.strip().lower()
+    if not normalized_zone:
+        return Err(
+            f"Node deployment requires a fully-qualified hostname; configure {DNS_ZONE_SETTING_KEY} before deploying."
+        )
+    if raw_zone != raw_zone.strip():
+        return Err("Node deployment DNS zone is invalid: surrounding whitespace is not allowed.")
+    if len(normalized_zone) > MAX_NODE_DNS_ZONE_LENGTH:
+        return Err("Node deployment DNS zone is too long for the generated node hostname.")
+
+    result = validate_domain_name(normalized_zone)
+    if result.is_err():
+        return Err(f"Node deployment DNS zone is invalid: {result.unwrap_err()}.")
+    return Ok(str(result.unwrap()))
+
+
+def validate_deployment_fqdn(hostname: str, dns_zone: str) -> Result[str, str]:
+    """Validate and return the canonical FQDN used by Virtualmin and DNS."""
+    zone_result = validate_deployment_dns_zone(dns_zone)
+    if zone_result.is_err():
+        return Err(zone_result.unwrap_err())
+
+    fqdn_result = validate_domain_name(f"{hostname.strip().lower()}.{zone_result.unwrap()}")
+    if fqdn_result.is_err():
+        return Err(f"Node deployment fully-qualified hostname is invalid: {fqdn_result.unwrap_err()}.")
+    return Ok(str(fqdn_result.unwrap()))

--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -33,6 +33,7 @@ from apps.infrastructure.cloud_gateway import (
     ServerCreateResult,
     get_cloud_gateway,
 )
+from apps.infrastructure.deployment_preflight import validate_deployment_fqdn
 from apps.infrastructure.maintenance import resolve_maintenance_playbooks
 from apps.infrastructure.provider_config import (
     run_provider_command,
@@ -133,6 +134,10 @@ class NodeDeploymentService:
         Returns:
             Result with DeploymentResult or error
         """
+        fqdn_result = validate_deployment_fqdn(deployment.hostname, deployment.dns_zone)
+        if fqdn_result.is_err():
+            return Err(fqdn_result.unwrap_err())
+
         start_time = timezone.now()
         stages_completed: list[str] = []
         _cloud_result: ServerCreateResult | None = None  # unused; actual tracking via server_create_result
@@ -843,6 +848,10 @@ class NodeDeploymentService:
         """
         if deployment.status != "failed":
             return Err(f"Can only retry failed deployments, current status: {deployment.status}")
+
+        fqdn_result = validate_deployment_fqdn(deployment.hostname, deployment.dns_zone)
+        if fqdn_result.is_err():
+            return Err(fqdn_result.unwrap_err())
 
         # Increment retry count
         deployment.retry_count += 1

--- a/services/platform/apps/infrastructure/forms.py
+++ b/services/platform/apps/infrastructure/forms.py
@@ -10,6 +10,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
+from apps.infrastructure.deployment_preflight import validate_deployment_dns_zone
 from apps.infrastructure.models import (
     CloudProvider,
     NodeDeployment,
@@ -69,7 +70,8 @@ class NodeDeploymentForm(forms.ModelForm):
             ),
         }
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, dns_zone: str | None = None, **kwargs: Any) -> None:
+        self._dns_zone = dns_zone
         super().__init__(*args, **kwargs)
 
         # Filter to only active providers
@@ -94,6 +96,11 @@ class NodeDeploymentForm(forms.ModelForm):
         provider = cleaned_data.get("provider")
         region = cleaned_data.get("region")
         node_size = cleaned_data.get("node_size")
+
+        if self._dns_zone is not None:
+            zone_result = validate_deployment_dns_zone(self._dns_zone)
+            if zone_result.is_err():
+                raise ValidationError(zone_result.unwrap_err())
 
         # Validate region belongs to selected provider
         if provider and region and region.provider != provider:

--- a/services/platform/apps/infrastructure/management/commands/deploy_node.py
+++ b/services/platform/apps/infrastructure/management/commands/deploy_node.py
@@ -38,6 +38,7 @@ from typing import Any
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
+from apps.infrastructure.deployment_preflight import validate_deployment_dns_zone
 from apps.infrastructure.provider_config import get_provider_token
 
 
@@ -158,6 +159,11 @@ class Command(BaseCommand):
         if not SettingsService.get_setting("node_deployment.enabled", True):
             raise CommandError("Node deployment is disabled in settings.")
 
+        dns_zone = str(SettingsService.get_setting("node_deployment.dns_default_zone", "") or "")
+        zone_result = validate_deployment_dns_zone(dns_zone)
+        if zone_result.is_err():
+            raise CommandError(zone_result.unwrap_err())
+
         # --- Resolve provider ---
         provider = CloudProvider.objects.filter(
             provider_type=options["provider"],
@@ -246,7 +252,7 @@ class Command(BaseCommand):
             # else: save() calls generate_hostname() automatically
 
             # Set DNS zone from settings (same as web UI)
-            deployment.dns_zone = str(SettingsService.get_setting("node_deployment.dns_default_zone", "") or "")
+            deployment.dns_zone = zone_result.unwrap()
 
             deployment.save()
 

--- a/services/platform/apps/infrastructure/tasks.py
+++ b/services/platform/apps/infrastructure/tasks.py
@@ -45,6 +45,10 @@ _INTERMEDIATE_STATUSES = [
 ]
 _DRIFT_SCAN_LOCK_ID = "drift_scan_running"
 _DRIFT_SCAN_LOCK_TIMEOUT = 900  # 15 minutes
+# A complete node deployment may run four 30-minute Ansible stages plus
+# provider provisioning and validation. Keep the worker alive for the full
+# supported pipeline with one hour of margin.
+NODE_DEPLOYMENT_TASK_TIMEOUT_SECONDS = 3 * 60 * 60
 
 
 def deploy_node_task(
@@ -1159,6 +1163,7 @@ def queue_deploy_node(
         user_id,
         task_name=f"deploy_node_{deployment_id}",
         hook="apps.infrastructure.tasks.deployment_complete_hook",
+        timeout=NODE_DEPLOYMENT_TASK_TIMEOUT_SECONDS,
     )
 
     logger.info(f"[Queue] Deployment queued: deployment_id={deployment_id}, task_id={task_id}")
@@ -1225,6 +1230,7 @@ def queue_retry_deployment(
         user_id,
         task_name=f"retry_deployment_{deployment_id}",
         hook="apps.infrastructure.tasks.deployment_complete_hook",
+        timeout=NODE_DEPLOYMENT_TASK_TIMEOUT_SECONDS,
     )
 
     logger.info(f"[Queue] Retry queued: deployment_id={deployment_id}, task_id={task_id}")

--- a/services/platform/apps/infrastructure/views.py
+++ b/services/platform/apps/infrastructure/views.py
@@ -31,6 +31,7 @@ from apps.infrastructure.audit_service import InfrastructureAuditContext, Infras
 from apps.infrastructure.provider_config import get_provider_sync_fn, get_provider_token, store_provider_token
 from apps.settings.services import SettingsService
 
+from .deployment_preflight import validate_deployment_dns_zone
 from .forms import (
     CloudProviderForm,
     DeploymentDestroyForm,
@@ -265,7 +266,13 @@ def deployment_create(request: HttpRequest) -> HttpResponse:
         messages.error(request, _("Node deployment is disabled in settings."))
         return redirect("infrastructure:deployment_list")
 
-    dns_zone = str(SettingsService.get_setting("node_deployment.dns_default_zone", "") or "")
+    raw_dns_zone = str(SettingsService.get_setting("node_deployment.dns_default_zone", "") or "")
+    zone_result = validate_deployment_dns_zone(raw_dns_zone)
+    if zone_result.is_err():
+        messages.error(request, zone_result.unwrap_err())
+        return redirect("infrastructure:deployment_list")
+    dns_zone = zone_result.unwrap()
+
     if request.method == "POST":
         form = NodeDeploymentForm(request.POST, dns_zone=dns_zone)
         if form.is_valid():

--- a/services/platform/apps/infrastructure/views.py
+++ b/services/platform/apps/infrastructure/views.py
@@ -265,8 +265,9 @@ def deployment_create(request: HttpRequest) -> HttpResponse:
         messages.error(request, _("Node deployment is disabled in settings."))
         return redirect("infrastructure:deployment_list")
 
+    dns_zone = str(SettingsService.get_setting("node_deployment.dns_default_zone", "") or "")
     if request.method == "POST":
-        form = NodeDeploymentForm(request.POST)
+        form = NodeDeploymentForm(request.POST, dns_zone=dns_zone)
         if form.is_valid():
             deployment = form.save(commit=False)
             deployment.initiated_by = request.user
@@ -285,7 +286,7 @@ def deployment_create(request: HttpRequest) -> HttpResponse:
                 deployment.hostname = deployment.generate_hostname()
 
                 # Set DNS zone from settings
-                deployment.dns_zone = SettingsService.get_setting("node_deployment.dns_default_zone", "")
+                deployment.dns_zone = dns_zone
 
                 deployment.save()
 
@@ -321,7 +322,7 @@ def deployment_create(request: HttpRequest) -> HttpResponse:
 
             return redirect("infrastructure:deployment_detail", pk=deployment.id)
     else:
-        form = NodeDeploymentForm()
+        form = NodeDeploymentForm(dns_zone=dns_zone)
 
     # Get data for JS
     providers = list(CloudProvider.objects.filter(is_active=True).values("id", "name", "code"))
@@ -360,7 +361,7 @@ def deployment_create(request: HttpRequest) -> HttpResponse:
         "providers_data": providers,
         "regions_data": regions,
         "sizes_data": sizes,
-        "dns_zone": SettingsService.get_setting("node_deployment.dns_default_zone", ""),
+        "dns_zone": dns_zone,
         "form_action": reverse("infrastructure:deployment_create"),
         "cancel_url": reverse("infrastructure:deployment_list"),
     }

--- a/services/platform/config/settings/base.py
+++ b/services/platform/config/settings/base.py
@@ -617,7 +617,9 @@ configure_rate_limiting(globals(), enabled=True)
 Q_CLUSTER_BASE = {
     "name": "praho-cluster",
     "timeout": 300,  # 5 minutes
-    "retry": 1800,  # Must exceed the longest per-task timeout override (drift EXECUTION_TASK_TIMEOUT_SECONDS=1500) or q2 redelivers a still-running task
+    # ORM broker visibility must exceed the longest per-task timeout
+    # (node deployment: 3h), or django-q2 redelivers a still-running task.
+    "retry": 4 * 60 * 60,
     "save_limit": 1000,  # Keep last 1000 task results
     "catch_up": False,  # Don't run missed scheduled tasks
     "orm": "default",  # Use PostgreSQL database backend

--- a/services/platform/tests/infrastructure/test_audit_integration.py
+++ b/services/platform/tests/infrastructure/test_audit_integration.py
@@ -93,6 +93,7 @@ def _create_deployment(
     count = NodeDeployment.objects.count() + 1
     defaults: dict[str, Any] = {
         "hostname": f"test-audit-node-{count}",
+        "dns_zone": "nodes.example.com",
         "environment": "prd",
         "node_type": "sha",
         "node_number": count,

--- a/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
+++ b/services/platform/tests/infrastructure/test_deployment_service_pipeline.py
@@ -23,6 +23,7 @@ from apps.common.types import Err, Ok, Retriability
 from apps.infrastructure.audit_service import InfrastructureAuditContext
 from apps.infrastructure.cloud_gateway import ServerCreateResult
 from apps.infrastructure.deployment_service import NodeDeploymentService
+from apps.infrastructure.forms import NodeDeploymentForm
 from apps.infrastructure.models import (
     CloudProvider,
     NodeDeployment,
@@ -704,6 +705,92 @@ class TestDeployNodeStatusChecks(TestCase):
 
         self.assertTrue(result.is_err())
         self.assertIn("disabled", result.unwrap_err())
+
+
+class TestDeploymentFqdnPreflight(TestCase):
+    """Deployment must fail closed before any mutation when its FQDN is unusable."""
+
+    def test_deploy_rejects_blank_dns_zone_before_state_or_external_mutation(self) -> None:
+        deployment = _create_deployment("pending")
+        deployment.dns_zone = ""
+        deployment.save(update_fields=["dns_zone", "updated_at"])
+        service = _make_service()
+
+        with patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True):
+            result = service.deploy_node(deployment=deployment, credentials={"api_token": "test"})
+
+        self.assertTrue(result.is_err())
+        self.assertIn("node_deployment.dns_default_zone", result.unwrap_err())
+        deployment.refresh_from_db()
+        self.assertEqual(deployment.status, "pending")
+        self.assertFalse(NodeDeploymentLog.objects.filter(deployment=deployment).exists())
+        service._ssh_manager.generate_deployment_key.assert_not_called()
+
+    def test_deploy_rejects_malformed_dns_zone_before_state_transition(self) -> None:
+        deployment = _create_deployment("pending")
+        deployment.dns_zone = "bad..example.com"
+        deployment.save(update_fields=["dns_zone", "updated_at"])
+        service = _make_service()
+
+        with patch("apps.infrastructure.deployment_service.SettingsService.get_setting", return_value=True):
+            result = service.deploy_node(deployment=deployment, credentials={"api_token": "test"})
+
+        self.assertTrue(result.is_err())
+        self.assertIn("DNS zone is invalid", result.unwrap_err())
+        deployment.refresh_from_db()
+        self.assertEqual(deployment.status, "pending")
+
+    def test_retry_rejects_blank_dns_zone_without_consuming_retry(self) -> None:
+        deployment = _create_deployment("failed")
+        deployment.dns_zone = ""
+        deployment.save(update_fields=["dns_zone", "updated_at"])
+        service = _make_service()
+
+        result = service.retry_deployment(deployment=deployment, credentials={"api_token": "test"})
+
+        self.assertTrue(result.is_err())
+        deployment.refresh_from_db()
+        self.assertEqual(deployment.status, "failed")
+        self.assertEqual(deployment.retry_count, 0)
+
+    def test_creation_form_rejects_blank_deployment_zone(self) -> None:
+        deployment = _create_deployment("pending")
+        form = NodeDeploymentForm(
+            data={
+                "environment": deployment.environment,
+                "node_type": deployment.node_type,
+                "provider": deployment.provider_id,
+                "region": deployment.region_id,
+                "node_size": deployment.node_size_id,
+                "panel_type": deployment.panel_type_id,
+                "display_name": "Guarded node",
+                "backup_enabled": True,
+            },
+            dns_zone="",
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("node_deployment.dns_default_zone", str(form.non_field_errors()))
+
+    def test_creation_form_rejects_zone_too_long_for_generated_hostname(self) -> None:
+        deployment = _create_deployment("pending")
+        dns_zone = f"{'a' * 63}.{'b' * 63}.{'c' * 63}.{'d' * 38}"
+        form = NodeDeploymentForm(
+            data={
+                "environment": deployment.environment,
+                "node_type": deployment.node_type,
+                "provider": deployment.provider_id,
+                "region": deployment.region_id,
+                "node_size": deployment.node_size_id,
+                "panel_type": deployment.panel_type_id,
+                "display_name": "Guarded node",
+                "backup_enabled": True,
+            },
+            dns_zone=dns_zone,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("too long", str(form.non_field_errors()))
 
 
 class TestDeployNodeNoApiToken(TestCase):

--- a/services/platform/tests/infrastructure/test_management_commands.py
+++ b/services/platform/tests/infrastructure/test_management_commands.py
@@ -347,6 +347,27 @@ class TestDeployNodeCommand(TestCase):
         finally:
             self._stop_patches(patches)
 
+    def test_missing_dns_zone_fails_before_creating_deployment(self) -> None:
+        """CLI deploys must reject a bare hostname before saving or queueing."""
+        patches = self._patch_deploy_deps()
+        patches["SettingsService"].get_setting.side_effect = (
+            lambda key, default=True: "" if key == "node_deployment.dns_default_zone" else default
+        )
+        try:
+            with self.assertRaises(CommandError) as ctx:
+                call_command(
+                    "deploy_node",
+                    "--provider=hetzner",
+                    "--environment=prd",
+                    "--region=fsn1",
+                    "--size=cpx21",
+                )
+
+            self.assertIn("node_deployment.dns_default_zone", str(ctx.exception))
+            patches["deployment"].save.assert_not_called()
+        finally:
+            self._stop_patches(patches)
+
 
 # ===========================================================================
 # TestManageNodeCommand

--- a/services/platform/tests/infrastructure/test_provider_views.py
+++ b/services/platform/tests/infrastructure/test_provider_views.py
@@ -19,6 +19,7 @@ from django.urls import reverse
 
 import apps.common.credential_vault as vault_module
 from apps.common.credential_vault import EncryptedCredential
+from apps.common.types import Ok
 from apps.infrastructure.models import (
     CloudProvider,
     DriftCheck,
@@ -403,3 +404,84 @@ class TestDeploymentCreateUniqueHostnames(_DeploymentTestMixin, TestCase):
                 node_size=size, region=region, panel_type=panel,
                 hostname="prd-sha-het-de-fsn1-001", node_number=2, status="pending",
             )
+
+
+class TestDeploymentCreateDnsZone(TestCase):
+    """The web deployment boundary must reject or canonicalize its configured DNS zone."""
+
+    def setUp(self) -> None:
+        self.superuser = User.objects.create_superuser(email="admin@test.com", password="testpass123")
+        self.client.force_login(self.superuser)
+        self.url = reverse("infrastructure:deployment_create")
+        self.provider = CloudProvider.objects.create(
+            name="Hetzner",
+            provider_type="hetzner",
+            code="het",
+            is_active=True,
+        )
+        self.region = NodeRegion.objects.create(
+            provider=self.provider,
+            name="Falkenstein",
+            provider_region_id="fsn1",
+            normalized_code="fsn1",
+            country_code="de",
+            city="Falkenstein",
+        )
+        self.size = NodeSize.objects.create(
+            provider=self.provider,
+            name="Small",
+            display_name="2 vCPU / 4GB",
+            provider_type_id="cpx21",
+            vcpus=2,
+            memory_gb=4,
+            disk_gb=40,
+            hourly_cost_eur=Decimal("0.0100"),
+            monthly_cost_eur=Decimal("7.20"),
+        )
+        self.panel = PanelType.objects.create(
+            name="Virtualmin",
+            panel_type="virtualmin",
+            ansible_playbook="virtualmin.yml",
+        )
+
+    @patch("apps.infrastructure.views.queue_deploy_node", return_value="task-123")
+    @patch("apps.infrastructure.views.get_provider_token", return_value=Ok("secret"))
+    @patch("apps.infrastructure.views.SettingsService.get_setting")
+    def test_post_persists_normalized_dns_zone(
+        self,
+        mock_get_setting: MagicMock,
+        _mock_token: MagicMock,
+        _mock_queue: MagicMock,
+    ) -> None:
+        mock_get_setting.side_effect = (
+            lambda key, default=None: "Nodes.Example.COM" if key == "node_deployment.dns_default_zone" else default
+        )
+
+        response = self.client.post(
+            self.url,
+            {
+                "environment": "prd",
+                "node_type": "sha",
+                "provider": self.provider.pk,
+                "region": self.region.pk,
+                "node_size": self.size.pk,
+                "panel_type": self.panel.pk,
+                "display_name": "Normalized node",
+                "backup_enabled": True,
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        deployment = NodeDeployment.objects.get(display_name="Normalized node")
+        self.assertEqual(deployment.dns_zone, "nodes.example.com")
+
+    @patch("apps.infrastructure.views.SettingsService.get_setting")
+    def test_get_rejects_invalid_dns_zone_before_rendering_form(self, mock_get_setting: MagicMock) -> None:
+        mock_get_setting.side_effect = (
+            lambda key, default=None: "" if key == "node_deployment.dns_default_zone" else default
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertRedirects(response, reverse("infrastructure:deployment_list"))
+        self.assertEqual(NodeDeployment.objects.count(), 0)

--- a/services/platform/tests/infrastructure/test_tasks_infrastructure.py
+++ b/services/platform/tests/infrastructure/test_tasks_infrastructure.py
@@ -15,6 +15,7 @@ import inspect
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.conf import settings as django_settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils import timezone
@@ -229,6 +230,7 @@ class TestQueueFunctionsNoCloudflareInPayload(TestCase):
         # Positional args after the function path should be: deployment_id, provider_id, user_id
         positional_args = args[0]
         self.assertEqual(positional_args, ("apps.infrastructure.tasks.deploy_node_task", 1, 2, 3))
+        self.assertGreaterEqual(args.kwargs["timeout"], 3 * 60 * 60)
 
     @patch("django_q.tasks.async_task", return_value="task-123")
     def test_queue_destroy_no_cloudflare_in_args(self, mock_async: MagicMock) -> None:
@@ -243,6 +245,12 @@ class TestQueueFunctionsNoCloudflareInPayload(TestCase):
         args = mock_async.call_args
         positional_args = args[0]
         self.assertEqual(positional_args, ("apps.infrastructure.tasks.retry_deployment_task", 1, 2, 3))
+        self.assertGreaterEqual(args.kwargs["timeout"], 3 * 60 * 60)
+
+    def test_cluster_retry_exceeds_longest_deployment_task(self) -> None:
+        """ORM broker visibility must outlast a legitimate node deployment."""
+        longest_deployment_task = 3 * 60 * 60
+        self.assertGreater(int(django_settings.Q_CLUSTER["retry"]), longest_deployment_task)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- give initial and retry node-deployment jobs an explicit three-hour worker timeout, covering four 30-minute Ansible stages plus provisioning and validation margin
- set the Django-Q2 ORM broker retry/visibility window to four hours so a legitimate running deployment is not redelivered and executed concurrently
- centralize fail-closed deployment DNS/FQDN validation and enforce it in the web form, CLI, initial orchestration, and retry orchestration
- reject missing, malformed, whitespace-padded, and oversized zones before a record is created, deployment state changes, a retry is consumed, or an external system is called
- canonicalize the web setting once and reuse it for form validation, persistence, and display; invalid configuration redirects before presenting an unusable form

Closes #362
Closes #365

## Root cause

Deployment queue helpers inherited the five-minute cluster timeout while a supported deployment can spend up to 30 minutes in each of four Ansible stages. The ORM broker retry window was only 30 minutes, so it could make a still-running deployment visible for a duplicate attempt.

Separately, the default deployment DNS zone was optional at the model/settings boundary. That allowed web or CLI creation to persist a bare hostname, with the failure surfacing only after orchestration reached DNS, Ansible, or Virtualmin.

## Design and safety

- The three-hour task timeout is explicit only on deploy/retry jobs; short tasks retain the five-minute cluster default.
- The four-hour ORM visibility window is deliberately greater than the longest task timeout. A worker process that dies during any task may therefore leave that task locked longer, but active node deployments cannot be redelivered while still running.
- Service-layer validation protects existing records and every caller, while web/CLI validation prevents new invalid records.
- Invalid retries remain failed and do not increment `retry_count`.
- The zone length cap reserves space for the model's 23-character generated hostname within the RFC 253-character FQDN limit.
- No data migration or schema change is required. An existing invalid deployment can be retried after its DNS zone is corrected.

## Verification

- `make test-file FILE=tests.infrastructure.test_deployment_service_pipeline.TestDeploymentFqdnPreflight` — 5 passed
- `make test-file FILE=tests.infrastructure.test_provider_views.TestDeploymentCreateDnsZone` — 2 passed
- `make test-file FILE=tests.infrastructure` — 554 passed
- `make test` — all phases passed (7,577 platform tests plus integration, cache, and security phases)
- `make lint` — passed after the review fix
- staged pre-commit hooks — passed
- `make lint-security` — repository baseline remains 52 Semgrep findings; none are in this patch, and the credentials checks passed
- `git diff --check` / complete branch diff review — passed

## Review follow-up

- Addressed Copilot's web-path normalization finding in `3c5294ea` with bidirectional regression coverage; replied to and resolved the review thread.

## Migration notes

None.