### PR TITLE
chore(orders): stop sending the dead payment_status field (#104 H11)

### DIFF
--- a/services/platform/tests/orders/test_order_flow_security.py
+++ b/services/platform/tests/orders/test_order_flow_security.py
@@ -134,27 +134,26 @@ class StripePaymentVerificationTest(TestCase):
 
         test_confirm_rejects_non_succeeded_pi already proves the *behavior* — a forged
         "succeeded" loses to Stripe's real status. This pins the stronger property the
-        fix established: confirm_order never consults request payment_status at all, so
-        no future refactor can reintroduce it as a shortcut (e.g. "trust it when Stripe
-        is unreachable"). Asserted on the source because a behavioral test cannot
-        distinguish "ignored" from "read but overridden".
-        """
-        # NOT inspect.getsource(confirm_order): @api_view replaces it with DRF's wrapper,
-        # so that would assert on 443 characters of framework code and pass unconditionally.
-        # Read the decorated function out of the module source instead.
-        module_source = pathlib.Path(inspect.getfile(views_module)).read_text(encoding="utf-8")
-        marker = "def confirm_order("
-        start = module_source.index(marker)
-        end = module_source.find("\ndef ", start + len(marker))
-        body = module_source[start : end if end != -1 else len(module_source)]
-        code = "\n".join(line.split("#")[0] for line in body.splitlines())
+        fix established: no code in this module consults request payment_status at all,
+        so no future refactor can reintroduce it as a shortcut (e.g. "trust it when
+        Stripe is unreachable"). Asserted on the source because a behavioral test
+        cannot distinguish "ignored" from "read but overridden".
 
-        self.assertIn("payment_intent_id", code, "guard is reading the wrong function")
+        MODULE scope on purpose, not a slice of confirm_order: function-slicing goes
+        vacuous the moment the payment read is extracted into a module-level helper
+        (this module's established refactor pattern), and inspect.getsource on the
+        view is defeated by @api_view wrapping. Quoted-form matching skips prose
+        mentions in comments/docstrings naturally — any legitimate future need for
+        the quoted literal in this module must consciously rewrite this guard.
+        """
+        module_source = pathlib.Path(inspect.getfile(views_module)).read_text(encoding="utf-8")
+
+        self.assertIn("payment_intent_id", module_source, "guard is reading the wrong module")
         for accessor in ('"payment_status"', "'payment_status'"):
             self.assertNotIn(
                 accessor,
-                code,
-                "confirm_order must not read payment_status from the request (#104 H11)",
+                module_source,
+                "orders API views must not read payment_status from a request (#104 H11)",
             )
 
     def test_confirm_rejects_non_succeeded_pi(self) -> None:

--- a/services/platform/tests/orders/test_order_flow_security.py
+++ b/services/platform/tests/orders/test_order_flow_security.py
@@ -9,12 +9,15 @@ Tests for:
 
 from __future__ import annotations
 
+import inspect
+import pathlib
 from unittest.mock import MagicMock, patch
 
 from django.http import HttpResponse
 from django.test import RequestFactory, SimpleTestCase, TestCase
 from rest_framework.test import APIRequestFactory
 
+from apps.api.orders import views as views_module
 from apps.api.orders.views import confirm_order
 from apps.billing.gateways.base import PaymentConfirmResult
 from apps.billing.models import Currency
@@ -125,6 +128,34 @@ class StripePaymentVerificationTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.data["success"])
         mock_gateway.confirm_payment.assert_called_once_with("pi_testVerifyOK1234567")
+
+    def test_confirm_never_reads_payment_status_from_the_request(self) -> None:
+        """#104 [H11] guardrail: the field must be structurally unread, not merely overridden.
+
+        test_confirm_rejects_non_succeeded_pi already proves the *behavior* — a forged
+        "succeeded" loses to Stripe's real status. This pins the stronger property the
+        fix established: confirm_order never consults request payment_status at all, so
+        no future refactor can reintroduce it as a shortcut (e.g. "trust it when Stripe
+        is unreachable"). Asserted on the source because a behavioral test cannot
+        distinguish "ignored" from "read but overridden".
+        """
+        # NOT inspect.getsource(confirm_order): @api_view replaces it with DRF's wrapper,
+        # so that would assert on 443 characters of framework code and pass unconditionally.
+        # Read the decorated function out of the module source instead.
+        module_source = pathlib.Path(inspect.getfile(views_module)).read_text(encoding="utf-8")
+        marker = "def confirm_order("
+        start = module_source.index(marker)
+        end = module_source.find("\ndef ", start + len(marker))
+        body = module_source[start : end if end != -1 else len(module_source)]
+        code = "\n".join(line.split("#")[0] for line in body.splitlines())
+
+        self.assertIn("payment_intent_id", code, "guard is reading the wrong function")
+        for accessor in ('"payment_status"', "'payment_status'"):
+            self.assertNotIn(
+                accessor,
+                code,
+                "confirm_order must not read payment_status from the request (#104 H11)",
+            )
 
     def test_confirm_rejects_non_succeeded_pi(self) -> None:
         """Stripe PI with status != succeeded rejects order confirmation."""

--- a/services/portal/apps/orders/views.py
+++ b/services/portal/apps/orders/views.py
@@ -1324,11 +1324,14 @@ def confirm_payment(request: HttpRequest) -> JsonResponse:  # noqa: PLR0911, PLR
             # Step 2: If payment succeeded, update order status
             if payment_status == "succeeded":
                 # Update order to confirmed status via API
+                # #104 [H11]: deliberately does NOT send payment_status. The platform
+                # re-retrieves the PaymentIntent from Stripe and derives the status
+                # itself; sending our copy would look like a trusted input to the next
+                # reader of this call site, which is exactly the confusion H11 was about.
                 order_update_result = api_client.post(
                     f"orders/{order_id}/confirm/",
                     {
                         "payment_intent_id": payment_intent_id,
-                        "payment_status": payment_status,
                         "customer_id": customer_id,
                     },
                     user_id=int(user_id),

--- a/services/portal/tests/orders/test_confirm_payment_user_id.py
+++ b/services/portal/tests/orders/test_confirm_payment_user_id.py
@@ -98,6 +98,49 @@ class ConfirmPaymentUserIdValidationTests(SimpleTestCase):
             call_kwargs = mock_api.post_billing.call_args
             self.assertIsInstance(call_kwargs[1]["user_id"], int)
 
+    @patch("apps.orders.views.PlatformAPIClient")
+    def test_confirm_payload_excludes_payment_status(self, mock_api_class: object) -> None:
+        """#104 [H11]: the confirm POST body must not carry payment_status.
+
+        The platform deliberately never reads it (it re-retrieves the PaymentIntent
+        from Stripe), so sending our copy made the field look like a trusted input.
+        This is the behavioral discriminator for the removal — asserted on the actual
+        payload the API client receives, so re-adding the field fails HERE even
+        though the platform would keep ignoring it.
+        """
+        self._set_session(active_customer_id=123, customer_id=123, user_id=456)
+        mock_api = mock_api_class.return_value
+        mock_api.post_billing.return_value = {"success": True, "status": "succeeded"}
+        mock_api.post.return_value = {"success": True}
+
+        self.client.post(
+            "/order/confirm-payment/",
+            data=json.dumps({
+                "payment_intent_id": "pi_testNoStatus123456789",
+                "order_id": "550e8400-e29b-41d4-a716-446655440000",
+                "gateway": "stripe",
+            }),
+            content_type="application/json",
+        )
+
+        self.assertTrue(mock_api.post.called, "confirm call should have been made")
+        confirm_path, confirm_payload = mock_api.post.call_args[0][0], mock_api.post.call_args[0][1]
+        self.assertIn("/confirm/", confirm_path)
+        self.assertIn("payment_intent_id", confirm_payload)  # anchor: right call inspected
+        self.assertNotIn("payment_status", confirm_payload)
+
+    def test_confirm_payment_source_never_sends_payment_status(self) -> None:
+        """Source-level second layer for the same H11 property (see test above).
+
+        confirm_payment is a plain Django view, so inspect.getsource works here —
+        unlike the platform's DRF @api_view-wrapped receiver. Quoted-form matching
+        skips the bare-identifier local variable that legitimately drives the
+        portal's own success branch.
+        """
+        source = inspect.getsource(confirm_payment)
+        self.assertNotIn('"payment_status"', source)
+        self.assertNotIn("'payment_status'", source)
+
     def test_view_level_user_id_guard_exists(self) -> None:
         """Defense-in-depth: confirm_payment validates user_id before int() cast."""
         source = inspect.getsource(confirm_payment)


### PR DESCRIPTION
## Problem

The portal's `confirm_payment` sent `payment_status` alongside `payment_intent_id` to the platform's confirm endpoint — but the platform deliberately never reads it (it re-retrieves the PaymentIntent from Stripe and derives the status itself, so a forged "succeeded" cannot skip payment). Sending our copy made the field look like a trusted input to the next reader of the call site — exactly the confusion #104's H11 flagged.

## Change

Recovered from PR #451 (`refs/pull/451/head` @ `3345646c`; the author's account was deleted before merge). The dead field is removed from the POST body, with a comment at the call site explaining why it must not come back. A source-level guardrail test pins the stronger property — `confirm_order` never *consults* request `payment_status` at all (a behavioral test cannot distinguish "ignored" from "read but overridden"); it parses the module source because `@api_view` replaces the function with DRF's wrapper, making `inspect.getsource` assert on framework code unconditionally.

## Verification

- Cross-service contract verified: the platform's only mention of the field is the explanatory comment (`views.py:1106`); no serializer requires it; no portal or platform test asserts the old payload; HMAC signs actual bytes, so field removal is signing-neutral.
- **Guard discriminator proven both ways**: injecting a `request.data.get("payment_status")` read into `confirm_order` turns the test red; reverting turns it green.
- Both services' gates: platform order-flow-security 15/15; portal mypy (73 files) + full portal suite 1103 passed.

Part of #104 (H11).
