### PR TITLE
fix(domains): stop releasing the idempotency claim on ambiguous registrar outcomes

### DIFF
--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -847,20 +847,34 @@ class BaseRegistrarGateway(ABC):
             return
 
         key = self._circuit_breaker_key()
-        # Atomic first-failure seed: add() only succeeds if the key is absent, so two
-        # concurrent first failures can't both reset the counter to 1 (W3). incr on an
-        # existing key preserves the TTL set here, so the window doesn't slide and the
-        # breaker auto-closes CIRCUIT_BREAKER_RESET_SECONDS after it first opened.
-        if cache.add(key, 1, CIRCUIT_BREAKER_RESET_SECONDS):
-            return
         try:
-            cache.incr(key)
-        except ValueError:
-            # The key expired between add() and incr() — reseed.
-            cache.set(key, 1, CIRCUIT_BREAKER_RESET_SECONDS)
+            # Atomic first-failure seed: add() only succeeds if the key is absent, so two
+            # concurrent first failures can't both reset the counter to 1 (W3). incr on an
+            # existing key preserves the TTL set here, so the window doesn't slide and the
+            # breaker auto-closes CIRCUIT_BREAKER_RESET_SECONDS after it first opened.
+            if cache.add(key, 1, CIRCUIT_BREAKER_RESET_SECONDS):
+                return
+            try:
+                cache.incr(key)
+            except ValueError:
+                # The key expired between add() and incr() — reseed.
+                cache.set(key, 1, CIRCUIT_BREAKER_RESET_SECONDS)
+        except Exception:
+            # A cache-backend outage here must not escape into the caller: this is
+            # bookkeeping for the NEXT call's circuit-breaker decision, not the current
+            # one's outcome. Letting it raise would abort whatever cleanup the caller
+            # still needs to run (releasing an idempotency claim, logging, auditing) —
+            # exactly the "bookkeeping failure crashes a call that already resolved"
+            # class this whole function's callers are being hardened against.
+            self.logger.warning("Circuit-breaker failure bookkeeping failed", exc_info=True)
 
     def _record_success(self) -> None:
-        cache.delete(self._circuit_breaker_key())
+        try:
+            cache.delete(self._circuit_breaker_key())
+        except Exception:
+            # See _record_failure's identical guard: this must never abort a caller
+            # that already has a successful result to return.
+            self.logger.warning("Circuit-breaker success bookkeeping failed", exc_info=True)
 
     # -- Retry with exponential backoff --------------------------------------
 

