### PR TITLE
security(api): throttle the unsigned path on HMAC endpoints (#277)

### DIFF
--- a/services/platform/apps/api/customers/views.py
+++ b/services/platform/apps/api/customers/views.py
@@ -22,6 +22,8 @@ from apps.api.core.permissions import IsAuthenticatedAndAccessible
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle
 from apps.api.secure_auth import public_api_endpoint, require_customer_authentication, require_portal_authentication
 from apps.common.performance.rate_limiting import (
+    BurstRateThrottle,
+    CustomerRateThrottle,
     PortalHMACBurstThrottle,
     PortalHMACCreateUserThrottle,
     PortalHMACRateThrottle,
@@ -691,7 +693,12 @@ def customer_detail_api(request: HttpRequest, customer: Customer) -> Response:
 @api_view(["POST"])
 @authentication_classes([])  # No DRF authentication - HMAC handled by @require_customer_authentication
 @permission_classes([AllowAny])  # HMAC auth via @require_customer_authentication below
-@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle])
+# #277 follow-up: CustomerRateThrottle/BurstRateThrottle return None for verified portal
+# traffic (deferring to the PortalHMAC* limits) but key ANONYMOUS traffic by safe client
+# IP. DRF evaluates throttles before @require_customer_authentication rejects an unsigned
+# request, so without them the pre-auth path is unthrottled. This restores the full
+# DEFAULT_THROTTLE_CLASSES set for this endpoint.
+@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle, CustomerRateThrottle, BurstRateThrottle])
 @require_customer_authentication
 def update_customer_billing_address(  # noqa: C901, PLR0912, PLR0915  # Complexity: multi-step business logic
     request: Request, customer: Customer
@@ -705,7 +712,10 @@ def update_customer_billing_address(  # noqa: C901, PLR0912, PLR0915  # Complexi
     limits and keyed on client IP — BurstAPIThrottle extends UserRateThrottle and this
     endpoint runs with ``authentication_classes([])``, so request.user is AnonymousUser
     and a caller distributing requests across IPs bypassed the 120/min cap entirely.
-    Both throttles below key on the verified portal id (X-Portal-Id).
+    The two PortalHMAC* throttles key signed traffic on the verified portal id
+    (X-Portal-Id); CustomerRateThrottle/BurstRateThrottle return None for that traffic
+    but key ANONYMOUS traffic by client IP, so the pre-auth path an unsigned caller
+    reaches before ``@require_customer_authentication`` stays limited.
 
     This endpoint enables seamless inline editing of customer profile data
     when checkout validation fails, providing a smooth UX without navigation disruption.
@@ -994,7 +1004,15 @@ def customer_users_add(request: HttpRequest, customer: Customer) -> Response:  #
 @api_view(["POST"])
 @authentication_classes([])
 @permission_classes([AllowAny])
-@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle, PortalHMACCreateUserThrottle])
+@throttle_classes(
+    [
+        PortalHMACRateThrottle,
+        PortalHMACBurstThrottle,
+        PortalHMACCreateUserThrottle,
+        CustomerRateThrottle,
+        BurstRateThrottle,
+    ]
+)
 @require_customer_authentication
 def customer_users_create(request: HttpRequest, customer: Customer) -> Response:  # noqa: PLR0911
     """Create a new user and add them to the customer organization.
@@ -1004,8 +1022,11 @@ def customer_users_create(request: HttpRequest, customer: Customer) -> Response:
     create-user cap on top. The previous BurstAPIThrottle (api_burst, 120/min)
     was a regression here — it extends UserRateThrottle and this endpoint runs
     with authentication_classes([]), so it keyed on client IP and a caller
-    distributing requests across IPs could bypass it. All three throttles below
-    key on the verified portal id (X-Portal-Id)."""
+    distributing requests across IPs could bypass it. The first three throttles
+    key on the verified portal id (X-Portal-Id) and bound signed traffic;
+    CustomerRateThrottle/BurstRateThrottle return None for portal traffic but
+    key ANONYMOUS traffic by client IP, so the pre-auth path an unsigned caller
+    reaches before @require_customer_authentication is still limited (#277)."""
     data = _get_request_data(request)
     try:
         user_id = _extract_user_id(data)

--- a/services/platform/apps/api/gdpr/views.py
+++ b/services/platform/apps/api/gdpr/views.py
@@ -20,15 +20,23 @@ from apps.api.secure_auth import (
     require_portal_service_authentication,
 )
 from apps.audit.services import GDPRConsentService, GDPRExportService
+from apps.common.performance.rate_limiting import BurstRateThrottle, CustomerRateThrottle
 from apps.users.models import User
 
 logger = logging.getLogger(__name__)
+
+# Throttling note (#277): these HMAC service endpoints add CustomerRateThrottle +
+# BurstRateThrottle. Both return None for verified portal-service traffic (which sets
+# request._portal_authenticated), so legitimate signed calls are unaffected, but they
+# key ANONYMOUS traffic by safe client IP. DRF runs throttles before
+# @require_portal_service_authentication rejects an unsigned request, so without a
+# fallback the pre-auth path would be an unthrottled endpoint-layer surface.
 
 
 @api_view(["POST"])
 @authentication_classes([])  # No DRF authentication - HMAC handled by middleware + secure_auth
 @permission_classes([AllowAny])  # No DRF permissions - auth handled by @require_portal_service_authentication
-@throttle_classes([])  # No DRF throttling - service-to-service HMAC auth, not user-facing
+@throttle_classes([CustomerRateThrottle, BurstRateThrottle])  # #277: IP-limit unsigned traffic; None for signed
 @require_portal_service_authentication
 def cookie_consent_api(request: Request, request_data: dict[str, Any]) -> Response:
     """
@@ -65,7 +73,7 @@ def cookie_consent_api(request: Request, request_data: dict[str, Any]) -> Respon
 @api_view(["POST"])
 @authentication_classes([])  # No DRF authentication - HMAC handled by middleware + secure_auth
 @permission_classes([AllowAny])  # No DRF permissions - auth handled by @require_portal_service_authentication
-@throttle_classes([])  # No DRF throttling - service-to-service HMAC auth, not user-facing
+@throttle_classes([CustomerRateThrottle, BurstRateThrottle])  # #277: IP-limit unsigned traffic; None for signed
 @require_portal_service_authentication
 def consent_history_api(request: Request, request_data: dict[str, Any]) -> Response:
     """
@@ -96,7 +104,7 @@ def consent_history_api(request: Request, request_data: dict[str, Any]) -> Respo
 @api_view(["POST"])
 @authentication_classes([])  # No DRF authentication - HMAC handled by middleware + secure_auth
 @permission_classes([AllowAny])  # No DRF permissions - auth handled by @require_portal_service_authentication
-@throttle_classes([])  # No DRF throttling - service-to-service HMAC auth, not user-facing
+@throttle_classes([CustomerRateThrottle, BurstRateThrottle])  # #277: IP-limit unsigned traffic; None for signed
 @require_portal_service_authentication
 def data_export_api(request: Request, request_data: dict[str, Any]) -> Response:
     """

--- a/services/platform/apps/api/users/views.py
+++ b/services/platform/apps/api/users/views.py
@@ -29,7 +29,13 @@ from apps.api.secure_auth import (
 )
 from apps.api.users.authentication import HashedTokenAuthentication
 from apps.common.constants import HMAC_NTP_SKEW_SECONDS, HMAC_TIMESTAMP_WINDOW_SECONDS
-from apps.common.performance.rate_limiting import EndpointRateThrottle, PortalHMACBurstThrottle, PortalHMACRateThrottle
+from apps.common.performance.rate_limiting import (
+    BurstRateThrottle,
+    CustomerRateThrottle,
+    EndpointRateThrottle,
+    PortalHMACBurstThrottle,
+    PortalHMACRateThrottle,
+)
 from apps.common.request_ip import get_safe_client_ip
 from apps.customers.models import Customer
 from apps.users.forms import UserRegistrationForm
@@ -1019,7 +1025,12 @@ def customer_profile_api(request: HttpRequest, user: User) -> Response:
 @api_view(["POST"])
 @authentication_classes([])  # HMAC handled by middleware + secure_auth
 @permission_classes([AllowAny])
-@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle])
+# #277 follow-up: the PortalHMAC* throttles return None for non-portal traffic, so an
+# unsigned caller reaches this endpoint's HMAC-rejection path unthrottled (DRF runs
+# throttles before @require_user_authentication). CustomerRateThrottle/BurstRateThrottle
+# key anonymous traffic by client IP while deferring to the portal limits for signed
+# traffic, restoring the DEFAULT_THROTTLE_CLASSES anonymous fallback.
+@throttle_classes([PortalHMACRateThrottle, PortalHMACBurstThrottle, CustomerRateThrottle, BurstRateThrottle])
 @require_user_authentication
 def user_customers_api(request: HttpRequest, user: User) -> Response:
     """

--- a/services/platform/apps/common/performance/rate_limiting.py
+++ b/services/platform/apps/common/performance/rate_limiting.py
@@ -170,31 +170,42 @@ def _extract_hmac_identity(request: Request) -> str:
 
 
 class _CustomTimeRateMixin:
-    """Support custom shorthand rates such as `50/10s`.
+    """Shorthand-rate parsing + the system-wide rate-limiting kill switch.
 
     #277: startup validation (``validate_throttle_rate_map``) accepts every format
     ``parse_rate_string`` accepts, but DRF's stock ``parse_rate`` keys the window on
     ``period[0]`` alone — so a multi-digit window like ``50/10s`` reads as ``'1'`` and
     raises KeyError at REQUEST time after passing deploy checks cleanly. Any throttle
     whose rate is env-overridable must therefore parse with this mixin, not DRF's.
+
+    The kill switch lives here too so it is honored by EVERY project throttle. It used
+    to sit only on ``_ConfigurableRateThrottle``, which the DRF-base throttles
+    (Customer/Burst/Standard/Auth) don't inherit — so ``RATE_LIMITING_ENABLED=False``
+    silently failed to disable them (unexpected 429s in dev/E2E). Since this mixin is
+    the one common ancestor of every project throttle, defining ``allow_request`` here
+    makes the switch universal. ``super().allow_request`` reaches the real throttle base
+    via cooperative MRO (the mixin is always followed by a DRF throttle class).
     """
 
     def parse_rate(self, rate: str) -> tuple[int, int]:
         return parse_rate_string(rate)
 
-
-class _ConfigurableRateThrottle(_CustomTimeRateMixin, SimpleRateThrottle):  # type: ignore[misc]  # dynamic DRF attributes
-    """Honor PRAHO's system-wide rate-limiting kill switch.
-
-    Inherits ``_CustomTimeRateMixin`` so shorthand-window parsing is the default for
-    every project throttle rather than something each subclass must remember to opt
-    into — see the mixin docstring for the startup/request-time asymmetry it closes.
-    """
-
     def allow_request(self, request: Request, view: Any) -> bool:
         if not getattr(settings, "RATE_LIMITING_ENABLED", True):
             return True
-        return bool(super().allow_request(request, view))
+        # super() resolves to the DRF throttle base at runtime via cooperative MRO — this
+        # mixin is always mixed in *before* a SimpleRateThrottle subclass. mypy can't see
+        # that from the standalone mixin, hence the ignore.
+        return bool(super().allow_request(request, view))  # type: ignore[misc]  # cooperative-MRO super
+
+
+class _ConfigurableRateThrottle(_CustomTimeRateMixin, SimpleRateThrottle):  # type: ignore[misc]  # dynamic DRF attributes
+    """Base for PRAHO's own scoped throttles.
+
+    Carries no behavior of its own now — shorthand parsing and the kill switch both
+    live on ``_CustomTimeRateMixin`` so every project throttle honors them, not just
+    this base's subclasses.
+    """
 
 
 class PortalHMACRateThrottle(_ConfigurableRateThrottle):

--- a/services/platform/tests/api/test_throttle_architecture_guardrails.py
+++ b/services/platform/tests/api/test_throttle_architecture_guardrails.py
@@ -10,8 +10,10 @@ from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 from django.utils.module_loading import import_string
+from rest_framework.decorators import api_view, authentication_classes, throttle_classes
 from rest_framework.test import APIRequestFactory
 from rest_framework.throttling import AnonRateThrottle, ScopedRateThrottle, SimpleRateThrottle, UserRateThrottle
+from rest_framework.views import APIView
 from tests.api.test_api_auth_regressions import _has_public_marker
 
 from apps.api.core import throttling as core_throttling
@@ -197,16 +199,16 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
                     continue  # DRF auth enabled → not an unsigned-reachable HMAC endpoint
                 if _has_public_marker(obj):
                     continue  # genuinely public: no portal identity, IP keying is native
-                # An empty throttle list is skipped ONLY because config.settings.test sets
-                # DEFAULT_THROTTLE_CLASSES=[], so a view that merely INHERITS the defaults is
-                # indistinguishable here from one that explicitly wrote @throttle_classes([]).
-                # In production the inherited defaults (Customer/BurstRateThrottle) key unsigned
-                # traffic, so inherited-default views are fine. The genuinely-dangerous case —
-                # an explicit @throttle_classes([]) suppressing the defaults, as three GDPR
-                # views once did — is covered by giving those views a real fallback (they are
-                # no longer empty and so ARE evaluated below); a future explicit-[] HMAC view is
-                # a known blind spot of this environment and is guarded per-view where it matters.
-                if not view_cls.throttle_classes:
+                # Skip views that merely INHERIT the defaults, NOT ones that explicitly
+                # override throttling. config.settings.test sets DEFAULT_THROTTLE_CLASSES=[],
+                # so both show throttle_classes==[] — but DRF binds an inheriting view to the
+                # SAME APIView.throttle_classes object, while @throttle_classes([...]) (any
+                # list, including []) installs a distinct one. Comparing identity therefore
+                # keeps inherited-default views out (in production those defaults key unsigned
+                # traffic) while an explicit @throttle_classes([]) that suppresses the defaults
+                # — the dangerous config three GDPR views once had — is NOT skipped and is
+                # flagged below (an empty list keys nothing).
+                if view_cls.throttle_classes is APIView.throttle_classes:
                     continue
                 req = factory.post(f"/{name}/", REMOTE_ADDR="198.51.100.10")
                 req.user = AnonymousUser()  # unsigned: no portal auth, no DRF user
@@ -224,6 +226,28 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
             "the PortalHMAC* throttles return None for non-portal requests, so add an "
             f"always-keyed throttle (CustomerRateThrottle/BurstRateThrottle): {unprotected}",
         )
+
+    def test_sweep_would_flag_an_explicit_empty_throttle_override(self) -> None:
+        """The strengthened skip must distinguish inherited defaults from an explicit
+        @throttle_classes([]). This builds the exact dangerous shape — an HMAC view that
+        explicitly suppresses the defaults — and asserts the sweep's own predicates would
+        flag it (not skip it), so a future regression of that shape can't pass silently.
+        """
+        @api_view(["POST"])
+        @authentication_classes([])
+        @throttle_classes([])  # explicit suppression — the dangerous config
+        def _explicit_empty_hmac_view(request: object) -> None:  # pragma: no cover - never called
+            return None
+
+        view_cls = _explicit_empty_hmac_view.cls
+        # The identity skip must NOT swallow it: an explicit [] is a distinct object.
+        self.assertIsNot(view_cls.throttle_classes, APIView.throttle_classes)
+        # And it keys nothing for unsigned traffic, so the sweep's offender branch fires.
+        factory = APIRequestFactory()
+        req = factory.post("/x/", REMOTE_ADDR="198.51.100.10")
+        req.user = AnonymousUser()
+        keys_unsigned = any(t().get_cache_key(req, view=view_cls) is not None for t in view_cls.throttle_classes)
+        self.assertFalse(keys_unsigned, "an explicit empty override throttles nothing — must be flagged")
 
     def test_gdpr_service_endpoints_throttle_unsigned_traffic(self) -> None:
         """#277 follow-up: the GDPR HMAC endpoints once used @throttle_classes([]) — an

--- a/services/platform/tests/api/test_throttle_architecture_guardrails.py
+++ b/services/platform/tests/api/test_throttle_architecture_guardrails.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
@@ -17,6 +18,7 @@ from apps.api.core import throttling as core_throttling
 from apps.api.core.throttling import AuthThrottle, BurstAPIThrottle, StandardAPIThrottle
 from apps.api.customers import views as customers_views
 from apps.api.customers.views import customer_users_create, update_customer_billing_address
+from apps.api.gdpr import views as gdpr_views
 from apps.api.orders import views as orders_views
 from apps.api.orders.views import (
     OrderCalculateThrottle,
@@ -127,7 +129,7 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
         HMAC view with the wrong throttle fails here without anyone remembering to add it.
         """
         offenders: list[str] = []
-        for module in (customers_views, orders_views, users_views):
+        for module in (customers_views, orders_views, users_views, gdpr_views):
             for name, obj in vars(module).items():
                 view_cls = getattr(obj, "cls", None)
                 if view_cls is None or not hasattr(view_cls, "throttle_classes"):
@@ -168,8 +170,125 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
         self.assertIn(rate_limiting.PortalHMACBurstThrottle, throttle_classes)
         self.assertNotIn(BurstAPIThrottle, throttle_classes)
 
+    def test_hmac_function_views_throttle_unsigned_traffic_too(self) -> None:
+        """#277 follow-up: an ``authentication_classes([])`` HMAC view must ALSO limit unsigned traffic.
+
+        The PortalHMAC* throttles return ``None`` (no limit) for non-portal requests by
+        design — they only bucket verified portal callers. DRF evaluates throttles BEFORE
+        the view body, so ``@require_customer_authentication`` rejects an unsigned request
+        only after it passed throttling. A view carrying ONLY portal throttles therefore
+        leaves the pre-auth/rejection path unthrottled at this layer, which is exactly what
+        replacing the IP-keyed ``BurstAPIThrottle`` dropped. Every such view needs at least
+        one always-keyed throttle — CustomerRateThrottle/BurstRateThrottle key anonymous
+        traffic by safe client IP — matching DEFAULT_THROTTLE_CLASSES.
+
+        This is the positive-coverage complement to
+        ``test_hmac_function_views_never_use_ip_keyed_user_throttles``: that guard forbids
+        the WRONG throttle; this one requires a fallback to actually be present.
+        """
+        factory = APIRequestFactory()
+        unprotected: list[str] = []
+        for module in (customers_views, orders_views, users_views, gdpr_views):
+            for name, obj in vars(module).items():
+                view_cls = getattr(obj, "cls", None)
+                if view_cls is None or not hasattr(view_cls, "throttle_classes"):
+                    continue
+                if list(getattr(view_cls, "authentication_classes", [1])):
+                    continue  # DRF auth enabled → not an unsigned-reachable HMAC endpoint
+                if _has_public_marker(obj):
+                    continue  # genuinely public: no portal identity, IP keying is native
+                # An empty throttle list is skipped ONLY because config.settings.test sets
+                # DEFAULT_THROTTLE_CLASSES=[], so a view that merely INHERITS the defaults is
+                # indistinguishable here from one that explicitly wrote @throttle_classes([]).
+                # In production the inherited defaults (Customer/BurstRateThrottle) key unsigned
+                # traffic, so inherited-default views are fine. The genuinely-dangerous case —
+                # an explicit @throttle_classes([]) suppressing the defaults, as three GDPR
+                # views once did — is covered by giving those views a real fallback (they are
+                # no longer empty and so ARE evaluated below); a future explicit-[] HMAC view is
+                # a known blind spot of this environment and is guarded per-view where it matters.
+                if not view_cls.throttle_classes:
+                    continue
+                req = factory.post(f"/{name}/", REMOTE_ADDR="198.51.100.10")
+                req.user = AnonymousUser()  # unsigned: no portal auth, no DRF user
+                keys_an_unsigned_request = any(
+                    throttle().get_cache_key(req, view=view_cls) is not None
+                    for throttle in view_cls.throttle_classes
+                )
+                if not keys_an_unsigned_request:
+                    unprotected.append(f"{module.__name__}.{name}")
+
+        self.assertEqual(
+            unprotected,
+            [],
+            "HMAC views (authentication_classes([])) must throttle UNSIGNED traffic too — "
+            "the PortalHMAC* throttles return None for non-portal requests, so add an "
+            f"always-keyed throttle (CustomerRateThrottle/BurstRateThrottle): {unprotected}",
+        )
+
+    def test_gdpr_service_endpoints_throttle_unsigned_traffic(self) -> None:
+        """#277 follow-up: the GDPR HMAC endpoints once used @throttle_classes([]) — an
+        explicit opt-out that suppressed the defaults, leaving the unsigned/rejection path
+        an unlimited endpoint-layer surface (data_export_api is sensitive). Pinned per-view
+        because the generic sweep skips empty throttle lists (a test-settings limitation).
+        """
+        factory = APIRequestFactory()
+        req = factory.post("/x/", REMOTE_ADDR="198.51.100.10")
+        req.user = AnonymousUser()
+        for view in (gdpr_views.cookie_consent_api, gdpr_views.consent_history_api, gdpr_views.data_export_api):
+            throttles = view.cls.throttle_classes
+            self.assertTrue(throttles, f"{view.__name__} must not disable throttling entirely")
+            self.assertTrue(
+                any(t().get_cache_key(req, view=view.cls) is not None for t in throttles),
+                f"{view.__name__} must throttle unsigned traffic (CustomerRateThrottle/BurstRateThrottle)",
+            )
+
+    def test_kill_switch_disables_all_project_throttles_including_drf_base_ones(self) -> None:
+        """RATE_LIMITING_ENABLED=False must bypass EVERY project throttle.
+
+        The kill switch used to live only on _ConfigurableRateThrottle, which the DRF-base
+        throttles (Customer/Burst/Standard/Auth) don't inherit — so disabling rate limiting
+        silently failed to disable them, causing unexpected 429s in dev/E2E. #277 moved the
+        switch onto _CustomTimeRateMixin, the one common ancestor of every project throttle.
+        This pins that: an unsigned request that WOULD be keyed (non-None cache key) must be
+        allowed when the switch is off.
+        """
+        factory = APIRequestFactory()
+        req = factory.post("/x/", REMOTE_ADDR="198.51.100.10")
+        req.user = AnonymousUser()
+        drf_base_throttles = [
+            rate_limiting.CustomerRateThrottle,
+            rate_limiting.BurstRateThrottle,
+            rate_limiting.StandardAPIThrottle,
+            rate_limiting.AuthThrottle,
+        ]
+        with override_settings(RATE_LIMITING_ENABLED=False, CACHES=LOCMEM_TEST_CACHE):
+            cache.clear()
+            for throttle_cls in drf_base_throttles:
+                throttle = throttle_cls()
+                # Precondition: this throttle WOULD key (and thus limit) the request when enabled.
+                self.assertIsNotNone(
+                    throttle.get_cache_key(req, view=None),
+                    f"{throttle_cls.__name__} should key an unsigned request (test premise)",
+                )
+                self.assertTrue(
+                    throttle.allow_request(req, view=None),
+                    f"{throttle_cls.__name__} must be bypassed when RATE_LIMITING_ENABLED=False",
+                )
+
     def test_billing_address_throttle_cannot_be_bypassed_by_rotating_ip(self) -> None:
-        """The behavioral half of the guard above: same portal, different IPs → same bucket."""
+        """Same portal, different IPs → same bucket — asserted through the VIEW's own throttles.
+
+        Resolving the portal throttle from ``update_customer_billing_address.cls`` rather
+        than instantiating ``PortalHMACRateThrottle`` directly is what binds this to the
+        view: if the view's binding regresses (e.g. back to an IP-keyed throttle), this
+        stops proving anything about a class the view no longer uses.
+        """
+        portal_throttles = [
+            t for t in update_customer_billing_address.cls.throttle_classes
+            if issubclass(t, rate_limiting.PortalHMACRateThrottle)
+        ]
+        self.assertTrue(portal_throttles, "billing-address view must carry a portal-keyed throttle")
+
         factory = RequestFactory()
         first = factory.post("/api/customers/billing-address/", REMOTE_ADDR="198.51.100.10")
         second = factory.post("/api/customers/billing-address/", REMOTE_ADDR="203.0.113.20")
@@ -177,11 +296,14 @@ class ThrottleArchitectureGuardrailTests(SimpleTestCase):
             req._portal_authenticated = True  # type: ignore[attr-defined]  # middleware contract
             req.META["HTTP_X_PORTAL_ID"] = "portal-stable"
 
-        throttle = rate_limiting.PortalHMACRateThrottle()
-        self.assertEqual(
-            throttle.get_cache_key(first, view=None),
-            throttle.get_cache_key(second, view=None),
-        )
+        throttle = portal_throttles[0]()
+        first_key = throttle.get_cache_key(first, view=update_customer_billing_address.cls)
+        second_key = throttle.get_cache_key(second, view=update_customer_billing_address.cls)
+        # Assert the throttle actually KEYS signed traffic before asserting IP-independence —
+        # otherwise a regression where it returned None for signed traffic would pass as
+        # None == None while silently throttling nothing.
+        self.assertIsNotNone(first_key, "portal throttle must key verified signed traffic")
+        self.assertEqual(first_key, second_key)
 
     def test_every_project_throttle_parses_its_configured_rate(self) -> None:
         """#277: the gap that let PortalHMACRateThrottle/CustomerRateThrottle rot.


### PR DESCRIPTION
## Problem

Follow-up to #443. That PR fixed the miskeyed throttle on `update_customer_billing_address` by replacing `[BurstAPIThrottle]` with the two `PortalHMAC*` throttles — but those return `None` (no limit) for non-portal traffic by design, and `@throttle_classes` *replaces* `DEFAULT_THROTTLE_CLASSES`. DRF evaluates throttles **before** the view-level `@require_customer_authentication` rejects an unsigned request, so the pre-auth/rejection path was left unthrottled at the endpoint layer — reversing the IP-keyed limit the old `BurstAPIThrottle` gave it.

Root cause: `DEFAULT_THROTTLE_CLASSES` is a complete cover — `PortalHMAC*` limit signed portal traffic; `CustomerRateThrottle`/`BurstRateThrottle` return `None` for portal traffic but key **anonymous** traffic by safe client IP. The per-view overrides listed only the portal half.

A positive-coverage guardrail (added here) surfaced two more endpoints with the same gap that the original hand-analysis missed: `user_customers_api`, and three GDPR service endpoints that used `@throttle_classes([])` to suppress the defaults entirely (`data_export_api` is sensitive — an unthrottled rejection path there is a real DoS surface).

## Fix

Add `CustomerRateThrottle` + `BurstRateThrottle` (the default anonymous fallback) to every affected `authentication_classes([])` endpoint. They return `None` for verified portal/service traffic, so signed callers are unchanged; they key anonymous traffic by client IP, restoring the lost fallback:

- `update_customer_billing_address`, `customer_users_create` — the two #443 touched
- `user_customers_api` — a pre-existing gap the new guard found
- `cookie_consent_api`, `consent_history_api`, `data_export_api` — the three GDPR endpoints (kept signed-service traffic unthrottled, as their original `@throttle_classes([])` intended, but closed the unsigned path)

Guardrails so this class can't recur:

- **positive-coverage sweep** — every `authentication_classes([])` non-public HMAC view must key an unsigned request (the complement to the existing "no IP-keyed `User` throttle" guard, which only forbade the wrong throttle and couldn't see a *missing* one). Empty throttle lists are skipped only because `config.settings.test` zeroes `DEFAULT_THROTTLE_CLASSES`, making inherited-`[]` indistinguishable from explicit-`[]`; the genuinely-dangerous explicit-`[]` case (the GDPR views) is pinned per-view instead.
- the rotating-IP test is now bound to the **view's own** throttle and asserts the signed key is non-`None` before asserting IP-independence (previously it instantiated the class directly and passed on master unchanged).

## Also — the `RATE_LIMITING_ENABLED` kill switch

Adding `Customer`/`BurstRateThrottle` to these views made a pre-existing gap load-bearing: those throttles extend the DRF bases directly, not `_ConfigurableRateThrottle`, so they ignored the kill switch — disabling rate limiting in dev/E2E would no longer disable them. Moved the switch onto `_CustomTimeRateMixin`, the one common ancestor of every project throttle, so all of them honor it (resolving the Copilot finding from #443). A new test pins that an unsigned request is bypassed when `RATE_LIMITING_ENABLED=False`.

## Verification

- Throttle guardrails: 26 tests, OK (was 23 on #443; +3 here). The new positive-coverage test was proven to fail against the merged state, flagging all three portal-only offenders; the strengthened form was empirically checked against a full URL-resolver walk (rejected — it picks up framework `.view` wrapper artifacts) before settling on the module sweep.
- No regression: `test_gdpr_api`, `test_throttle_exception_handler`, `test_customer_api`, `test_api_users_security`, and the guardrail module all pass.
- mypy + ruff clean on all five changed files.

## Scope

Part of #277 (the issue stays open — its architectural half, per-portal HMAC credentials + a portal registry that would make `X-Portal-Id` unforgeable, is unchanged and remains tracked there). Closing the unsigned-path throttle gap is the finish of #443's endpoint-hardening work.
