### PR TITLE
fix(ui): harden delegated action registry dispatch

### DIFF
--- a/services/portal/static/js/csp-actions.js
+++ b/services/portal/static/js/csp-actions.js
@@ -39,7 +39,16 @@
       case "navigate": {
         var href = el.dataset.href;
         if (href) {
-          window.location.href = href;
+          try {
+            var url = new URL(href, window.location.origin);
+            if (url.origin !== window.location.origin) {
+              console.warn("Blocked cross-origin navigation:", href);
+              break;
+            }
+            window.location.href = url.href;
+          } catch (err) {
+            console.warn("Blocked malformed navigation URL:", href, err);
+          }
         }
         break;
       }
@@ -69,10 +78,14 @@
         navigator.clipboard.writeText(value).then(function () {
           var feedback = el.dataset.copyFeedback;
           if (feedback) {
-            var originalHtml = el.innerHTML;
+            var originalContent = document.createDocumentFragment();
+            while (el.firstChild) {
+              originalContent.appendChild(el.firstChild);
+            }
             el.textContent = feedback;
             setTimeout(function () {
-              el.innerHTML = originalHtml;
+              el.textContent = "";
+              el.appendChild(originalContent);
             }, 2000);
           }
         }).catch(function (err) {
@@ -81,13 +94,13 @@
         break;
       }
       case "load-usage": {
-        if (window.loadUsageData) {
+        if (typeof window.loadUsageData === "function") {
           window.loadUsageData(el.dataset.period);
         }
         break;
       }
       case "remove-file": {
-        if (window.removeFile) {
+        if (typeof window.removeFile === "function") {
           window.removeFile(Number(el.dataset.index));
         }
         break;
@@ -95,12 +108,12 @@
       case "submit-form": {
         var submitForm = el.closest("form");
         if (submitForm) {
-          submitForm.submit();
+          HTMLFormElement.prototype.requestSubmit.call(submitForm);
         }
         break;
       }
       case "cookie-prefs": {
-        if (window.showCookiePreferences) {
+        if (typeof window.showCookiePreferences === "function") {
           window.showCookiePreferences();
         }
         break;
@@ -123,19 +136,19 @@
       }
       case "modal-open-by-id": {
         var openModalId = el.dataset.modalId;
-        if (openModalId && window.openModal) {
+        if (openModalId && typeof window.openModal === "function") {
           window.openModal(openModalId);
         }
         break;
       }
       case "print-codes": {
-        if (window.printCodes) {
+        if (typeof window.printCodes === "function") {
           window.printCodes();
         }
         break;
       }
       case "regenerate-codes": {
-        if (window.regenerateCodes) {
+        if (typeof window.regenerateCodes === "function") {
           window.regenerateCodes();
         }
         break;
@@ -154,11 +167,11 @@
         break;
       }
       case "toggle-customer-selector": {
-        if (window.toggleCustomerSelector) { window.toggleCustomerSelector(); }
+        if (typeof window.toggleCustomerSelector === "function") { window.toggleCustomerSelector(); }
         break;
       }
       case "toggle-mobile-menu": {
-        if (window.toggleMobileMenu) { window.toggleMobileMenu(); }
+        if (typeof window.toggleMobileMenu === "function") { window.toggleMobileMenu(); }
         break;
       }
       default:
@@ -175,7 +188,7 @@
 
   document.addEventListener("change", function (event) {
     var el = event.target.closest('[data-action="switch-customer"]');
-    if (el && window.switchCustomer) {
+    if (el && typeof window.switchCustomer === "function") {
       window.switchCustomer(el.value);
     }
   });
@@ -203,7 +216,7 @@
         if (typeof el.reset === "function") {
           el.reset();
         }
-        if (window.updateReplyCount) {
+        if (typeof window.updateReplyCount === "function") {
           window.updateReplyCount();
         }
         break;
@@ -216,7 +229,7 @@
   document.addEventListener("htmx:responseError", function (event) {
     var el = event.detail && event.detail.elt;
     var errorToast = el && el.getAttribute("data-htmx-error-toast");
-    if (errorToast && window.showToast) {
+    if (errorToast && typeof window.showToast === "function") {
       window.showToast("error", errorToast);
     }
   });

--- a/services/portal/tests/ui/test_registry_invoke_allowlist.py
+++ b/services/portal/tests/ui/test_registry_invoke_allowlist.py
@@ -1,0 +1,102 @@
+"""Source guardrails for the delegated action registries.
+
+No database access (portal test isolation).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TEMPLATE_ROOTS = (
+    REPO_ROOT / "services" / "platform" / "templates",
+    REPO_ROOT / "services" / "portal" / "templates",
+    REPO_ROOT / "shared" / "ui" / "templates",
+)
+UI_ACTIONS = REPO_ROOT / "shared" / "ui" / "static" / "js" / "ui-actions.js"
+CSP_ACTIONS = REPO_ROOT / "services" / "portal" / "static" / "js" / "csp-actions.js"
+
+EXPECTED_INVOKE_NAMES = 11
+TEMPLATE_INVOKE_RE = re.compile(
+    r"(?:data_invoke|data-invoke)\s*=\s*(?P<quote>['\"])(?P<name>[A-Za-z_$][\w$]*)(?P=quote)"
+)
+ALLOWLIST_RE = re.compile(
+    r"var INVOKE_ALLOWLIST = Object\.freeze\(\{(?P<body>.*?)\}\);",
+    re.DOTALL,
+)
+ALLOWLIST_NAME_RE = re.compile(r"^\s*([A-Za-z_$][\w$]*): true,?\s*$", re.MULTILINE)
+
+
+def _template_invoke_names() -> set[str]:
+    names: set[str] = set()
+    for root in TEMPLATE_ROOTS:
+        for path in root.rglob("*.html"):
+            source = path.read_text(encoding="utf-8")
+            names.update(match.group("name") for match in TEMPLATE_INVOKE_RE.finditer(source))
+    return names
+
+
+def _allowlist_names(source: str) -> list[str]:
+    match = ALLOWLIST_RE.search(source)
+    if match is None:
+        return []
+    return ALLOWLIST_NAME_RE.findall(match.group("body"))
+
+
+class RegistryInvokeAllowlistGuardTests(SimpleTestCase):
+    def test_invoke_allowlist_matches_literal_template_usage(self) -> None:
+        template_names = _template_invoke_names()
+        allowlist_names = _allowlist_names(UI_ACTIONS.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            len(template_names),
+            EXPECTED_INVOKE_NAMES,
+            "The template invoke-name count changed; update the templates and JavaScript allow-list deliberately.",
+        )
+        self.assertEqual(
+            len(allowlist_names),
+            EXPECTED_INVOKE_NAMES,
+            "The JavaScript invoke allow-list count changed; update it and the template inventory deliberately.",
+        )
+        self.assertEqual(
+            len(set(allowlist_names)),
+            EXPECTED_INVOKE_NAMES,
+            "The JavaScript invoke allow-list contains duplicate names; keep all 11 entries unique.",
+        )
+        self.assertEqual(template_names, set(allowlist_names))
+
+    def test_confirm_submit_unknown_gate_fails_closed(self) -> None:
+        source = UI_ACTIONS.read_text(encoding="utf-8")
+        start = source.index('case "confirm-submit":')
+        end = source.index('case "close-modal":', start)
+        confirm_submit_source = source[start:end]
+
+        self.assertIn("var gateName = el.dataset.invoke;", confirm_submit_source)
+        self.assertIn("if (gateName !== undefined) {", confirm_submit_source)
+        self.assertIn(
+            "!Object.prototype.hasOwnProperty.call(INVOKE_ALLOWLIST, gateName)",
+            confirm_submit_source,
+        )
+        self.assertIn('typeof window[gateName] !== "function"', confirm_submit_source)
+        self.assertIn(
+            'event.preventDefault();\n            console.warn("Blocked confirm-submit gate:", gateName);\n            break;',
+            confirm_submit_source,
+        )
+
+    def test_submit_form_uses_unclobberable_request_submit(self) -> None:
+        source = CSP_ACTIONS.read_text(encoding="utf-8")
+
+        self.assertIn("HTMLFormElement.prototype.requestSubmit.call(submitForm)", source)
+        self.assertNotIn("submitForm.submit()", source)
+
+    def test_navigate_requires_same_origin_url(self) -> None:
+        source = CSP_ACTIONS.read_text(encoding="utf-8")
+        start = source.index('case "navigate":')
+        end = source.index('case "dismiss":', start)
+        navigate_source = source[start:end]
+
+        self.assertIn("new URL(href, window.location.origin)", navigate_source)
+        self.assertIn("url.origin !== window.location.origin", navigate_source)

--- a/services/portal/tests/ui/test_registry_invoke_allowlist.py
+++ b/services/portal/tests/ui/test_registry_invoke_allowlist.py
@@ -81,9 +81,13 @@ class RegistryInvokeAllowlistGuardTests(SimpleTestCase):
             confirm_submit_source,
         )
         self.assertIn('typeof window[gateName] !== "function"', confirm_submit_source)
-        self.assertIn(
-            'event.preventDefault();\n            console.warn("Blocked confirm-submit gate:", gateName);\n            break;',
+        # Whitespace-tolerant but order-preserving: the blocked branch must
+        # preventDefault, warn, and break adjacently, in that order.
+        self.assertRegex(
             confirm_submit_source,
+            r'event\.preventDefault\(\);\s*'
+            r'console\.warn\("Blocked confirm-submit gate:", gateName\);\s*'
+            r'break;',
         )
 
     def test_submit_form_uses_unclobberable_request_submit(self) -> None:

--- a/shared/ui/static/js/ui-actions.js
+++ b/shared/ui/static/js/ui-actions.js
@@ -17,6 +17,21 @@
 (function () {
   "use strict";
 
+  // The guard test pins this allow-list to literal data-invoke template usage.
+  var INVOKE_ALLOWLIST = Object.freeze({
+    checkWebAuthnSupport: true,
+    closeEventDetail: true,
+    closeModal: true,
+    confirmDisable: true,
+    confirmRegenerate: true,
+    exportCSV: true,
+    resetFilters: true,
+    showInvoiceRefundModal: true,
+    showInvoiceRefundRequestModal: true,
+    showOrderRefundRequestModal: true,
+    showRefundModal: true,
+  });
+
   document.addEventListener("click", function (event) {
     var el = event.target.closest("[data-action]");
     if (!el) {
@@ -39,17 +54,30 @@
         break;
       }
       case "invoke": {
-        var invokeFn = window[el.dataset.invoke];
-        if (typeof invokeFn === "function") {
-          invokeFn(el);
+        var invokeName = el.dataset.invoke;
+        if (
+          !Object.prototype.hasOwnProperty.call(INVOKE_ALLOWLIST, invokeName) ||
+          typeof window[invokeName] !== "function"
+        ) {
+          console.warn("Blocked invoke action:", invokeName);
+          break;
         }
+        window[invokeName](el);
         break;
       }
       case "confirm-submit": {
-        var gateFn = el.dataset.invoke ? window[el.dataset.invoke] : null;
+        var gateName = el.dataset.invoke;
         var proceed = true;
-        if (typeof gateFn === "function") {
-          proceed = gateFn(el) !== false;
+        if (gateName !== undefined) {
+          if (
+            !Object.prototype.hasOwnProperty.call(INVOKE_ALLOWLIST, gateName) ||
+            typeof window[gateName] !== "function"
+          ) {
+            event.preventDefault();
+            console.warn("Blocked confirm-submit gate:", gateName);
+            break;
+          }
+          proceed = window[gateName](el) !== false;
         } else if (el.dataset.confirm) {
           proceed = window.confirm(el.dataset.confirm);
         }
@@ -60,7 +88,7 @@
       }
       case "close-modal": {
         var modalId = el.dataset.modalId;
-        if (modalId && window.closeModal) {
+        if (modalId && typeof window.closeModal === "function") {
           window.closeModal(modalId);
         }
         break;
@@ -119,7 +147,7 @@
       t.classList.add('border-transparent', 'text-slate-400');
     }
     /* Activate clicked tab (both desktop and mobile instances share same data attrs) */
-    var allMatching = root.querySelectorAll('.list-filter-tab[data-tab-value="' + value + '"]');
+    var allMatching = root.querySelectorAll('.list-filter-tab[data-tab-value="' + CSS.escape(value) + '"]');
     for (var j = 0; j < allMatching.length; j++) {
       var m = allMatching[j];
       m.setAttribute('aria-selected', 'true');


### PR DESCRIPTION
## Summary

Hardens the delegated action registry (`shared/ui/static/js/ui-actions.js`, `services/portal/static/js/csp-actions.js`) against the findings of an internal security review. Split out of the interactivity-consolidation evaluation (#462) because these fixes stand on their own — the code is live in both services today.

## Fixes

**High — arbitrary global dispatch.** The `invoke` and `confirm-submit` actions called `window[el.dataset.invoke]()`, letting any injected markup name an arbitrary global. Both now dispatch only through a frozen 11-name allow-list (checked with `Object.prototype.hasOwnProperty.call`, so prototype-chain names like `toString` cannot match). `invoke` warns and no-ops on unknown names; `confirm-submit` **fails closed** — an unknown or not-yet-defined gate blocks the submit rather than proceeding unguarded. All four platform `confirm-submit` call sites were audited: two use the `data_confirm` path (unchanged), two use gates (`confirmDisable`, `confirmRegenerate`) defined in the same templates, so legitimate flows are unaffected.

**Medium — submit gate/validation bypass.** `submit-form` called `form.submit()`, which skips HTML validation and the delegated `data-confirm` submit gate, and is clobberable by a control named `submit`. Now uses `HTMLFormElement.prototype.requestSubmit.call(form)`. Sole call site (portal logout form) has neither validation nor a confirm gate, so behaviour is unchanged there.

**Medium — open redirect.** `navigate` assigned `location.href` from `data-href` unvalidated. Now parses with `new URL(href, window.location.origin)` and navigates only same-origin; cross-origin, protocol-relative (`//evil.example`), `javascript:`, and malformed URLs are blocked with a console warning.

**Low.** `copy` feedback no longer round-trips `innerHTML` (original child nodes are detached and reattached, preserving SVG icons without reparse); `CSS.escape` on the tab-selector interpolation; `typeof … === "function"` guards on every `window.*` helper call in both files.

## Tests

New `services/portal/tests/ui/test_registry_invoke_allowlist.py` (source-assertion guardrails, `SimpleTestCase`, no DB):

- **Bijection**: the set of literal `data_invoke` values across all template roots (platform, portal, shared) must equal the allow-list parsed from `ui-actions.js`, both pinned at 11 — either side drifting fails loudly in both directions.
- Fail-closed `confirm-submit`, prototype `requestSubmit`, and same-origin `navigate` contracts pinned against the sources.

Each test was proven red against the unfixed sources, then green after the fix. Reverting any fix re-fails its named test.

## Verification

- `make test-portal`: 1099 passed (182 subtests)
- `make test-platform`: 7819 ran, OK (22 skipped) — platform loads the shared file
- `make lint` incl. per-file on the new test: clean
- Existing guardrails (`test_csp_handler_inventory_guardrail.py`, ticket-list keyboard-contract pin on `ui-actions.js`) untouched and green