--- a/services/platform/apps/domains/gateways/base.py
+++ b/services/platform/apps/domains/gateways/base.py
@@ -313,9 +313,7 @@ class BaseRegistrarGateway(ABC):
         # ``"1"`` cannot collide with the tokenless one-year key, and arbitrary caller
         # input cannot create an overlong or backend-invalid cache key.
         token_fingerprint = (
-            hashlib.sha256(idempotency_token.encode("utf-8")).hexdigest()
-            if idempotency_token is not None
-            else None
+            hashlib.sha256(idempotency_token.encode("utf-8")).hexdigest() if idempotency_token is not None else None
         )
         intent = f"token:{token_fingerprint}" if token_fingerprint is not None else str(years)
         return self._execute_idempotent_operation(
@@ -422,9 +420,9 @@ class BaseRegistrarGateway(ABC):
             return Err(RegistrarConflictError(domain_name, self.registrar.name))
 
         # Exception-safety: _retry(fn) can raise (e.g. _safe_json → RegistrarAPIError on
-        # an oversized body). Convert any escape to an Err so the claim-release path below
-        # always runs — otherwise the in-progress claim would strand the key for the full
-        # TTL and block every legitimate retry.
+        # an oversized body). Convert any escape to an Err (default retriability=UNKNOWN,
+        # the safe "don't know" state) so the classification below always runs on a real
+        # Result rather than letting an unclassified exception propagate uncaught.
         try:
             result = self._retry(fn, operation=operation)
         except RegistrarAPIError as exc:
@@ -444,20 +442,62 @@ class BaseRegistrarGateway(ABC):
             # the idempotency cache is plaintext (DatabaseCache/Redis). The immediate
             # caller still receives the full result (with the EPP) to store encrypted;
             # only the replay copy is redacted.
-            cache.set(idempotency_key, _redact_secrets(result.unwrap()), IDEMPOTENCY_TTL_SECONDS)
+            try:
+                cache.set(idempotency_key, _redact_secrets(result.unwrap()), IDEMPOTENCY_TTL_SECONDS)
+            except Exception:
+                # The registrar call already succeeded — a chargeable operation happened.
+                # Reporting this as a failure would be false, would skip the caller's local
+                # persistence of the result, and (worse) would risk a retry re-issuing the
+                # same paid operation. Swallow and log loudly instead: the in-progress
+                # sentinel written by cache.add() above is still in place (this exception
+                # means the REPLACE failed, not that the claim vanished), so a same-token
+                # retry within the TTL still hits the "concurrent claim" rejection path
+                # rather than calling the registrar again — degraded bookkeeping, not zero
+                # protection. Still worth paging on: replay protection here is uncertain
+                # until TTL expiry, not confirmed.
+                self.logger.error(
+                    "Idempotency cache write failed after %s succeeded via %s — replay "
+                    "protection is degraded until TTL expiry, investigate",
+                    operation,
+                    self.gateway_name,
+                    exc_info=True,
+                )
             self._record_success()
             self.logger.info("%s succeeded via %s", operation, self.gateway_name)
             self._audit_api_call(audit_event, domain_name, success=True, metadata=audit_metadata)
         else:
-            cache.delete(idempotency_key)  # release the claim so a legitimate retry can proceed
             error = result.unwrap_err()
             self._record_failure(error)
-            # Log/audit the machine-readable code, never the raw registrar body — it can
-            # echo registrant PII (CNP, address) supplied in the request (W4).
-            self.logger.error("%s failed with %s", operation, error.code.value)
-            self._audit_api_call(
-                audit_event, domain_name, success=False, error=error.code.value, metadata=audit_metadata
-            )
+            # A registrar-outcome-UNKNOWN failure (the Err default — see Retriability's
+            # docstring: "non-idempotent paths... treat UNKNOWN as do not retry") means the
+            # mutating call MAY have already applied even though we can't confirm it. Deleting
+            # the claim here would let an immediate retry re-issue the same chargeable
+            # operation. Leave the in-progress sentinel in place instead — a same-token retry
+            # within the TTL hits the "concurrent claim" rejection below rather than calling
+            # the registrar again, and the hold self-heals at TTL expiry. This is a mitigation
+            # window, not a resolution: the ambiguity itself is never resolved, so the risk
+            # reopens after TTL. Only RETRIABLE (never reached the registrar) and NOT_RETRIABLE
+            # (definite rejection) are provably safe to release immediately.
+            if retriability_of(result) == Retriability.UNKNOWN:
+                self.logger.warning(
+                    "%s outcome UNKNOWN via %s — idempotency claim retained (not deleted) so a "
+                    "retry is blocked until TTL expiry rather than risking a duplicate chargeable "
+                    "call: %s",
+                    operation,
+                    self.gateway_name,
+                    error.code.value,
+                )
+                self._audit_api_call(
+                    audit_event, domain_name, success=False, error=error.code.value, metadata=audit_metadata
+                )
+            else:
+                cache.delete(idempotency_key)  # provably safe to release — see comment above
+                # Log/audit the machine-readable code, never the raw registrar body — it can
+                # echo registrant PII (CNP, address) supplied in the request (W4).
+                self.logger.error("%s failed with %s", operation, error.code.value)
+                self._audit_api_call(
+                    audit_event, domain_name, success=False, error=error.code.value, metadata=audit_metadata
+                )
 
         return result
 
@@ -560,13 +600,39 @@ class BaseRegistrarGateway(ABC):
         )
 
         if result.is_ok():
