### PR TITLE
fix(infrastructure): atomic unowned DNS check + provider-unavailable orphan marker (#347)

### DIFF
--- a/services/platform/apps/infrastructure/deployment_service.py
+++ b/services/platform/apps/infrastructure/deployment_service.py
@@ -1536,7 +1536,12 @@ class NodeDeploymentService:
         try:
             gateway = get_dns_gateway("cloudflare", token)
         except ValueError as exc:
-            logger.warning(f"[Deployment:{deployment.hostname}] DNS teardown: provider unavailable: {exc}")
+            NodeDeploymentLog.objects.create(
+                deployment=deployment,
+                level="WARNING",
+                message=f"DNS teardown skipped (provider unavailable: {exc}); {len(entries)} record(s) may be orphaned",
+                phase="destroy",
+            )
             return
 
         remaining: list[dict[str, Any]] = []

--- a/services/platform/apps/infrastructure/dns_gateway.py
+++ b/services/platform/apps/infrastructure/dns_gateway.py
@@ -280,16 +280,17 @@ class CloudflareDnsGateway(DnsProviderGateway):
             return outcome
         existing: list[dict[str, Any]] = env.unwrap() or []
 
+        # Fail closed atomically: if ANY desired record type collides with an unowned record,
+        # refuse to mutate anything — never leave a half-configured record set (Copilot).
+        for spec in specs:
+            if any(r.get("type") == spec.record_type and r.get("comment") != owner_tag for r in existing):
+                outcome.error = f"unowned {spec.record_type} record exists for {name}; refusing to manage"
+                return outcome
+
         delete_failures: list[str] = []
         try:
             for spec in specs:
-                same = [r for r in existing if r.get("type") == spec.record_type]
-                unowned = [r for r in same if r.get("comment") != owner_tag]
-                owned = [r for r in same if r.get("comment") == owner_tag]
-                if unowned:
-                    # Never touch a record we do not own (operator-managed) — fail closed.
-                    outcome.error = f"unowned {spec.record_type} record exists for {name}; refusing to manage"
-                    continue
+                owned = [r for r in existing if r.get("type") == spec.record_type and r.get("comment") == owner_tag]
                 if not owned:
                     res = self._create(zone_id, spec)
                 else:

--- a/services/platform/apps/infrastructure/tests/test_dns_gateway.py
+++ b/services/platform/apps/infrastructure/tests/test_dns_gateway.py
@@ -224,6 +224,20 @@ class ReconcileRecordsTests(SimpleTestCase):
         self.assertIn("op1", fake.store)
         self.assertEqual(fake.store["op1"]["content"], "198.51.100.9")
 
+    def test_unowned_conflict_blocks_all_mutations(self) -> None:
+        # An unowned A must block the ENTIRE reconcile atomically — the AAAA must NOT be
+        # created either, so we never leave a half-configured record set (Copilot).
+        fake = FakeCloudflare(
+            [{"id": "op", "type": "A", "name": _FQDN, "content": "198.51.100.9", "comment": "operator-manual"}]
+        )
+        with patch("apps.infrastructure.dns_gateway.safe_request", fake):
+            out = self._gw().reconcile_records(
+                _ZONE, [_spec("A", "203.0.113.10"), _spec("AAAA", "2001:db8::1")], _OWNER
+            )
+        self.assertIsNotNone(out.error)
+        self.assertEqual(fake.n_posts(), 0)  # neither A nor AAAA created
+        self.assertEqual(out.applied, [])
+
     def test_partial_failure_returns_applied_a_before_failing_aaaa(self) -> None:
         # A succeeds, AAAA POST fails → applied carries A so it is not leaked.
         fake = FakeCloudflare(post_fail_types={"AAAA"})

--- a/services/platform/tests/infrastructure/test_deployment_dns.py
+++ b/services/platform/tests/infrastructure/test_deployment_dns.py
@@ -138,6 +138,16 @@ class DeleteOwnedDnsTests(TestCase):
             NodeDeploymentLog.objects.filter(deployment=dep, message__icontains="orphan").exists()
         )
 
+    def test_provider_unavailable_writes_orphan_marker(self) -> None:
+        # If the DNS provider can't be built, teardown must still record a durable orphan
+        # marker (not just log) so the records remain discoverable for reconciliation (Copilot).
+        dep = _create_deployment("completed")
+        dep.dns_record_ids = [_entry()]
+        dep.save()
+        with patch(_DNS_GW, side_effect=ValueError("unknown provider")), patch(_GET_SETTING, return_value="tok"):
+            NodeDeploymentService._delete_owned_dns(dep)
+        self.assertTrue(NodeDeploymentLog.objects.filter(deployment=dep, message__icontains="orphan").exists())
+
     def test_no_entries_is_noop(self) -> None:
         dep = _create_deployment("completed")  # dns_record_ids defaults to []
         gw = MagicMock()


### PR DESCRIPTION
Two follow-up hardening tweaks from the #438 review, on top of #347 GAP 3:

- **Atomic unowned check** — `reconcile_records` pre-scans all desired records for an unowned collision *before* any mutation, so an operator-owned A record can no longer let a competing AAAA be created (a half-configured set). Fails closed atomically. Covered by `test_unowned_conflict_blocks_all_mutations`.
- **Provider-unavailable orphan marker** — `_delete_owned_dns` writes a durable orphan marker when the DNS provider can't be built (matching the missing-token path), so records stay discoverable for reconciliation. Covered by `test_provider_unavailable_writes_orphan_marker`.

No migration. Full affected suites green (dns_gateway 18, deployment_dns 14).