### PR TITLE
fix(provisioning): harden Virtualmin recovery and retry policy

### DIFF
--- a/services/platform/apps/provisioning/service_models.py
+++ b/services/platform/apps/provisioning/service_models.py
@@ -290,6 +290,10 @@ class Server(models.Model):
 class Service(ConcurrentTransitionMixin, models.Model):
     """Customer services (hosting accounts, domains, etc.)"""
 
+    VIRTUALMIN_HOSTING_PLAN_TYPES: ClassVar[frozenset[str]] = frozenset(
+        {"shared_hosting", "vps", "dedicated", "reseller"}
+    )
+
     STATUS_CHOICES: ClassVar[tuple[tuple[str, Any], ...]] = (
         ("pending", _("Pending")),
         ("provisioning", _("Provisioning")),
@@ -504,10 +508,8 @@ class Service(ConcurrentTransitionMixin, models.Model):
 
         Cross-app integration helper for billing → provisioning triggers.
         """
-        # Check if service plan is a hosting type that needs control panel account
-        hosting_plan_types = ["shared_hosting", "vps", "dedicated", "reseller"]
         return (
-            self.service_plan.plan_type in hosting_plan_types
+            self.service_plan.plan_type in self.VIRTUALMIN_HOSTING_PLAN_TYPES
             and self.status in ["active", "provisioning"]
             and bool(self.domain)  # Must have a domain
         )

--- a/services/platform/apps/provisioning/virtualmin_auth_manager.py
+++ b/services/platform/apps/provisioning/virtualmin_auth_manager.py
@@ -33,7 +33,7 @@ from .virtualmin_gateway import (
     resolve_server_credentials,
 )
 from .virtualmin_models import VirtualminServer
-from .virtualmin_validators import VirtualminValidator
+from .virtualmin_validators import VirtualminValidator, is_virtualmin_read_only_program
 
 logger = logging.getLogger(__name__)
 
@@ -185,7 +185,7 @@ class VirtualminAuthenticationManager:
 
         # Determine authentication method to try
         methods_to_try = [force_method] if force_method else self._get_auth_method_priority()
-        is_read_only = program == "info" or program.startswith("list-")
+        is_read_only = is_virtualmin_read_only_program(program)
 
         last_error = ""
         last_retriability = Retriability.UNKNOWN

--- a/services/platform/apps/provisioning/virtualmin_gateway.py
+++ b/services/platform/apps/provisioning/virtualmin_gateway.py
@@ -33,7 +33,7 @@ from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 from apps.settings.services import SettingsService
 
 from .virtualmin_models import VirtualminServer
-from .virtualmin_validators import VirtualminValidator
+from .virtualmin_validators import VirtualminValidator, is_virtualmin_read_only_program
 
 if TYPE_CHECKING:
     from apps.common.credential_vault import CredentialVault
@@ -343,6 +343,61 @@ class VirtualminResponse:
     server_hostname: str
 
 
+_TRANSIENT_APPLICATION_ERROR_PATTERNS = (
+    "rate limit",
+    "too many requests",
+    "server busy",
+    "service unavailable",
+    "temporarily unavailable",
+    "temporary failure",
+    "try again",
+    "overload",
+)
+_PERMANENT_APPLICATION_ERROR_PATTERNS = (
+    "already exists",
+    "does not exist",
+    "forbidden",
+    "invalid",
+    "missing parameter",
+    "not allowed",
+    "not found",
+    "permission denied",
+    "quota exceeded",
+    "unauthorized",
+    "unknown command",
+)
+_TRANSIENT_APPLICATION_ERROR_CODES = frozenset({"429", "500", "502", "503", "504"})
+_PERMANENT_APPLICATION_ERROR_CODES = frozenset({"400", "401", "403", "404", "409", "422"})
+
+
+def classify_virtualmin_application_error(response: VirtualminResponse) -> Retriability:
+    """Classify an explicit command rejection without guessing replay safety.
+
+    Virtualmin's remote API documents an exit-status success/failure envelope,
+    not a stable error-code taxonomy. Recognize only conservative operational
+    signals; an unfamiliar rejection remains UNKNOWN so mutations are not
+    replayed while operators retain honest diagnostics.
+    """
+    code = response.data.get("error_code", response.data.get("code", ""))
+    code_text = str(code).strip()
+    if code_text in _TRANSIENT_APPLICATION_ERROR_CODES:
+        return Retriability.RETRIABLE
+    if code_text in _PERMANENT_APPLICATION_ERROR_CODES:
+        return Retriability.NOT_RETRIABLE
+
+    parts = (
+        response.data.get("error", ""),
+        response.data.get("message", ""),
+        response.data.get("detail", ""),
+    )
+    error_text = " ".join(str(part) for part in parts if part).lower()
+    if any(pattern in error_text for pattern in _TRANSIENT_APPLICATION_ERROR_PATTERNS):
+        return Retriability.RETRIABLE
+    if any(pattern in error_text for pattern in _PERMANENT_APPLICATION_ERROR_PATTERNS):
+        return Retriability.NOT_RETRIABLE
+    return Retriability.UNKNOWN
+
+
 @dataclass(frozen=True)
 class VirtualminConfig:
     """Virtualmin server configuration"""
@@ -532,8 +587,16 @@ class VirtualminResponseParser:
     def _normalize_json_response(data: dict[str, Any]) -> dict[str, Any]:
         """Normalize JSON response to standard format"""
         if isinstance(data, dict):
-            # Check for common success indicators
-            success = data.get("status") == "success" or data.get("success") is True or "error" not in data
+            status = str(data.get("status", "")).strip().lower()
+            success_flag = data.get("success")
+            explicit_failure = (
+                status in {"error", "failed", "failure"} or success_flag is False or bool(data.get("error"))
+            )
+            explicit_success = status == "success" or success_flag is True
+            success = explicit_success if not explicit_failure else False
+            if not explicit_failure and not explicit_success:
+                # Some read APIs return a bare payload without an envelope.
+                success = "error" not in data
 
             return {
                 "success": success,
@@ -776,7 +839,7 @@ class VirtualminGateway:
 
         return Ok(True)
 
-    def call(  # noqa: PLR0911, C901  # Explicit per-stage guard returns (validate/health/rate-limit/auth) + retry loop
+    def call(  # noqa: PLR0911, PLR0912, C901  # Explicit per-stage guards + retry loop
         self,
         program: str,
         params: dict[str, Any] | None = None,
@@ -869,7 +932,7 @@ class VirtualminGateway:
 
         # Make API request with retries
         last_error: VirtualminAPIError | None = None
-        is_read_only = program == "info" or program.startswith("list-")
+        is_read_only = is_virtualmin_read_only_program(program)
         for attempt in range(VIRTUALMIN_MAX_RETRIES):
             try:
                 response = self._make_request(api_params, attempt + 1, auth=call_auth)
@@ -879,9 +942,16 @@ class VirtualminGateway:
                 parsed_data = VirtualminResponseParser.parse_response(response.text, program)
 
                 # Create normalized response
+                response_data = parsed_data.get("data", {})
+                if not isinstance(response_data, dict):
+                    response_data = {"data": response_data}
+                parsed_error = parsed_data.get("error")
+                if parsed_error and not response_data.get("error"):
+                    response_data = {**response_data, "error": str(parsed_error)}
+
                 virtualmin_response = VirtualminResponse(
                     success=parsed_data["success"],
-                    data=parsed_data.get("data", {}),
+                    data=response_data,
                     raw_response=response.text[:10000],  # Limit logged response size
                     http_status=response.status_code,
                     execution_time=execution_time,
@@ -1102,7 +1172,7 @@ class VirtualminGateway:
             else:
                 return Err(
                     f"Failed to get server info: {response.data.get('error', 'Unknown error')}",
-                    retriability=Retriability.NOT_RETRIABLE,
+                    retriability=classify_virtualmin_application_error(response),
                 )
         else:
             return Err(f"API call failed: {result.unwrap_err()}", retriability=retriability_of(result))
@@ -1128,7 +1198,7 @@ class VirtualminGateway:
             else:
                 return Err(
                     f"Failed to list domains: {response.data.get('error', 'Unknown error')}",
-                    retriability=Retriability.NOT_RETRIABLE,
+                    retriability=classify_virtualmin_application_error(response),
                 )
         else:
             return Err(f"API call failed: {result.unwrap_err()}", retriability=retriability_of(result))
@@ -1181,24 +1251,46 @@ class VirtualminGateway:
         """List available server template names (normalized across formats)."""
         result = self.call("list-templates", {"name-only": ""})
         if result.is_err():
-            return Err(f"API call failed: {result.unwrap_err()}")
+            return Err(f"API call failed: {result.unwrap_err()}", retriability=retriability_of(result))
         response = result.unwrap()
         if not response.success:
-            return Err(f"Failed to list templates: {response.data.get('error', 'Unknown error')}")
+            return Err(
+                f"Failed to list templates: {response.data.get('error', 'Unknown error')}",
+                retriability=classify_virtualmin_application_error(response),
+            )
+        return VirtualminGateway._parse_template_names(response.data)
 
-        data = response.data
+    @staticmethod
+    def _parse_template_names(data: dict[str, Any]) -> Result[list[str], str]:
+        """Parse only documented/recognized list-templates response shapes."""
         if "templates" in data:
-            return Ok([t["name"] if isinstance(t, dict) else str(t) for t in data["templates"]])
+            templates = data["templates"]
+            if not isinstance(templates, list):
+                return Err("Template listing returned an unrecognized response shape")
+            return VirtualminGateway._normalize_template_items(templates)
         if "data" in data:
-            names = []
-            for item in data["data"]:
-                if isinstance(item, dict) and "name" in item:
-                    line = item["name"].strip()
-                    if line and not line.startswith(("Template", "---")):
-                        names.append(line.split()[0])
-            return Ok(names)
-        raw = data.get("raw_response", "")
-        return Ok([line.strip() for line in raw.split("\n") if line.strip()])
+            items = data["data"]
+            if not isinstance(items, list):
+                return Err("Template listing returned an unrecognized response shape")
+            return VirtualminGateway._normalize_template_items(items, skip_table_headers=True)
+        if "raw_response" in data:
+            raw = data["raw_response"]
+            if isinstance(raw, str) and raw.strip():
+                return Ok([line.strip() for line in raw.splitlines() if line.strip()])
+        return Err("Template listing returned an unrecognized response shape")
+
+    @staticmethod
+    def _normalize_template_items(items: list[Any], *, skip_table_headers: bool = False) -> Result[list[str], str]:
+        """Normalize template rows without turning malformed rows into absence."""
+        names: list[str] = []
+        for item in items:
+            name = item.get("name") if isinstance(item, dict) else item
+            if not isinstance(name, str) or not name.strip():
+                return Err("Template listing returned an unrecognized response shape")
+            normalized = name.strip()
+            if not skip_table_headers or not normalized.startswith(("Template", "---")):
+                names.append(normalized)
+        return Ok(names)
 
     def ping_server(self) -> bool:
         """Ping server to check connectivity"""
@@ -1223,10 +1315,13 @@ class VirtualminGateway:
         """Full multiline listing normalized to [{'domain', 'username'}] rows."""
         result = self.call("list-domains", {"multiline": ""})
         if result.is_err():
-            return Err(f"Domain listing failed: {result.unwrap_err()}")
+            return Err(f"Domain listing failed: {result.unwrap_err()}", retriability=retriability_of(result))
         response = result.unwrap()
         if not response.success:
-            return Err(f"Domain listing rejected: {response.data.get('error', 'Unknown error')}")
+            return Err(
+                f"Domain listing rejected: {response.data.get('error', 'Unknown error')}",
+                retriability=classify_virtualmin_application_error(response),
+            )
 
         if not isinstance(response.data, dict) or not isinstance(response.data.get("data"), list):
             return Err("Domain listing returned an unrecognized response shape")
@@ -1244,10 +1339,13 @@ class VirtualminGateway:
         """Normalized existence/enabled/owner snapshot for one domain."""
         result = self.call("list-domains", {"domain": domain, "multiline": ""})
         if result.is_err():
-            return Err(f"Domain state probe failed: {result.unwrap_err()}")
+            return Err(f"Domain state probe failed: {result.unwrap_err()}", retriability=retriability_of(result))
         response = result.unwrap()
         if not response.success:
-            return Err(f"Domain state probe rejected: {response.data.get('error', 'Unknown error')}")
+            return Err(
+                f"Domain state probe rejected: {response.data.get('error', 'Unknown error')}",
+                retriability=classify_virtualmin_application_error(response),
+            )
         if not isinstance(response.data, dict) or not isinstance(response.data.get("data"), list):
             return Err(f"Domain state probe returned an unrecognized response shape for {domain}")
 
@@ -1279,10 +1377,13 @@ class VirtualminGateway:
         """
         result = self.call("list-domains", {"domain": domain, "multiline": ""})
         if result.is_err():
-            return Err(f"Ownership probe failed: {result.unwrap_err()}")
+            return Err(f"Ownership probe failed: {result.unwrap_err()}", retriability=retriability_of(result))
         response = result.unwrap()
         if not response.success:
-            return Err(f"Ownership probe rejected: {response.data.get('error', 'Unknown error')}")
+            return Err(
+                f"Ownership probe rejected: {response.data.get('error', 'Unknown error')}",
+                retriability=classify_virtualmin_application_error(response),
+            )
 
         if not isinstance(response.data, dict) or not isinstance(response.data.get("data"), list):
             # Unrecognized shape is NOT proof of absence — treating it as
@@ -1336,7 +1437,7 @@ class VirtualminGateway:
         if not response.success:
             return Err(
                 f"Failed to get disk usage: {response.data.get('error', 'Unknown error')}",
-                retriability=Retriability.NOT_RETRIABLE,
+                retriability=classify_virtualmin_application_error(response),
             )
 
         disk_info = self._parse_multiline_domain_response(response.data)

--- a/services/platform/apps/provisioning/virtualmin_models.py
+++ b/services/platform/apps/provisioning/virtualmin_models.py
@@ -12,7 +12,6 @@ from datetime import timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.urls import reverse
@@ -677,14 +676,18 @@ class VirtualminProvisioningJob(models.Model):
     def recover_expired_claims(cls, cutoff: Any, retry_at: Any) -> int:
         """Return orphaned in-flight jobs to the failed pool so the sweep retries them.
 
-        Two orphan classes, both recovered by age:
+        Three orphan classes, all recovered by age:
         - a leased retry whose claimed_at lease expired; and
         - an INITIAL execution that died mid-run — mark_started() sets
           status='running' and started_at but never claims (claimed_at stays
           NULL), so without the started_at arm a first-execution worker death
           (SIGKILL/OOM/deploy restart) would strand the job in 'running'
-          forever. started_at is only compared for unclaimed rows so a live
-          leased job is never reclaimed on started_at alone.
+          forever; and
+        - a legacy pre-lease pending/running row with neither timestamp, aged
+          by updated_at so a freshly-created initial job keeps its full lease.
+
+        started_at/updated_at are only compared for unclaimed rows so a live
+        leased job is never reclaimed on either timestamp alone.
         """
         return (
             cls.objects.filter(
@@ -692,7 +695,12 @@ class VirtualminProvisioningJob(models.Model):
             )
             .filter(
                 models.Q(claimed_at__isnull=False, claimed_at__lt=cutoff)
-                | models.Q(claimed_at__isnull=True, started_at__isnull=False, started_at__lt=cutoff),
+                | models.Q(claimed_at__isnull=True, started_at__isnull=False, started_at__lt=cutoff)
+                | models.Q(
+                    claimed_at__isnull=True,
+                    started_at__isnull=True,
+                    updated_at__lt=cutoff,
+                ),
             )
             .update(status="failed", next_retry_at=retry_at, claimed_at=None, updated_at=timezone.now())
         )
@@ -799,37 +807,6 @@ class VirtualminProvisioningJob(models.Model):
                 "result",
                 "execution_time_seconds",
                 "next_retry_at",
-                "rollback_executed",
-                "rollback_status",
-                "rollback_details",
-                "updated_at",
-            ]
-        )
-
-    def schedule_retry(self) -> None:
-        """Schedule job for retry"""
-        if not self.can_retry:
-            raise ValidationError(_("Job cannot be retried"))
-
-        self.retry_count += 1
-        self.status = "pending"
-        self.status_message = ""
-        self.started_at = None
-        self.completed_at = None
-        self.execution_time_seconds = None
-        # Reset rollback tracking for new attempt
-        self.rollback_executed = False
-        self.rollback_status = ""
-        self.rollback_details = {}
-
-        self.save(
-            update_fields=[
-                "retry_count",
-                "status",
-                "status_message",
-                "started_at",
-                "completed_at",
-                "execution_time_seconds",
                 "rollback_executed",
                 "rollback_status",
                 "rollback_details",

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -890,6 +890,7 @@ class VirtualminProvisioningService:
             logger.warning(f"🛡️ [VirtualminService] {error_msg}")
             return Err(error_msg)
 
+        idempotency_key: str | None = None
         try:
             # Generate idempotency key for this operation
             idempotency_key = IdempotencyManager.generate_key(
@@ -975,7 +976,7 @@ class VirtualminProvisioningService:
                                 rollback_status="failed",
                                 rollback_details=rollback_details,
                             )
-                            IdempotencyManager.clear(idempotency_key)
+                            _clear_idempotency_key(idempotency_key, operation="delete", domain=account.domain)
 
                             # Try to at least revert server stats
                             try:
@@ -993,21 +994,21 @@ class VirtualminProvisioningService:
                         error_msg = response.data.get("error", "Deletion failed")
                         retriability = classify_virtualmin_application_error(response)
                         job.mark_failed(error_msg, response.data, retriability=retriability)
-                        IdempotencyManager.clear(idempotency_key)
+                        _clear_idempotency_key(idempotency_key, operation="delete", domain=account.domain)
                         return Err(error_msg, retriability=retriability)
 
                 else:
                     error = result.unwrap_err()
                     error_msg = str(error)
                     job.mark_failed(error_msg, retriability=retriability_of(result))
-                    IdempotencyManager.clear(idempotency_key)
+                    _clear_idempotency_key(idempotency_key, operation="delete", domain=account.domain)
                     return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
-                IdempotencyManager.clear(idempotency_key)
                 raise
 
         except Exception as e:
+            _clear_idempotency_key(idempotency_key, operation="delete", domain=account.domain)
             logger.exception(f"Error deleting account {account.domain}: {e}")
             return Err(str(e))
 

--- a/services/platform/apps/provisioning/virtualmin_service.py
+++ b/services/platform/apps/provisioning/virtualmin_service.py
@@ -9,7 +9,6 @@ Implements:
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import secrets
 import string
@@ -26,7 +25,12 @@ from apps.common.types import Err, Ok, Result, Retriability, retriability_of
 
 from .security_utils import IdempotencyManager
 from .virtualmin_backup_service import BackupConfig, RestoreConfig
-from .virtualmin_gateway import VirtualminConfig, VirtualminGateway, get_virtualmin_config
+from .virtualmin_gateway import (
+    VirtualminConfig,
+    VirtualminGateway,
+    classify_virtualmin_application_error,
+    get_virtualmin_config,
+)
 from .virtualmin_models import (
     HEALTH_AUTO_FAIL_THRESHOLD,
     VirtualminAccount,
@@ -45,6 +49,21 @@ logger = logging.getLogger(__name__)
 MIN_USERNAME_LENGTH = 3
 _DEFAULT_MAX_USERNAME_UNIQUENESS_ATTEMPTS = 1000
 MAX_USERNAME_UNIQUENESS_ATTEMPTS = _DEFAULT_MAX_USERNAME_UNIQUENESS_ATTEMPTS
+
+
+def _clear_idempotency_key(idempotency_key: str | None, *, operation: str, domain: str) -> None:
+    """Best-effort cleanup that preserves and exposes the primary failure."""
+    if not idempotency_key:
+        return
+    try:
+        IdempotencyManager.clear(idempotency_key)
+    except Exception:
+        logger.warning(
+            "Failed to clear idempotency key after %s failure for %s; the operation may remain blocked until TTL",
+            operation,
+            domain,
+            exc_info=True,
+        )
 
 
 def get_max_username_uniqueness_attempts() -> int:
@@ -331,8 +350,9 @@ class VirtualminProvisioningService:
 
                 else:
                     error_msg = response.data.get("error", "Domain creation failed")
-                    job.mark_failed(error_msg, response.data, retriability=Retriability.NOT_RETRIABLE)
-                    return Err(error_msg, retriability=Retriability.NOT_RETRIABLE)
+                    retriability = classify_virtualmin_application_error(response)
+                    job.mark_failed(error_msg, response.data, retriability=retriability)
+                    return Err(error_msg, retriability=retriability)
 
             else:
                 error = result.unwrap_err()
@@ -587,6 +607,7 @@ class VirtualminProvisioningService:
             If database update fails after API call succeeds, will attempt
             to re-enable the domain in Virtualmin.
         """
+        idempotency_key: str | None = None
         try:
             # Idempotency check - already suspended
             if account.status == "suspended":
@@ -609,7 +630,7 @@ class VirtualminProvisioningService:
                 if cached_success:
                     # Cached success no longer matches reality (flip-flop inside
                     # the TTL) — self-heal: clear and execute for real.
-                    IdempotencyManager.clear(idempotency_key)
+                    _clear_idempotency_key(idempotency_key, operation="suspend", domain=account.domain)
                     is_new, _ = IdempotencyManager.check_and_set(idempotency_key)
                     if not is_new:
                         return Err("Operation already in progress")
@@ -675,28 +696,27 @@ class VirtualminProvisioningService:
                                 rollback_status=rollback_status,
                                 rollback_details=rollback_details,
                             )
-                            IdempotencyManager.clear(idempotency_key)
+                            _clear_idempotency_key(idempotency_key, operation="suspend", domain=account.domain)
                             return Err(f"Suspension failed during database update: {db_error}")
                     else:
                         error_msg = response.data.get("error", "Suspension failed")
-                        job.mark_failed(error_msg, response.data, retriability=Retriability.NOT_RETRIABLE)
-                        IdempotencyManager.clear(idempotency_key)
-                        return Err(error_msg, retriability=Retriability.NOT_RETRIABLE)
+                        retriability = classify_virtualmin_application_error(response)
+                        job.mark_failed(error_msg, response.data, retriability=retriability)
+                        _clear_idempotency_key(idempotency_key, operation="suspend", domain=account.domain)
+                        return Err(error_msg, retriability=retriability)
 
                 else:
                     error = result.unwrap_err()
                     error_msg = str(error)
                     job.mark_failed(error_msg, retriability=retriability_of(result))
-                    IdempotencyManager.clear(idempotency_key)
+                    _clear_idempotency_key(idempotency_key, operation="suspend", domain=account.domain)
                     return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
-                IdempotencyManager.clear(idempotency_key)
                 raise
 
         except Exception as e:
-            with contextlib.suppress(Exception):
-                IdempotencyManager.clear(idempotency_key)
+            _clear_idempotency_key(idempotency_key, operation="suspend", domain=account.domain)
             logger.exception(f"Error suspending account {account.domain}: {e}")
             return Err(str(e))
 
@@ -719,6 +739,7 @@ class VirtualminProvisioningService:
             If database update fails after API call succeeds, will attempt
             to re-disable the domain in Virtualmin.
         """
+        idempotency_key: str | None = None
         try:
             # Idempotency check - already active
             if account.status == "active":
@@ -739,7 +760,7 @@ class VirtualminProvisioningService:
                     logger.info(f"✅ [VirtualminService] Returning cached unsuspend result for {account.domain}")
                     return Ok(True)
                 if cached_success:
-                    IdempotencyManager.clear(idempotency_key)
+                    _clear_idempotency_key(idempotency_key, operation="unsuspend", domain=account.domain)
                     is_new, _ = IdempotencyManager.check_and_set(idempotency_key)
                     if not is_new:
                         return Err("Operation already in progress")
@@ -807,28 +828,27 @@ class VirtualminProvisioningService:
                                 rollback_status=rollback_status,
                                 rollback_details=rollback_details,
                             )
-                            IdempotencyManager.clear(idempotency_key)
+                            _clear_idempotency_key(idempotency_key, operation="unsuspend", domain=account.domain)
                             return Err(f"Unsuspension failed during database update: {db_error}")
                     else:
                         error_msg = response.data.get("error", "Unsuspension failed")
-                        job.mark_failed(error_msg, response.data, retriability=Retriability.NOT_RETRIABLE)
-                        IdempotencyManager.clear(idempotency_key)
-                        return Err(error_msg, retriability=Retriability.NOT_RETRIABLE)
+                        retriability = classify_virtualmin_application_error(response)
+                        job.mark_failed(error_msg, response.data, retriability=retriability)
+                        _clear_idempotency_key(idempotency_key, operation="unsuspend", domain=account.domain)
+                        return Err(error_msg, retriability=retriability)
 
                 else:
                     error = result.unwrap_err()
                     error_msg = str(error)
                     job.mark_failed(error_msg, retriability=retriability_of(result))
-                    IdempotencyManager.clear(idempotency_key)
+                    _clear_idempotency_key(idempotency_key, operation="unsuspend", domain=account.domain)
                     return Err(error_msg, retriability=retriability_of(result))
 
             except Exception:
-                IdempotencyManager.clear(idempotency_key)
                 raise
 
         except Exception as e:
-            with contextlib.suppress(Exception):
-                IdempotencyManager.clear(idempotency_key)
+            _clear_idempotency_key(idempotency_key, operation="unsuspend", domain=account.domain)
             logger.exception(f"Error unsuspending account {account.domain}: {e}")
             return Err(str(e))
 
@@ -971,9 +991,10 @@ class VirtualminProvisioningService:
 
                     else:
                         error_msg = response.data.get("error", "Deletion failed")
-                        job.mark_failed(error_msg, response.data, retriability=Retriability.NOT_RETRIABLE)
+                        retriability = classify_virtualmin_application_error(response)
+                        job.mark_failed(error_msg, response.data, retriability=retriability)
                         IdempotencyManager.clear(idempotency_key)
-                        return Err(error_msg, retriability=Retriability.NOT_RETRIABLE)
+                        return Err(error_msg, retriability=retriability)
 
                 else:
                     error = result.unwrap_err()
@@ -1112,10 +1133,10 @@ class VirtualminProvisioningService:
 
         response = result.unwrap()
         if not response.success:
-            # A structured application rejection is a proven, permanent failure.
             error_msg = response.data.get("error", f"{program} failed")
-            job.mark_failed(error_msg, response.data, retriability=Retriability.NOT_RETRIABLE)
-            return Err(error_msg, retriability=Retriability.NOT_RETRIABLE)
+            retriability = classify_virtualmin_application_error(response)
+            job.mark_failed(error_msg, response.data, retriability=retriability)
+            return Err(error_msg, retriability=retriability)
 
         previous_status = account.status
         with transaction.atomic():

--- a/services/platform/apps/provisioning/virtualmin_tasks.py
+++ b/services/platform/apps/provisioning/virtualmin_tasks.py
@@ -949,18 +949,34 @@ def reconcile_divergent_services_task() -> dict[str, Any]:
         "service_id", flat=True
     )[:50]:
         divergent_ids.add(str(sid))
+    # (c) active hosting Service whose original on_commit enqueue was lost
+    # before any VirtualminAccount row existed. Apply the hosting predicates
+    # before the safety cap so unrelated services cannot starve this scan.
+    for sid in (
+        Service.objects.filter(
+            status="active",
+            virtualmin_account__isnull=True,
+            service_plan__plan_type__in=Service.VIRTUALMIN_HOSTING_PLAN_TYPES,
+        )
+        .exclude(domain="")
+        .order_by("pk")
+        .values_list("pk", flat=True)[:50]
+    ):
+        divergent_ids.add(str(sid))
 
     queued = 0
+    failed = 0
     for service_id in divergent_ids:
         try:
             reconcile_virtualmin_service_state_async(service_id)
             queued += 1
         except Exception as e:
+            failed += 1
             logger.warning(f"⚠️ [VirtualminTask] Failed to queue divergence reconcile for {service_id}: {e}")
 
     if queued:
         logger.info(f"🔄 [VirtualminTask] Divergence backstop queued {queued} reconciliations")
-    return {"success": True, "queued": queued}
+    return {"success": failed == 0, "queued": queued, "failed": failed}
 
 
 def reconcile_virtualmin_service_state_async(service_id: str) -> str:

--- a/services/platform/apps/provisioning/virtualmin_tasks.py
+++ b/services/platform/apps/provisioning/virtualmin_tasks.py
@@ -970,9 +970,13 @@ def reconcile_divergent_services_task() -> dict[str, Any]:
         try:
             reconcile_virtualmin_service_state_async(service_id)
             queued += 1
-        except Exception as e:
+        except Exception:
             failed += 1
-            logger.warning(f"⚠️ [VirtualminTask] Failed to queue divergence reconcile for {service_id}: {e}")
+            logger.warning(
+                "⚠️ [VirtualminTask] Failed to queue divergence reconcile for %s",
+                service_id,
+                exc_info=True,
+            )
 
     if queued:
         logger.info(f"🔄 [VirtualminTask] Divergence backstop queued {queued} reconciliations")

--- a/services/platform/apps/provisioning/virtualmin_validators.py
+++ b/services/platform/apps/provisioning/virtualmin_validators.py
@@ -25,6 +25,74 @@ MAX_DOMAIN_LENGTH = 253  # RFC 1035 limit
 MIN_USERNAME_LENGTH = 3
 MAX_USERNAME_LENGTH = 32
 
+# Keep replay safety beside the command allowlist. A name prefix is not a
+# capability: future Virtualmin plugins may expose a mutating `list-*` command.
+VIRTUALMIN_ALLOWED_PROGRAMS = frozenset(
+    {
+        "create-domain",
+        "delete-domain",
+        "list-domains",
+        "modify-domain",
+        "enable-domain",
+        "disable-domain",
+        "get-domain",
+        "create-alias",
+        "delete-alias",
+        "list-aliases",
+        "create-subdomain",
+        "delete-subdomain",
+        "list-subdomains",
+        "create-user",
+        "delete-user",
+        "list-users",
+        "modify-user",
+        "create-database",
+        "delete-database",
+        "list-databases",
+        "request-letsencrypt-cert",
+        "install-cert",
+        "list-certs",
+        "create-dns",
+        "delete-dns",
+        "list-dns",
+        "modify-dns",
+        "backup-domain",
+        "restore-domain",
+        "list-backups",
+        "get-template",
+        "list-templates",
+        "list-bandwidth",
+        "list-plans",
+        "get-plan",
+        "info",
+    }
+)
+
+VIRTUALMIN_READ_ONLY_PROGRAMS = frozenset(
+    {
+        "get-domain",
+        "get-plan",
+        "get-template",
+        "info",
+        "list-aliases",
+        "list-backups",
+        "list-bandwidth",
+        "list-certs",
+        "list-databases",
+        "list-dns",
+        "list-domains",
+        "list-plans",
+        "list-subdomains",
+        "list-templates",
+        "list-users",
+    }
+)
+
+
+def is_virtualmin_read_only_program(program: str) -> bool:
+    """Return whether an audited command is safe to replay after ambiguity."""
+    return program in VIRTUALMIN_READ_ONLY_PROGRAMS
+
 
 class VirtualminValidator:
     """
@@ -452,58 +520,7 @@ class VirtualminValidator:
         # XSS/injection check
         SecureInputValidator._check_malicious_patterns(program)
 
-        # Allowed Virtualmin programs (whitelist approach)
-        allowed_programs = {
-            # Domain management
-            "create-domain",
-            "delete-domain",
-            "list-domains",
-            "modify-domain",
-            "enable-domain",
-            "disable-domain",
-            "get-domain",
-            # Alias management
-            "create-alias",
-            "delete-alias",
-            "list-aliases",
-            # Subdomain management
-            "create-subdomain",
-            "delete-subdomain",
-            "list-subdomains",
-            # User management
-            "create-user",
-            "delete-user",
-            "list-users",
-            "modify-user",
-            # Database management
-            "create-database",
-            "delete-database",
-            "list-databases",
-            # SSL management
-            "request-letsencrypt-cert",
-            "install-cert",
-            "list-certs",
-            # DNS management
-            "create-dns",
-            "delete-dns",
-            "list-dns",
-            "modify-dns",
-            # Backup management
-            "backup-domain",
-            "restore-domain",
-            "list-backups",
-            # Template management
-            "get-template",
-            "list-templates",
-            # Monitoring
-            "list-bandwidth",
-            # System info
-            "list-plans",
-            "get-plan",
-            "info",
-        }
-
-        if program not in allowed_programs:
+        if program not in VIRTUALMIN_ALLOWED_PROGRAMS:
             raise ValidationError(_("Program '%(program)s' is not allowed") % {"program": program})
 
         return program

--- a/services/platform/tests/provisioning/test_auth_manager_regressions.py
+++ b/services/platform/tests/provisioning/test_auth_manager_regressions.py
@@ -182,6 +182,32 @@ class ExecuteWithMethodDispatchTests(TestCase):
         self.assertEqual(result.unwrap(), {"domains": []})
         self.assertEqual(execute.call_count, 2)
 
+    def test_list_prefix_does_not_allow_ambiguous_mutation_fallback(self) -> None:
+        ambiguous = Err("response lost", retriability=Retriability.UNKNOWN)
+
+        with (
+            patch(
+                "apps.provisioning.virtualmin_auth_manager.VirtualminValidator.validate_virtualmin_program",
+                return_value="list-and-clean-cache",
+            ),
+            patch.object(
+                self.manager,
+                "_get_auth_method_priority",
+                return_value=[AuthMethod.ACL, AuthMethod.MASTER_PROXY],
+            ),
+            patch.object(
+                self.manager,
+                "_execute_with_method",
+                side_effect=[ambiguous, Ok({"success": True})],
+            ) as execute,
+            patch.object(self.manager, "_cache_failed_auth_method"),
+        ):
+            result = self.manager.execute_virtualmin_command("list-and-clean-cache", {})
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+        execute.assert_called_once()
+
     def test_auth_fallback_stops_after_unexpected_mutation_exception(self) -> None:
         with (
             patch.object(

--- a/services/platform/tests/provisioning/test_provisioning_idempotency_rollback.py
+++ b/services/platform/tests/provisioning/test_provisioning_idempotency_rollback.py
@@ -513,6 +513,23 @@ class DeleteAccountIdempotencyTest(TestCase):
         self.assertTrue(result.is_err())
         self.assertIn("must be terminated or in error state", result.unwrap_err())
 
+    def test_delete_logs_cleanup_failure_without_masking_original_error(self):
+        gateway = MagicMock()
+        gateway.call.side_effect = RuntimeError("Virtualmin request exploded")
+        service = VirtualminProvisioningService(self.server)
+
+        with (
+            patch.object(service, "_get_gateway", return_value=gateway),
+            patch.object(IdempotencyManager, "check_and_set", return_value=(True, None)),
+            patch.object(IdempotencyManager, "clear", side_effect=RuntimeError("cache cleanup failed")),
+            self.assertLogs("apps.provisioning.virtualmin_service", level="WARNING") as logs,
+        ):
+            result = service.delete_account(self.account)
+
+        self.assertTrue(result.is_err())
+        self.assertIn("Virtualmin request exploded", str(result.unwrap_err()))
+        self.assertTrue(any("Failed to clear idempotency key" in line for line in logs.output))
+
 
 class RollbackMechanismTest(TestCase):
     """Test rollback mechanisms using MockVirtualminGateway for realistic API simulation."""

--- a/services/platform/tests/provisioning/test_provisioning_idempotency_rollback.py
+++ b/services/platform/tests/provisioning/test_provisioning_idempotency_rollback.py
@@ -11,7 +11,7 @@ Comprehensive tests for Virtualmin provisioning idempotency and rollback mechani
 """
 
 from decimal import Decimal
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone
@@ -254,31 +254,6 @@ class VirtualminProvisioningJobRollbackTest(TestCase):
         self.assertEqual(job.rollback_status, "partial")
         self.assertEqual(job.rollback_details["failed_operations"], 1)
 
-    def test_schedule_retry_clears_rollback(self):
-        """Test that schedule_retry clears rollback status"""
-        job = VirtualminProvisioningJob.objects.create(
-            operation="suspend_domain",
-            server=self.server,
-            correlation_id="test-126",
-            max_retries=3,
-        )
-        job.mark_started()
-        job.mark_failed(
-            "Error",
-            rollback_executed=True,
-            rollback_status="success",
-            rollback_details={"test": "data"},
-        )
-
-        job.schedule_retry()
-
-        job.refresh_from_db()
-        self.assertEqual(job.status, "pending")
-        self.assertFalse(job.rollback_executed)
-        self.assertEqual(job.rollback_status, "")
-        self.assertEqual(job.rollback_details, {})
-
-
 class SuspendAccountIdempotencyTest(TestCase):
     """Test suspend_account idempotency"""
 
@@ -354,6 +329,23 @@ class SuspendAccountIdempotencyTest(TestCase):
         self.assertTrue(result.is_err())
         self.assertIn("already in progress", result.unwrap_err())
 
+    def test_suspend_logs_cleanup_failure_without_masking_original_error(self):
+        gateway = MagicMock()
+        gateway.call.side_effect = RuntimeError("Virtualmin request exploded")
+        service = VirtualminProvisioningService(self.server)
+
+        with (
+            patch.object(service, "_get_gateway", return_value=gateway),
+            patch.object(IdempotencyManager, "check_and_set", return_value=(True, None)),
+            patch.object(IdempotencyManager, "clear", side_effect=RuntimeError("cache cleanup failed")),
+            self.assertLogs("apps.provisioning.virtualmin_service", level="WARNING") as logs,
+        ):
+            result = service.suspend_account(self.account, "Test reason")
+
+        self.assertTrue(result.is_err())
+        self.assertIn("Virtualmin request exploded", str(result.unwrap_err()))
+        self.assertTrue(any("Failed to clear idempotency key" in line for line in logs.output))
+
 
 class UnsuspendAccountIdempotencyTest(TestCase):
     """Test unsuspend_account idempotency"""
@@ -416,6 +408,23 @@ class UnsuspendAccountIdempotencyTest(TestCase):
         self.assertTrue(result.is_ok())
         self.account.refresh_from_db()
         self.assertEqual(self.account.status, "active")
+
+    def test_unsuspend_logs_cleanup_failure_without_masking_original_error(self):
+        gateway = MagicMock()
+        gateway.call.side_effect = RuntimeError("Virtualmin request exploded")
+        service = VirtualminProvisioningService(self.server)
+
+        with (
+            patch.object(service, "_get_gateway", return_value=gateway),
+            patch.object(IdempotencyManager, "check_and_set", return_value=(True, None)),
+            patch.object(IdempotencyManager, "clear", side_effect=RuntimeError("cache cleanup failed")),
+            self.assertLogs("apps.provisioning.virtualmin_service", level="WARNING") as logs,
+        ):
+            result = service.unsuspend_account(self.account)
+
+        self.assertTrue(result.is_err())
+        self.assertIn("Virtualmin request exploded", str(result.unwrap_err()))
+        self.assertTrue(any("Failed to clear idempotency key" in line for line in logs.output))
 
 
 class DeleteAccountIdempotencyTest(TestCase):

--- a/services/platform/tests/provisioning/test_virtualmin_gateway_followups.py
+++ b/services/platform/tests/provisioning/test_virtualmin_gateway_followups.py
@@ -1,0 +1,106 @@
+"""Regression tests for Virtualmin response honesty and retry policy."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from apps.common.types import Err, Ok, Retriability
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminGateway,
+    VirtualminResponse,
+    classify_virtualmin_application_error,
+)
+from apps.provisioning.virtualmin_validators import (
+    VIRTUALMIN_ALLOWED_PROGRAMS,
+    VIRTUALMIN_READ_ONLY_PROGRAMS,
+    is_virtualmin_read_only_program,
+)
+
+
+def _response(data: dict, *, success: bool = False) -> VirtualminResponse:
+    return VirtualminResponse(
+        success=success,
+        data=data,
+        raw_response="",
+        http_status=200,
+        execution_time=0.01,
+        program="list-templates",
+        server_hostname="vm.example.com",
+    )
+
+
+class VirtualminApplicationFailurePolicyTests(SimpleTestCase):
+    def test_rate_limit_rejection_is_retriable(self) -> None:
+        response = _response({"error": "Rate limit exceeded, try again later"})
+
+        self.assertEqual(classify_virtualmin_application_error(response), Retriability.RETRIABLE)
+
+    def test_proven_validation_rejection_is_terminal(self) -> None:
+        response = _response({"error": "Invalid domain name specified"})
+
+        self.assertEqual(classify_virtualmin_application_error(response), Retriability.NOT_RETRIABLE)
+
+    def test_unknown_application_failure_stays_unknown(self) -> None:
+        response = _response({"error": "Operation failed"})
+
+        self.assertEqual(classify_virtualmin_application_error(response), Retriability.UNKNOWN)
+
+
+class VirtualminReadOnlyPolicyTests(SimpleTestCase):
+    def test_known_query_is_read_only(self) -> None:
+        self.assertTrue(is_virtualmin_read_only_program("list-domains"))
+
+    def test_prefix_alone_never_makes_program_read_only(self) -> None:
+        self.assertFalse(is_virtualmin_read_only_program("list-and-clean-cache"))
+
+    def test_every_read_only_program_is_an_allowed_program(self) -> None:
+        self.assertLessEqual(VIRTUALMIN_READ_ONLY_PROGRAMS, VIRTUALMIN_ALLOWED_PROGRAMS)
+
+
+class VirtualminTemplateParsingTests(SimpleTestCase):
+    def _gateway_with(self, result):
+        gateway = MagicMock(spec=VirtualminGateway)
+        gateway.call.return_value = result
+        return gateway
+
+    def test_name_only_table_preserves_multi_word_template_name(self) -> None:
+        gateway = self._gateway_with(Ok(_response({"data": [{"name": "Premium Hosting"}]}, success=True)))
+
+        result = VirtualminGateway.list_templates(gateway)
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), ["Premium Hosting"])
+
+    def test_unrecognized_response_shape_is_error(self) -> None:
+        gateway = self._gateway_with(Ok(_response({}, success=True)))
+
+        result = VirtualminGateway.list_templates(gateway)
+
+        self.assertTrue(result.is_err())
+        self.assertIn("unrecognized", str(result.unwrap_err()).lower())
+
+    def test_explicit_empty_template_collection_is_valid(self) -> None:
+        gateway = self._gateway_with(Ok(_response({"templates": []}, success=True)))
+
+        result = VirtualminGateway.list_templates(gateway)
+
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), [])
+
+    def test_template_object_without_name_is_an_error(self) -> None:
+        gateway = self._gateway_with(Ok(_response({"templates": [{"id": 7}]}, success=True)))
+
+        result = VirtualminGateway.list_templates(gateway)
+
+        self.assertTrue(result.is_err())
+        self.assertIn("unrecognized", str(result.unwrap_err()).lower())
+
+    def test_transport_retriability_is_preserved(self) -> None:
+        gateway = self._gateway_with(Err("temporarily unavailable", retriability=Retriability.RETRIABLE))
+
+        result = VirtualminGateway.list_templates(gateway)
+
+        self.assertTrue(result.is_err())
+        self.assertEqual(result.retriability, Retriability.RETRIABLE)

--- a/services/platform/tests/provisioning/test_virtualmin_retry_contract.py
+++ b/services/platform/tests/provisioning/test_virtualmin_retry_contract.py
@@ -11,7 +11,11 @@ from django.test import SimpleTestCase
 
 from apps.common.outbound_http import OutboundSecurityError
 from apps.common.types import Err, Retriability
-from apps.provisioning.virtualmin_gateway import VirtualminConfig, VirtualminGateway
+from apps.provisioning.virtualmin_gateway import (
+    VirtualminConfig,
+    VirtualminGateway,
+    classify_virtualmin_application_error,
+)
 from apps.provisioning.virtualmin_models import VirtualminServer
 
 
@@ -120,6 +124,73 @@ class VirtualminRetryContractTests(SimpleTestCase):
         self.assertIsInstance(result, Err)
         self.assertEqual(result.retriability, Retriability.UNKNOWN)
         self.assertEqual(request_mock.call_count, 3)
+
+    def test_list_prefix_does_not_make_unknown_program_replay_safe(self) -> None:
+        """A future/plugin mutation named list-* must not inherit read-only
+        replay semantics merely from its spelling."""
+        gateway = _gateway()
+
+        with (
+            patch(
+                "apps.provisioning.virtualmin_gateway.VirtualminValidator.validate_virtualmin_program",
+                return_value="list-and-clean-cache",
+            ),
+            patch.object(gateway, "_check_rate_limit", return_value=True),
+            patch.object(
+                gateway,
+                "_execute_http_request",
+                side_effect=requests.exceptions.ReadTimeout("response lost"),
+            ) as request_mock,
+            patch("apps.provisioning.virtualmin_gateway.time.sleep"),
+        ):
+            result = gateway.call("list-and-clean-cache")
+
+        self.assertIsInstance(result, Err)
+        self.assertEqual(result.retriability, Retriability.UNKNOWN)
+        request_mock.assert_called_once()
+
+    def test_text_application_error_survives_normalization_for_classification(self) -> None:
+        """The plain-text API format stores its error outside `data`; the
+        normalized response must retain it for downstream retry policy."""
+        gateway = _gateway()
+        response = _response(200)
+        response._content = b"Error: Service temporarily unavailable, try again later"
+
+        with (
+            patch.object(gateway, "_check_rate_limit", return_value=True),
+            patch.object(gateway, "_execute_http_request", return_value=response),
+        ):
+            result = gateway.call("create-domain", {"domain": "example.com"})
+
+        self.assertTrue(result.is_ok())
+        application_response = result.unwrap()
+        self.assertFalse(application_response.success)
+        self.assertIn("temporarily unavailable", application_response.data["error"])
+        self.assertEqual(
+            classify_virtualmin_application_error(application_response),
+            Retriability.RETRIABLE,
+        )
+
+    def test_explicit_json_failure_without_error_key_is_not_success(self) -> None:
+        """An explicit failure status wins even when Virtualmin provides only
+        a message; otherwise the application classifier is bypassed."""
+        gateway = _gateway()
+        response = _response(200)
+        response._content = b'{"status":"failure","message":"Service temporarily unavailable"}'
+
+        with (
+            patch.object(gateway, "_check_rate_limit", return_value=True),
+            patch.object(gateway, "_execute_http_request", return_value=response),
+        ):
+            result = gateway.call("create-domain", {"domain": "example.com"})
+
+        self.assertTrue(result.is_ok())
+        application_response = result.unwrap()
+        self.assertFalse(application_response.success)
+        self.assertEqual(
+            classify_virtualmin_application_error(application_response),
+            Retriability.RETRIABLE,
+        )
 
     def test_client_error_is_not_retried(self) -> None:
         gateway = _gateway()

--- a/services/platform/tests/provisioning/test_virtualmin_tasks.py
+++ b/services/platform/tests/provisioning/test_virtualmin_tasks.py
@@ -25,7 +25,7 @@ from apps.customers.models import Customer
 from apps.provisioning.models import Service, ServicePlan
 from apps.provisioning.signals import handle_service_virtualmin_reconciliation
 from apps.provisioning.tasks import queue_service_provisioning
-from apps.provisioning.virtualmin_gateway import VirtualminConfig, VirtualminGateway
+from apps.provisioning.virtualmin_gateway import VirtualminConfig, VirtualminGateway, VirtualminResponse
 from apps.provisioning.virtualmin_models import (
     VirtualminAccount,
     VirtualminDriftRecord,
@@ -725,6 +725,42 @@ class TestReviewHardening325(VirtualminTaskTestBase):
         job.refresh_from_db()
         self.assertEqual(job.status, "failed")
 
+    def test_aged_legacy_pending_job_without_lease_or_start_is_recovered(self):
+        """Pre-lease pending rows have neither claimed_at nor started_at.
+        Once older than the lease, they are abandoned work and must re-enter
+        the failed pool instead of remaining invisible forever."""
+        job = self._failed_job(
+            status="pending",
+            claimed_at=None,
+            started_at=None,
+            next_retry_at=None,
+        )
+        stale_at = timezone.now() - timedelta(minutes=31)
+        VirtualminProvisioningJob.objects.filter(pk=job.pk).update(updated_at=stale_at)
+
+        recovered = VirtualminProvisioningJob.recover_expired_claims(
+            timezone.now() - timedelta(minutes=30), timezone.now() + timedelta(minutes=5)
+        )
+
+        self.assertEqual(recovered, 1)
+        job.refresh_from_db()
+        self.assertEqual(job.status, "failed")
+        self.assertIsNotNone(job.next_retry_at)
+
+    def test_fresh_unclaimed_pending_job_is_not_recovered(self):
+        """A newly-created initial job may briefly be pending before the
+        worker calls mark_started; the legacy backstop must honor the lease
+        window and not steal live work."""
+        job = self._failed_job(status="pending", claimed_at=None, started_at=None)
+
+        recovered = VirtualminProvisioningJob.recover_expired_claims(
+            timezone.now() - timedelta(minutes=30), timezone.now() + timedelta(minutes=5)
+        )
+
+        self.assertEqual(recovered, 0)
+        job.refresh_from_db()
+        self.assertEqual(job.status, "pending")
+
     def test_exhausted_job_opts_out_of_future_sweeps(self):
         job = self._failed_job(retry_count=3, max_retries=3)
 
@@ -762,6 +798,39 @@ class TestReviewHardening325(VirtualminTaskTestBase):
         self.assertFalse(result["success"])
         job.refresh_from_db()
         self.assertEqual(job.status, "failed")
+        self.assertIsNotNone(job.next_retry_at)
+
+    def test_lifecycle_retry_arms_next_retry_on_application_rate_limit(self):
+        """HTTP 200 can still carry a rejected Virtualmin command. An explicit
+        application-level rate limit must retain retry eligibility."""
+        self.account.status = "active"
+        self.account.save(update_fields=["status"])
+        force_status(self.service, "suspended")
+        job = self._failed_job(
+            operation="suspend_domain",
+            status="pending",
+            retry_count=1,
+            claimed_at=timezone.now(),
+        )
+        gateway = MagicMock()
+        gateway.call.return_value = Ok(
+            VirtualminResponse(
+                success=False,
+                data={"error": "Rate limit exceeded, try again later"},
+                raw_response='{"status":"failure"}',
+                http_status=200,
+                execution_time=0.01,
+                program="disable-domain",
+                server_hostname=self.server.hostname,
+            )
+        )
+
+        with patch("apps.provisioning.virtualmin_service.VirtualminGateway", return_value=gateway):
+            result = retry_virtualmin_job(str(job.id))
+
+        self.assertFalse(result["success"])
+        job.refresh_from_db()
+        self.assertEqual(job.result["retriability"], Retriability.RETRIABLE.value)
         self.assertIsNotNone(job.next_retry_at)
 
     def test_stale_unsuspend_job_is_superseded_by_current_state(self):
@@ -979,6 +1048,91 @@ class TestAtoZReviewFixes(VirtualminTaskTestBase):
         result = reconcile_divergent_services_task()
 
         self.assertEqual(result["queued"], 1)
+        mock_reconcile.assert_called_once_with(str(self.service.id))
+
+    @patch("apps.provisioning.virtualmin_tasks.reconcile_virtualmin_service_state_async", return_value="t-1")
+    def test_divergence_backstop_requeues_active_hosting_service_without_account(self, mock_reconcile):
+        """A broker outage can lose the original on_commit enqueue before a
+        VirtualminAccount exists; the periodic scan must discover the Service
+        row itself, not only account-state divergence."""
+        unprovisioned = Service.objects.create(
+            customer=self.customer,
+            service_plan=self.plan,
+            currency=self.currency,
+            service_name="lost.example.com",
+            domain="lost.example.com",
+            username="lostuser",
+            billing_cycle="monthly",
+            price=Decimal("10.00"),
+            status="active",
+        )
+
+        result = reconcile_divergent_services_task()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["queued"], 1)
+        mock_reconcile.assert_called_once_with(str(unprovisioned.id))
+
+    @patch("apps.provisioning.virtualmin_tasks.reconcile_virtualmin_service_state_async", return_value="t-1")
+    def test_non_hosting_services_cannot_starve_missing_account_scan(self, mock_reconcile):
+        """The 50-row safety cap belongs after the hosting predicates; a busy
+        deployment may have many active domain/SSL services that must not hide
+        a recoverable hosting service forever."""
+        domain_plan = ServicePlan.objects.create(
+            name="Domain only",
+            plan_type="domain",
+            price_monthly=Decimal("1.00"),
+        )
+        Service.objects.bulk_create(
+            [
+                Service(
+                    customer=self.customer,
+                    service_plan=domain_plan,
+                    currency=self.currency,
+                    service_name=f"domain-{index}.example",
+                    domain=f"domain-{index}.example",
+                    username=f"domain{index}",
+                    billing_cycle="annual",
+                    price=Decimal("1.00"),
+                    status="active",
+                )
+                for index in range(50)
+            ]
+        )
+        unprovisioned = Service.objects.create(
+            customer=self.customer,
+            service_plan=self.plan,
+            currency=self.currency,
+            service_name="recover-me.example.com",
+            domain="recover-me.example.com",
+            username="recoverme",
+            billing_cycle="monthly",
+            price=Decimal("10.00"),
+            status="active",
+        )
+
+        result = reconcile_divergent_services_task()
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["queued"], 1)
+        mock_reconcile.assert_called_once_with(str(unprovisioned.id))
+
+    @patch(
+        "apps.provisioning.virtualmin_tasks.reconcile_virtualmin_service_state_async",
+        side_effect=RuntimeError("broker unavailable"),
+    )
+    def test_divergence_backstop_reports_enqueue_failures(self, mock_reconcile):
+        """A failed broker enqueue is an unhealthy scan result, never the
+        same success payload as a clean scan with no divergence."""
+        self.account.status = "active"
+        self.account.save(update_fields=["status"])
+        force_status(self.service, "suspended")
+
+        result = reconcile_divergent_services_task()
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["queued"], 0)
+        self.assertEqual(result["failed"], 1)
         mock_reconcile.assert_called_once_with(str(self.service.id))
 
     @patch("apps.provisioning.virtualmin_tasks.reconcile_virtualmin_service_state_async", return_value="t-1")

--- a/services/platform/tests/provisioning/test_virtualmin_tasks.py
+++ b/services/platform/tests/provisioning/test_virtualmin_tasks.py
@@ -1128,12 +1128,14 @@ class TestAtoZReviewFixes(VirtualminTaskTestBase):
         self.account.save(update_fields=["status"])
         force_status(self.service, "suspended")
 
-        result = reconcile_divergent_services_task()
+        with patch("apps.provisioning.virtualmin_tasks.logger") as mock_logger:
+            result = reconcile_divergent_services_task()
 
         self.assertFalse(result["success"])
         self.assertEqual(result["queued"], 0)
         self.assertEqual(result["failed"], 1)
         mock_reconcile.assert_called_once_with(str(self.service.id))
+        self.assertTrue(mock_logger.warning.call_args.kwargs["exc_info"])
 
     @patch("apps.provisioning.virtualmin_tasks.reconcile_virtualmin_service_state_async", return_value="t-1")
     def test_raw_fixture_load_does_not_trigger_reconciliation(self, mock_reconcile):


### PR DESCRIPTION
## Summary

- add a durable reconciliation backstop for active hosting services whose initial enqueue was lost before a `VirtualminAccount` existed, with hosting predicates applied before the batch cap
- recover aged legacy pending/running jobs that predate the lease timestamps while preserving the full lease window for fresh work
- report broker enqueue failures honestly and warn when idempotency cleanup fails without masking the primary suspend, unsuspend, or delete error
- replace `list-*` prefix-based replay safety with one explicit, audited read-only command allowlist shared by the gateway and authentication fallback
- classify explicit Virtualmin application rejections conservatively: known transient overload/rate-limit failures retry, proven permanent failures stop, unknown failures remain unknown
- normalize explicit JSON/text failure envelopes correctly and preserve retriability through gateway/service wrappers and lifecycle retries
- make template discovery fail honestly on malformed shapes, preserve multi-word names, and remove the unused `schedule_retry()` path

## Design and review notes

Virtualmin documents a success/failure response envelope but not a stable public application error-code taxonomy, so this intentionally uses a small conservative code/text classifier and fails to `UNKNOWN` rather than guessing that a mutation is replay-safe. The read-only policy is an exact allowlist; command spelling alone never grants replay safety.

The lease-margin/counter-drift observation in #338 did not warrant a speculative counter change: no drift evidence was found, and the issue itself conditions that follow-up on observed drift. This PR instead implements the confirmed recovery and observability defects.

No schema migration is required.

References:
- https://www.virtualmin.com/docs/development/remote-api/
- https://www.virtualmin.com/docs/development/api-programs/list-templates/

## Test-driven verification

- `make test-file FILE=tests.provisioning` — 432 passed on final HEAD
- `make lint` — Ruff, MyPy, Django checks, audit/i18n/code-health/FSM/architecture gates passed on final HEAD
- `make test` — complete platform, portal, integration, and security-isolation pipeline passed after rebasing onto current master (7,715 platform tests discovered)
- pre-commit hooks passed for both commits
- post-rebase merge audit found no file overlap with the intervening master commit
- DCO sign-offs verified on both commits
- GitHub DCO, platform, Bandit, lint/security, service-isolation, cache, and integration checks passed on final HEAD
- Copilot reviewed all 12 files; both actionable comments were fixed with regression tests, answered, and resolved

Closes #338
Closes #340