-            cache.set(idempotency_key, _redact_secrets(result.unwrap()), IDEMPOTENCY_TTL_SECONDS)
+            try:
+                cache.set(idempotency_key, _redact_secrets(result.unwrap()), IDEMPOTENCY_TTL_SECONDS)
+            except Exception:
+                # See _execute_idempotent_operation's identical guard: the transfer already
+                # succeeded (chargeable), so this must not be reported as a failure. The
+                # in-progress sentinel from cache.add() above is still in place, so a
+                # same-domain retry within the TTL still hits the "concurrent claim"
+                # rejection below rather than posting a second transfer.
+                self.logger.error(
+                    "Idempotency cache write failed after transfer succeeded via %s — replay "
+                    "protection is degraded until TTL expiry, investigate",
+                    self.gateway_name,
+                    exc_info=True,
+                )
             self._record_success()
             self._audit_api_call("domain_transfer", domain_name, success=True)
         else:
-            cache.delete(idempotency_key)  # release the claim so a legitimate retry can proceed
             error = result.unwrap_err()
             self._record_failure(error)
+            # See _execute_idempotent_operation's identical branch: an UNKNOWN outcome may
+            # have already applied at the registrar, so releasing the claim here would let a
+            # retry post a duplicate, chargeable transfer. Only a provably safe outcome
+            # (RETRIABLE/NOT_RETRIABLE) releases the claim immediately.
+            if retriability_of(result) == Retriability.UNKNOWN:
+                self.logger.warning(
+                    "Transfer outcome UNKNOWN for %s via %s — idempotency claim retained until "
+                    "TTL expiry rather than risking a duplicate chargeable transfer: %s",
+                    domain_name,
+                    self.gateway_name,
+                    error.code.value,
+                )
+            else:
+                cache.delete(idempotency_key)  # provably safe to release — see comment above
             self._audit_api_call("domain_transfer", domain_name, success=False, error=error.code.value)
 
         return result

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -1144,9 +1144,26 @@ class DomainOrderService:
                 # #259: the order item pk IS the renewal intent — durable, and exactly one
                 # per item, so a retried batch replays rather than re-charging, while two
                 # separate order items for the same domain+years stay distinct.
-                renewal_result = DomainLifecycleService.process_domain_renewal(
-                    domain=item.domain, years=item.years, idempotency_token=f"order_item:{item.pk}"
-                )
+                #
+                # Wrapped: process_domain_renewal's own Result-returning paths never raise,
+                # but the registrar call sits behind several cache operations (gateways/base.py)
+                # that can — a backend outage on cache.get/add is not caught anywhere below
+                # this call. One item's infrastructure failure must not abort the rest of the
+                # order's valid renewals, matching the transfer/unhandled-action branches'
+                # log-and-continue behavior. The register branch above has the equivalent gap
+                # (create_domain_registration isn't wrapped either) — left alone here since it
+                # wasn't part of what this fix addresses; tracked as a follow-up.
+                try:
+                    renewal_result = DomainLifecycleService.process_domain_renewal(
+                        domain=item.domain, years=item.years, idempotency_token=f"order_item:{item.pk}"
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "🔥 [Domain] Renewal of %s crashed unexpectedly (not a registrar rejection): %s",
+                        item.domain_name,
+                        exc,
+                    )
+                    continue
 
                 if renewal_result.is_ok():
                     processed_domains.append(item.domain)

--- a/services/platform/apps/domains/services.py
+++ b/services/platform/apps/domains/services.py
@@ -1162,6 +1162,7 @@ class DomainOrderService:
                         "🔥 [Domain] Renewal of %s crashed unexpectedly (not a registrar rejection): %s",
                         item.domain_name,
                         exc,
+                        exc_info=True,
                     )
                     continue
 

--- a/services/platform/tests/domains/test_domain_service_logic.py
+++ b/services/platform/tests/domains/test_domain_service_logic.py
@@ -336,6 +336,41 @@ class DomainOrderRenewTransferProcessingTests(DomainFixtureMixin, TestCase):
 
         self.assertIn(domain, processed)
 
+    def test_renew_exception_does_not_abort_remaining_items(self) -> None:
+        """One failed renew item must not stop later valid renewals from processing.
+
+        DomainOrderItem's default Meta.ordering is -created_at (newest first), and
+        process_domain_order_items's queryset has no explicit .order_by() overriding
+        it — so the side_effect must be keyed by which domain is being renewed, not
+        by creation order, or this test silently proves the wrong thing.
+        """
+        first_domain = self._owned_domain("first.ro")
+        second_domain = self._owned_domain("second.ro")
+        DomainOrderService.create_domain_order_item(
+            order=self.order, domain_name=first_domain.name, action="renew", years=1
+        )
+        DomainOrderService.create_domain_order_item(
+            order=self.order, domain_name=second_domain.name, action="renew", years=1
+        )
+
+        def _renew_side_effect(*, domain: Domain, **_kwargs: object) -> object:
+            if domain.pk == first_domain.pk:
+                raise RuntimeError("registrar adapter crashed")
+            return _Ok("renewed")
+
+        with (
+            self.assertLogs("apps.domains.services", level="ERROR") as logs,
+            patch.object(
+                DomainLifecycleService, "process_domain_renewal", side_effect=_renew_side_effect
+            ) as mock_renew,
+        ):
+            processed = DomainOrderService.process_domain_order_items(self.order)
+
+        self.assertEqual(mock_renew.call_count, 2)
+        self.assertNotIn(first_domain, processed)
+        self.assertIn(second_domain, processed)
+        self.assertTrue(any("first.ro" in message and "crashed" in message for message in logs.output))
+
     def test_process_refuses_to_renew_another_customers_domain(self) -> None:
         """Ownership is re-checked at processing time, not only when the link is created.
 

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -210,6 +210,42 @@ class TransferIdempotencyClaimTests(TestCase):
         # The chargeable registrar call must NOT be made when the claim is lost.
         mock_do.assert_not_called()
 
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_initiate_transfer")
+    @patch("apps.domains.gateways.base.cache")
+    def test_unknown_outcome_retains_claim_instead_of_releasing_it(
+        self, mock_cache: MagicMock, mock_do: MagicMock
+    ) -> None:
+        """A registrar-outcome-UNKNOWN failure (e.g. a lost response) must NOT release the
+        claim — the transfer may have already applied. Mirrors
+        RenewalIdempotencyTokenTests.test_unknown_outcome_blocks_same_token_retry; this
+        gateway inlines its own claim/release protocol instead of routing through
+        _execute_idempotent_operation, so it needed the identical fix applied separately."""
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_do.return_value = Err(RegistrarAPIError("transfer response lost"))  # default UNKNOWN
+
+        result = self.gateway.initiate_transfer("example.com", "EPP")
+
+        self.assertTrue(result.is_err())
+        mock_cache.delete.assert_not_called()  # claim retained — outcome is ambiguous
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._do_initiate_transfer")
+    @patch("apps.domains.gateways.base.cache")
+    def test_not_retriable_outcome_releases_claim(self, mock_cache: MagicMock, mock_do: MagicMock) -> None:
+        """A definite (NOT_RETRIABLE) rejection still releases the claim immediately —
+        the carve-out proving the UNKNOWN fix doesn't overcorrect into blocking every
+        failure."""
+        mock_cache.get.side_effect = [0, None]
+        mock_cache.add.return_value = True
+        mock_do.return_value = Err(
+            RegistrarAPIError("epp code rejected"), retriability=Retriability.NOT_RETRIABLE
+        )
+
+        result = self.gateway.initiate_transfer("example.com", "EPP")
+
+        self.assertTrue(result.is_err())
+        mock_cache.delete.assert_called_once()
+
 
 class BulkAvailabilityExceptionSafetyTests(TestCase):
     """check_availability_bulk must convert a raised registrar error into an Err,

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -554,8 +554,14 @@ class IdempotencyClaimTests(TestCase):
         mock_cache.add.return_value = True
 
         with patch.object(self.gateway, "_do_register") as mock_do:
+            # RegistrarAPIError (not RegistrarTransientError): _record_failure only
+            # trips the circuit breaker for RegistrarTransientError/RegistrarRateLimitError
+            # (systemic failures) — pairing a transient-error TYPE with a NOT_RETRIABLE
+            # tag would be internally contradictory and would exercise breaker bookkeeping
+            # this test isn't about, potentially masking a real breaker regression.
             mock_do.return_value = Err(
-                RegistrarTransientError("gandi", "boom"), retriability=Retriability.NOT_RETRIABLE
+                RegistrarAPIError("boom", code=RegistrarErrorCode.INVALID_REGISTRANT_DATA),
+                retriability=Retriability.NOT_RETRIABLE,
             )
             result = self.gateway.register_domain("example.com", 1, self.registrant)
 

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -539,11 +539,24 @@ class IdempotencyClaimTests(TestCase):
 
     @patch("apps.domains.gateways.base.cache")
     def test_claim_is_released_on_failure(self, mock_cache: MagicMock) -> None:
+        """A DEFINITE (NOT_RETRIABLE) rejection releases the claim immediately.
+
+        Previously this used a bare Err() (default retriability=UNKNOWN) to represent
+        "some failure happened", from when every failure released the claim
+        unconditionally. That became unsafe for genuinely ambiguous outcomes (a timed-out
+        POST may have already applied at the registrar) — see
+        test_idempotency_claim_retained_when_operation_raises_unexpectedly below, and
+        RenewalIdempotencyTokenTests.test_unknown_outcome_blocks_same_token_retry, for
+        that half. This test is narrowed to what it always meant to prove: a PROVEN
+        non-application still releases the claim right away.
+        """
         mock_cache.get.side_effect = [0, None]
         mock_cache.add.return_value = True
 
         with patch.object(self.gateway, "_do_register") as mock_do:
-            mock_do.return_value = Err(RegistrarTransientError("gandi", "boom"))
+            mock_do.return_value = Err(
+                RegistrarTransientError("gandi", "boom"), retriability=Retriability.NOT_RETRIABLE
+            )
             result = self.gateway.register_domain("example.com", 1, self.registrant)
 
         self.assertTrue(result.is_err())
@@ -818,9 +831,21 @@ class GatewayHardeningTests(TestCase):
 
     @patch("apps.domains.gateways.gandi.GandiGateway._do_register")
     @patch("apps.domains.gateways.base.cache")
-    def test_idempotency_claim_released_when_operation_raises(self, mock_cache: MagicMock, mock_do: MagicMock) -> None:
-        """An unexpected exception (e.g. oversized-response RegistrarAPIError) must still
-        release the in-progress claim so a later retry isn't permanently blocked."""
+    def test_idempotency_claim_retained_when_operation_raises_unexpectedly(
+        self, mock_cache: MagicMock, mock_do: MagicMock
+    ) -> None:
+        """An unexpected/unclassified exception (e.g. oversized-response RegistrarAPIError)
+        must RETAIN the in-progress claim, not release it.
+
+        This inverts what the test previously asserted ("must still release the claim so
+        a later retry isn't permanently blocked"). An unclassified exception's retriability
+        defaults to UNKNOWN — the registrar POST may already have applied even though we
+        caught an exception building/parsing the response. Releasing the claim here would
+        let an immediate retry double-charge exactly the class of failure it's least safe
+        to retry. The claim now self-heals at TTL expiry (IDEMPOTENCY_TTL_SECONDS) instead;
+        see test_claim_is_released_on_failure above for the definite-rejection case, which
+        still releases immediately.
+        """
         mock_cache.get.side_effect = [0, None]
         mock_cache.add.return_value = True
         mock_do.side_effect = RegistrarAPIError("boom", code=RegistrarErrorCode.INVALID_RESPONSE)
@@ -828,7 +853,7 @@ class GatewayHardeningTests(TestCase):
         result = self.gateway.register_domain("example.com", 1, self.registrant)
 
         self.assertTrue(result.is_err())
-        mock_cache.delete.assert_called_once()  # claim released
+        mock_cache.delete.assert_not_called()  # claim retained — outcome is ambiguous, not proven
 
     @patch("apps.domains.gateways.base.cache")
     def test_breaker_ignores_non_systemic_errors(self, mock_cache: MagicMock) -> None:

--- a/services/platform/tests/domains/test_renewal_idempotency_token.py
+++ b/services/platform/tests/domains/test_renewal_idempotency_token.py
@@ -18,13 +18,14 @@ failure (a duplicate chargeable renewal at the registrar).
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 
-from apps.common.types import Ok
-from apps.domains.gateways.base import DomainRenewalResult
+from apps.common.types import Err, Ok, Retriability
+from apps.domains.gateways.base import MAX_RETRIES, DomainRenewalResult
+from apps.domains.gateways.errors import RegistrarAPIError, RegistrarConflictError
 from apps.domains.gateways.gandi import GandiGateway
 from apps.domains.models import Registrar
 from config.settings.test import LOCMEM_TEST_CACHE
@@ -105,3 +106,75 @@ class RenewalIdempotencyTokenTests(TestCase):
             self.gateway.renew_domain("g-2", "two.ro", 1, idempotency_token="order_item:3")
 
         self.assertEqual(do_renew.call_count, 2)
+
+    def test_unknown_outcome_blocks_same_token_retry(self) -> None:
+        ambiguous = Err(RegistrarAPIError("registrar response lost"))
+
+        with patch.object(GandiGateway, "_do_renew", return_value=ambiguous) as do_renew:
+            first = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:8")
+            second = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:8")
+
+        self.assertTrue(first.is_err())
+        self.assertTrue(second.is_err())
+        self.assertIsInstance(second.unwrap_err(), RegistrarConflictError)
+        self.assertEqual(do_renew.call_count, 1, "an ambiguous result must retain the idempotency claim")
+
+    def test_not_retriable_outcome_releases_same_token_claim(self) -> None:
+        rejected = Err(
+            RegistrarAPIError("definite rejection"),
+            retriability=Retriability.NOT_RETRIABLE,
+        )
+
+        with patch.object(GandiGateway, "_do_renew", return_value=rejected) as do_renew:
+            first = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:9")
+            second = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:9")
+
+        self.assertTrue(first.is_err())
+        self.assertTrue(second.is_err())
+        self.assertNotIsInstance(second.unwrap_err(), RegistrarConflictError)
+        self.assertEqual(do_renew.call_count, 2, "a definite rejection must release the claim")
+
+    def test_retriable_outcome_releases_same_token_claim(self) -> None:
+        safely_retriable = Err(
+            RegistrarAPIError("request never reached registrar"),
+            retriability=Retriability.RETRIABLE,
+        )
+
+        with (
+            patch.object(GandiGateway, "_do_renew", return_value=safely_retriable) as do_renew,
+            patch("apps.domains.gateways.base.time.sleep"),
+        ):
+            first = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:10")
+            second = self.gateway.renew_domain("g-1", "example.ro", 1, idempotency_token="order_item:10")
+
+        self.assertTrue(first.is_err())
+        self.assertTrue(second.is_err())
+        self.assertNotIsInstance(second.unwrap_err(), RegistrarConflictError)
+        self.assertEqual(
+            do_renew.call_count,
+            2 * MAX_RETRIES,
+            "both outer calls must exhaust the registrar retry path",
+        )
+
+    def test_cache_write_failure_after_success_still_reports_success(self) -> None:
+        renewal = self._renewal()
+
+        with (
+            patch.object(GandiGateway, "_do_renew", return_value=Ok(renewal)),
+            patch("apps.domains.gateways.base.cache.set", side_effect=RuntimeError("cache unavailable")),
+            patch.object(GandiGateway, "_audit_api_call") as mock_audit,
+            self.assertLogs("apps.domains.gateways.gandi", level="ERROR") as logs,
+        ):
+            result = self.gateway.renew_domain(
+                "g-1", "example.ro", 1, idempotency_token="order_item:11"
+            )
+
+        # The registrar call genuinely succeeded — a real, paid renewal happened. Losing
+        # the cache write must not turn that into a reported failure.
+        self.assertTrue(result.is_ok())
+        self.assertEqual(result.unwrap(), renewal)
+        self.assertTrue(any("idempotency" in message.lower() for message in logs.output))
+        # Success bookkeeping (the audit trail for a chargeable operation) must still run —
+        # this is what pins the fix to "wrap only cache.set", not "wrap the whole success
+        # block", per ADR-0016. A too-broad try/except would silently drop this call.
+        mock_audit.assert_called_once_with("domain_renewal", "example.ro", success=True, metadata=ANY)


### PR DESCRIPTION
## Problem

Reviewing #435 + #458 together (their branches conflicted on the same function, and #458's protection only makes sense once #435's ownership-linking is live) surfaced two money-safety gaps in the registrar idempotency wrapper underneath both — pre-existing, not introduced by either.

**1. Ambiguous registrar outcomes released the idempotency claim.** `_execute_idempotent_operation` (`gateways/base.py`) unconditionally ran `cache.delete(idempotency_key)` on any failure. A timeout or 5xx — where the mutating call may already have applied at the registrar — carries `Retriability.UNKNOWN` (the `Err` default). Deleting the claim for that case is exactly as unsafe as for a definite rejection: once any retry path is wired up, a retry after an ambiguous outcome would call the registrar again. This is the double-charge scenario #458's idempotency token exists to prevent, for the one outcome class its fix doesn't cover. `initiate_transfer` inlines the same claim/release protocol separately (rather than routing through the shared helper) and carried the identical gap.

**2. A cache-write failure after a successful registrar call crashed uncaught.** `cache.set(...)` in the success path had no exception handling, and nothing up the call chain (`DomainRegistrarGateway.renew_domain`'s facade, `process_domain_renewal`, `process_domain_order_items`'s loop) wrapped the registrar call either. If the cache write failed after `_do_renew` already succeeded — a real, paid renewal — the exception propagated out of the entire order-processing loop, aborting whatever items hadn't been processed yet, with the successful renewal's replay protection left unconfirmed.

`process_domain_order_items` has zero live callers today (verified via a repo-wide grep — only tests invoke it), so nothing in production is affected right now. But #435/#458 explicitly frame this renewal path as the foundation for imminent wiring, which is why this closes the gap now rather than after.

## Fix

**Only release the idempotency claim when the outcome is provably safe to retry.** This codebase already has a complete `Retriability` classification system (`Err` defaults to `UNKNOWN`; `_handle_error_response` maps every HTTP status to a typed error + explicit retriability; `_retry`'s own internal loop already honors it and won't auto-replay `UNKNOWN`) — the one place the signal was computed but never consulted was this function's failure branch. `RETRIABLE` (never reached the registrar) and `NOT_RETRIABLE` (definite rejection) still release the claim immediately, unchanged. `UNKNOWN` now retains the in-progress sentinel instead: a same-token retry within the TTL hits the existing "concurrent claim" rejection rather than re-issuing the call, and the hold still self-heals at TTL expiry (1h) — a mitigation window, not a full resolution of the underlying ambiguity, which is called out explicitly rather than oversold. Applied to both `_execute_idempotent_operation` (shared by register/renew) and `initiate_transfer` (which inlines its own copy of the same protocol).

**Cache-write failure is now narrowly caught.** Only `cache.set(...)` itself is wrapped — not `_record_success()`, the log, or the audit call — so a cache-backend hiccup doesn't also drop the audit trail for a chargeable operation (ADR-0016). Logged loudly (`exc_info=True`) since replay protection is degraded until TTL expiry; the caller still receives the successful result, since the registrar operation genuinely succeeded and reporting it as a failure would skip `process_domain_renewal`'s local `expires_at` update while risking a retry re-issuing the same paid call.

**`process_domain_order_items`'s renew branch gets a per-item exception boundary**, matching the log-and-continue behavior its transfer/unknown-action sibling branches already have by construction. The registrar call sits behind cache operations (`cache.get`/`cache.add`) that can still raise before either guard above applies; one item's infrastructure failure must not abort the rest of the order's valid renewals. The `register` branch has the same theoretical gap (`create_domain_registration` isn't wrapped either) — left alone here since it wasn't part of what this fix addresses; noted as a follow-up rather than silently scope-creeping into an unreviewed path.

## Tests

Five new tests (`gateways/base.py`'s shared helper) plus two companion tests for `initiate_transfer`'s separate copy of the same protocol:

- `test_unknown_outcome_blocks_same_token_retry` / `test_unknown_outcome_retains_claim_instead_of_releasing_it` — an ambiguous outcome retains the claim; the registrar is never called a second time for the same token.
- `test_not_retriable_outcome_releases_same_token_claim` / `test_not_retriable_outcome_releases_claim` — the carve-out proving the fix doesn't overcorrect: a definite rejection still releases the claim immediately, exactly as before.
- `test_retriable_outcome_releases_same_token_claim` — same carve-out for the RETRIABLE case, accounting for `_retry`'s own internal `MAX_RETRIES` backoff loop (`time.sleep` patched) so the assertion isolates `_execute_idempotent_operation`'s own claim-handling rather than retry-loop policy.
- `test_cache_write_failure_after_success_still_reports_success` — no exception escapes, the original successful result is returned, and — the assertion that actually pins the "wrap only `cache.set`" scope decision — the audit call still fires.
- `test_renew_exception_does_not_abort_remaining_items` — one item raising doesn't stop a second, valid item from processing.

Two pre-existing tests asserted the old unconditional-release behavior using a default-`UNKNOWN` error (`test_claim_is_released_on_failure`, `test_idempotency_claim_released_when_operation_raises`) — updated in place with explanatory docstrings rather than deleted (ADR-0014). The second is a genuine behavior inversion (renamed to `test_idempotency_claim_retained_when_operation_raises_unexpectedly`): an unclassified exception must now retain the claim, not release it, since its retriability defaults to the same `UNKNOWN` this PR treats as ambiguous.

Domains suite: **169 tests, OK**. mypy + ruff clean on all six changed files.

## Scope

This is infrastructure underneath #435/#458, not a change to either. Deliberately not doing: propagating `retriability` further up through `process_domain_renewal`'s return type or `DomainRegistrarGateway.renew_domain`'s facade (the money-safety property is already guaranteed at this layer regardless of what the upper layers do with the error message, and there's no live caller yet to consume a richer signal); durable ambiguous-outcome tracking requiring operator reconciliation before a replay is allowed (the "Best" option — this PR takes the "Good" one: verified safe, minimal, and the 1-hour TTL window is a real, useful reduction in exposure even though it isn't a full resolution); wrapping the `register` branch's equivalent gap in `process_domain_order_items` (same shape, not part of what this fix reviewed).
