### PR TITLE
fix(domains): correct three Gandi request payload shapes (#265)

### DIFF
--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -6,7 +6,7 @@ Auth: Personal Access Token via Authorization header.
 Rate limit: 30 requests / 2 seconds (negotiable for resellers).
 
 PROVISIONAL — NOT SANDBOX-VERIFIED. The success-response parsing here (expecting
-id/expires_at/auth_info in the register/renew body) was written from documentation
+id/expires_at/authinfo in the register/renew body) was written from documentation
 and has not been validated against the live Gandi API, which documents a 202
 "accepted" body (message + Location) that likely requires polling the returned
 operation/domain resource for the confirmed state and expiry. Chargeable
@@ -128,7 +128,10 @@ class GandiGateway(BaseRegistrarGateway):
                     registrar_domain_id=data.get("id", domain_name),
                     expires_at=expires_at,
                     nameservers=nameservers or self.registrar.default_nameservers or [],
-                    epp_code=data.get("auth_info", ""),
+                    # authinfo, not auth_info — the identical misspelling this change
+                    # fixed on the write side. Gandi's domain-details response documents a
+                    # top-level `authinfo`, so the EPP credential read back was always "".
+                    epp_code=data.get("authinfo", ""),
                 )
             )
 
@@ -241,26 +244,39 @@ class GandiGateway(BaseRegistrarGateway):
         url = f"{GANDI_API_BASE}/domain/transferin"
         body: dict[str, Any] = {"fqdn": domain_name, "authinfo": epp_code}
 
+        # Query string, not body — the same rule _do_register already follows above. Gandi
+        # documents sharing_id as a query param AND as the reseller billing identifier, so
+        # in the body it is at best ignored: the chargeable transfer then bills the PAT's
+        # default organization instead of the customer's sharing org.
+        params = {}
         sharing_id = self._get_sharing_id()
         if sharing_id:
-            body["sharing_id"] = sharing_id
+            params["sharing_id"] = sharing_id
 
         try:
-            response = self._api_request("POST", url, json=body, headers=self._auth_headers())
+            response = self._api_request("POST", url, json=body, params=params, headers=self._auth_headers())
         except requests.RequestException as exc:
             # Transfer POST may have reached the registrar — not provably unapplied (UNKNOWN default).
             return Err(RegistrarTransientError(self.registrar.name, f"Network error during transfer: {exc}"))
 
-        if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
-            data = response.json()
+        # 202 ONLY: a 200 here is the documented Dry-Run *validation* response, whose body
+        # can be {"status": "error", "errors": [...]} — accepting it would report a failed
+        # validation as a started transfer.
+        if response.status_code == HTTP_ACCEPTED:
+            data = self._safe_json(response)  # size-capped, like every sibling parse
+            # The 202 body is documented as {"message": ...} only; the Location header is
+            # the sole operation handle. Reading id/status/expected_completion from it
+            # yields ""/"pending"/None on every real response, and services.py stores that
+            # empty string as the registrar operation id.
+            transfer_id = data.get("id") or response.headers.get("Location", "")
             return Ok(
                 DomainTransferResult(
-                    transfer_id=data.get("id", ""),
+                    transfer_id=transfer_id,
                     status=data.get("status", "pending"),
                     expected_completion=_parse_gandi_date(data.get("expected_completion", "")),
                 )
             )
-        return self._handle_error_response(response, f"transfer {domain_name}")
+        return self._handle_error_response(response, f"transfer {domain_name}", domain_name=domain_name)
 
     def _do_get_domain_info(self, domain_name: str) -> Result[DomainInfoResult, RegistrarAPIError]:
         url = f"{GANDI_API_BASE}/domain/domains/{domain_name}"
@@ -287,10 +303,13 @@ class GandiGateway(BaseRegistrarGateway):
                     if isinstance(data.get("status"), list)
                     else False,
                     whois_privacy=data.get("whois_privacy", False),
-                    epp_code=data.get("auth_info", ""),
+                    # authinfo, not auth_info — the identical misspelling this change
+                    # fixed on the write side. Gandi's domain-details response documents a
+                    # top-level `authinfo`, so the EPP credential read back was always "".
+                    epp_code=data.get("authinfo", ""),
                 )
             )
-        return self._handle_error_response(response, f"info {domain_name}")
+        return self._handle_error_response(response, f"info {domain_name}", domain_name=domain_name)
 
     def _do_update_nameservers(
         self, domain_name: str, nameservers: list[str]
@@ -308,7 +327,7 @@ class GandiGateway(BaseRegistrarGateway):
 
         if response.status_code in (HTTP_OK, HTTP_ACCEPTED):
             return Ok(NameserverUpdateResult(nameservers=nameservers))
-        return self._handle_error_response(response, f"update nameservers for {domain_name}")
+        return self._handle_error_response(response, f"update nameservers for {domain_name}", domain_name=domain_name)
 
     def _do_set_lock(self, domain_name: str, locked: bool) -> Result[DomainLockResult, RegistrarAPIError]:
         # #265: transfer lock lives on the /status sub-resource, not the domain resource.

--- a/services/platform/apps/domains/gateways/gandi.py
+++ b/services/platform/apps/domains/gateways/gandi.py
@@ -227,8 +227,19 @@ class GandiGateway(BaseRegistrarGateway):
     # -- Phase 2 operations --------------------------------------------------
 
     def _do_initiate_transfer(self, domain_name: str, epp_code: str) -> Result[DomainTransferResult, RegistrarAPIError]:
+        # #265: the auth code field is `authinfo`, not `auth_info` — Gandi rejects the
+        # latter, so real inbound transfers never started. See
+        # https://api.gandi.net/docs/domains/ (POST /v5/domain/transferin).
+        #
+        # NOTE: Gandi also requires an `owner` contact object on transfer-in. It is not
+        # sent here because the gateway's initiate_transfer(domain_name, epp_code)
+        # signature carries no registrant data — threading it through means changing the
+        # base interface, both adapters, and DomainService.initiate_transfer (which does
+        # have the Customer). Tracked as the remaining half of #265; transfer-in stays
+        # unusable until then, but it now fails on a missing contact rather than on a
+        # field name, which is the error a sandbox run needs to surface.
         url = f"{GANDI_API_BASE}/domain/transferin"
-        body: dict[str, Any] = {"fqdn": domain_name, "auth_info": epp_code}
+        body: dict[str, Any] = {"fqdn": domain_name, "authinfo": epp_code}
 
         sharing_id = self._get_sharing_id()
         if sharing_id:
@@ -284,10 +295,13 @@ class GandiGateway(BaseRegistrarGateway):
     def _do_update_nameservers(
         self, domain_name: str, nameservers: list[str]
     ) -> Result[NameserverUpdateResult, RegistrarAPIError]:
+        # #265: the endpoint expects the documented object wrapper {"nameservers": [...]},
+        # not a bare array. A bare array is a client error, so the update could never
+        # succeed — the service correctly reported failure, but for the wrong reason.
         url = f"{GANDI_API_BASE}/domain/domains/{domain_name}/nameservers"
 
         try:
-            response = self._api_request("PUT", url, json=nameservers, headers=self._auth_headers())
+            response = self._api_request("PUT", url, json={"nameservers": nameservers}, headers=self._auth_headers())
         except requests.RequestException as exc:
             # Nameserver update is a mutation — may have applied; UNKNOWN default.
             return Err(RegistrarTransientError(self.registrar.name, f"Network error: {exc}"))
@@ -297,9 +311,13 @@ class GandiGateway(BaseRegistrarGateway):
         return self._handle_error_response(response, f"update nameservers for {domain_name}")
 
     def _do_set_lock(self, domain_name: str, locked: bool) -> Result[DomainLockResult, RegistrarAPIError]:
-        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}"
-        # Gandi uses PATCH on domain to toggle transfer lock
-        body: dict[str, Any] = {"tags": ["locked"]} if locked else {"autorenew": None}
+        # #265: transfer lock lives on the /status sub-resource, not the domain resource.
+        # The previous body patched the DOMAIN with tags/autorenew, so lock/unlock never
+        # touched the transfer-lock state at all — and unlock sent {"autorenew": None},
+        # which risked clearing autorenew instead. See https://api.gandi.net/docs/domains/
+        # (PATCH /v5/domain/domains/{domain}/status).
+        url = f"{GANDI_API_BASE}/domain/domains/{domain_name}/status"
+        body: dict[str, Any] = {"clientTransferProhibited": locked}
 
         try:
             response = self._api_request("PATCH", url, json=body, headers=self._auth_headers())

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -44,11 +44,25 @@ def _make_registrar(name: str = "gandi", **kwargs: Any) -> Registrar:
     return Registrar(name=name, **defaults)
 
 
-def _mock_response(status_code: int, json_data: dict | None = None, text: str = "") -> MagicMock:
+def _cache_get_stub(key: str, default: object = None) -> object:
+    """cache.get() stub keyed by NAME, not call order.
+
+    The circuit breaker expects an int (`cb:...:failures`); everything else here is an
+    idempotency claim that must read as absent. A positional side_effect list couples the
+    test to the exact number of cache.get calls inside the base gateway and raises
+    StopIteration the moment one is added.
+    """
+    return 0 if str(key).startswith("cb:") else default
+
+def _mock_response(
+    status_code: int, json_data: dict | None = None, text: str = "", headers: dict | None = None
+) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status_code
     resp.text = text or json.dumps(json_data or {})
-    resp.headers = {}
+    # Gandi's 202 bodies carry only {"message": ...}; the operation handle is in Location,
+    # so a fixture that cannot set headers can never notice the header matters.
+    resp.headers = headers or {}
     if json_data is not None:
         resp.json.return_value = json_data
     else:
@@ -140,7 +154,7 @@ class GandiTransferTests(TestCase):
     @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
     @patch("apps.domains.gateways.base.cache")
     def test_successful_transfer(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_request.return_value = _mock_response(
             202,
             {
@@ -159,7 +173,7 @@ class GandiTransferTests(TestCase):
     @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
     @patch("apps.domains.gateways.base.cache")
     def test_transfer_auth_failure(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_request.return_value = _mock_response(401, {"message": "Bad auth"})
 
         result = self.gateway.initiate_transfer("example.com", "BAD-EPP")
@@ -182,7 +196,7 @@ class TransferIdempotencyClaimTests(TestCase):
         self, mock_cache: MagicMock, mock_do: MagicMock
     ) -> None:
         # circuit breaker closed (0), idempotency slot free (None), claim wins.
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_cache.add.return_value = True
         mock_do.return_value = Ok(DomainTransferResult(transfer_id="t-1", status="pending"))
 
@@ -220,7 +234,7 @@ class TransferIdempotencyClaimTests(TestCase):
         RenewalIdempotencyTokenTests.test_unknown_outcome_blocks_same_token_retry; this
         gateway inlines its own claim/release protocol instead of routing through
         _execute_idempotent_operation, so it needed the identical fix applied separately."""
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_cache.add.return_value = True
         mock_do.return_value = Err(RegistrarAPIError("transfer response lost"))  # default UNKNOWN
 
@@ -235,7 +249,7 @@ class TransferIdempotencyClaimTests(TestCase):
         """A definite (NOT_RETRIABLE) rejection still releases the claim immediately —
         the carve-out proving the UNKNOWN fix doesn't overcorrect into blocking every
         failure."""
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_cache.add.return_value = True
         mock_do.return_value = Err(
             RegistrarAPIError("epp code rejected"), retriability=Retriability.NOT_RETRIABLE
@@ -288,7 +302,7 @@ class GandiDomainInfoTests(TestCase):
                 "dates": {"registry_ends_at": "2028-01-01T00:00:00Z"},
                 "nameservers": ["ns1.gandi.net", "ns2.gandi.net"],
                 "whois_privacy": True,
-                "auth_info": "EPP-CODE",
+                "authinfo": "EPP-CODE",  # Gandi's documented field name
             },
         )
 
@@ -357,7 +371,7 @@ class ROTLDTransferTests(TestCase):
     @patch("apps.domains.gateways.rotld.ROTLDGateway._api_request")
     @patch("apps.domains.gateways.base.cache")
     def test_successful_transfer(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
-        mock_cache.get.side_effect = [0, None]
+        mock_cache.get.side_effect = _cache_get_stub
         mock_request.return_value = _mock_response(
             201,
             {
@@ -662,15 +676,63 @@ class GandiPayloadShapeTests(TestCase):
     @patch("apps.domains.gateways.base.cache")
     def test_transfer_sends_authinfo_not_auth_info(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
         """#265(1): Gandi's field is `authinfo`; `auth_info` was rejected outright."""
-        mock_cache.get.side_effect = [0, None]
-        mock_request.return_value = _mock_response(202, {"id": "t-1", "status": "pending"})
+        mock_cache.get.side_effect = _cache_get_stub
+        # The DOCUMENTED 202: body is {"message": ...} only, handle in Location. The
+        # previous fixture invented id/status, which is exactly how a response shape Gandi
+        # never emits stays pinned in the suite.
+        mock_request.return_value = _mock_response(
+            202,
+            {"message": "Your transfer request has been accepted"},
+            headers={"Location": "https://api.gandi.net/v5/domain/transferin/example.com"},
+        )
 
-        self.gateway.initiate_transfer("example.com", "EPP-CODE")
+        result = self.gateway.initiate_transfer("example.com", "EPP-CODE")
 
         body = mock_request.call_args.kwargs["json"]
         self.assertEqual(body["authinfo"], "EPP-CODE")
         self.assertNotIn("auth_info", body)
         self.assertEqual(body["fqdn"], "example.com")
+        self.assertTrue(mock_request.call_args.args[1].endswith("/domain/transferin"))
+        # A real 202 must still yield a usable operation handle rather than "".
+        self.assertTrue(result.is_ok(), result)
+        self.assertTrue(result.unwrap().transfer_id, "202 must produce a handle, not an empty id")
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_transfer_sends_sharing_id_in_the_query_string(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """#265: sharing_id is a query param AND the reseller billing identifier.
+
+        In the body it is ignored, so a reseller's chargeable transfer bills the PAT's
+        default organization instead of the customer's sharing org. _do_register already
+        got this right; transfer-in contradicted it.
+        """
+        mock_cache.get.side_effect = _cache_get_stub
+        mock_request.return_value = _mock_response(202, {"message": "accepted"})
+        self.gateway.registrar.api_username = "reseller-org-id"
+
+        self.gateway.initiate_transfer("example.com", "EPP-CODE")
+
+        self.assertEqual(mock_request.call_args.kwargs["params"], {"sharing_id": "reseller-org-id"})
+        self.assertNotIn("sharing_id", mock_request.call_args.kwargs["json"])
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_transfer_rejects_the_dry_run_validation_response(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """A 200 on transferin is the Dry-Run validation response, not a started transfer.
+
+        Its body can be {"status": "error", "errors": [...]}; accepting it reported a
+        failed validation as a submitted transfer.
+        """
+        mock_cache.get.side_effect = _cache_get_stub
+        mock_request.return_value = _mock_response(200, {"status": "error", "errors": ["bad authinfo"]})
+
+        result = self.gateway.initiate_transfer("example.com", "EPP-CODE")
+
+        self.assertTrue(result.is_err(), "a validation response must not read as success")
 
     @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
     @patch("apps.domains.gateways.base.cache")

--- a/services/platform/tests/domains/test_gateway_phase2.py
+++ b/services/platform/tests/domains/test_gateway_phase2.py
@@ -636,3 +636,85 @@ class LifecycleServicePhase2FailureContractTests(TestCase):
         self.assertEqual(DomainOperation.objects.count(), 0)
         self.domain.refresh_from_db()
         self.assertEqual(self.domain.nameservers, ["ns1.old.com"])
+
+
+# ===============================================================================
+# GANDI REQUEST PAYLOAD SHAPES (#265)
+# ===============================================================================
+
+
+@override_settings(REGISTRAR_ADAPTERS_VERIFIED=True)
+class GandiPayloadShapeTests(TestCase):
+    """Assert the exact request bodies sent to Gandi.
+
+    The pre-existing Phase 2 tests assert only the parsed RESULT, and all three payloads
+    below were wrong while those tests passed — a mocked 200 response says nothing about
+    whether the request Gandi received was well-formed. These pin the wire format against
+    https://api.gandi.net/docs/domains/ so a regression fails here rather than in
+    production (or, today, silently against a sandbox nobody has run yet).
+    """
+
+    def setUp(self) -> None:
+        self.registrar = _make_registrar("gandi")
+        self.gateway = GandiGateway(self.registrar)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_transfer_sends_authinfo_not_auth_info(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        """#265(1): Gandi's field is `authinfo`; `auth_info` was rejected outright."""
+        mock_cache.get.side_effect = [0, None]
+        mock_request.return_value = _mock_response(202, {"id": "t-1", "status": "pending"})
+
+        self.gateway.initiate_transfer("example.com", "EPP-CODE")
+
+        body = mock_request.call_args.kwargs["json"]
+        self.assertEqual(body["authinfo"], "EPP-CODE")
+        self.assertNotIn("auth_info", body)
+        self.assertEqual(body["fqdn"], "example.com")
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_nameserver_update_wraps_the_list_in_an_object(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """#265(2): the endpoint takes {"nameservers": [...]}, not a bare array."""
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {})
+        nameservers = ["ns1.new.com", "ns2.new.com"]
+
+        self.gateway.update_nameservers("example.com", nameservers)
+
+        body = mock_request.call_args.kwargs["json"]
+        self.assertEqual(body, {"nameservers": nameservers})
+        self.assertNotIsInstance(body, list)
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_lock_patches_the_status_subresource(self, mock_cache: MagicMock, mock_request: MagicMock) -> None:
+        """#265(3): lock lives on /status, and must not touch autorenew."""
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {})
+
+        self.gateway.set_lock("example.com", locked=True)
+
+        args = mock_request.call_args.args
+        body = mock_request.call_args.kwargs["json"]
+        self.assertEqual(args[0], "PATCH")
+        self.assertTrue(args[1].endswith("/domain/domains/example.com/status"))
+        self.assertEqual(body, {"clientTransferProhibited": True})
+
+    @patch("apps.domains.gateways.gandi.GandiGateway._api_request")
+    @patch("apps.domains.gateways.base.cache")
+    def test_unlock_clears_the_flag_without_touching_autorenew(
+        self, mock_cache: MagicMock, mock_request: MagicMock
+    ) -> None:
+        """The unlock path previously sent {"autorenew": None} — a different field entirely."""
+        mock_cache.get.return_value = 0
+        mock_request.return_value = _mock_response(200, {})
+
+        self.gateway.set_lock("example.com", locked=False)
+
+        body = mock_request.call_args.kwargs["json"]
+        self.assertEqual(body, {"clientTransferProhibited": False})
+        self.assertNotIn("autorenew", body)
+        self.assertNotIn("tags", body)

--- a/services/platform/tests/domains/test_registrar_gateways.py
+++ b/services/platform/tests/domains/test_registrar_gateways.py
@@ -162,7 +162,9 @@ class GandiGatewayRegisterTests(TestCase):
             {
                 "id": "gandi-dom-123",
                 "expires_at": "2027-04-06T00:00:00Z",
-                "auth_info": "EPP-SECRET",
+                # authinfo is Gandi's documented field; the fixture previously pinned the
+                # misspelling, which is what let the read-side bug survive (#265).
+                "authinfo": "EPP-SECRET",
             },
         )
 
@@ -618,7 +620,7 @@ class GandiInvalidResponseTests(TestCase):
     ) -> None:
         mock_cache.get.side_effect = [0, None]
         # 202 success but NO expires_at → must not fabricate a date.
-        mock_request.return_value = _mock_response(202, {"id": "g-1", "auth_info": "EPP"})
+        mock_request.return_value = _mock_response(202, {"id": "g-1", "authinfo": "EPP"})
 
         result = self.gateway.register_domain("example.com", 1, {})
 


### PR DESCRIPTION
## Problem

Three request payloads in the Gandi adapter did not match the documented v5 API, so each operation could never have succeeded against the live service:

| Operation | Sent | Documented |
|---|---|---|
| Transfer-in | `{"auth_info": ...}` | `{"authinfo": ...}` |
| Nameserver update | bare array `[...]` | `{"nameservers": [...]}` |
| Transfer lock | `PATCH /domain/domains/{d}` with `{"tags": ["locked"]}` / `{"autorenew": None}` | `PATCH /domain/domains/{d}/status` with `{"clientTransferProhibited": bool}` |

The lock one is the worst of the three: it patched the **domain resource** rather than the `/status` sub-resource, so lock and unlock never touched transfer-lock state at all — and the unlock body `{"autorenew": None}` risked **clearing autorenew** instead of unlocking.

## Change

Recovered from PR #452 (`refs/pull/452/head` @ `a2a76d55`; the author's account was deleted before merge). Each fix carries the doc reference in a comment.

## Known remaining half

**Transfer-in is still unusable.** Gandi also requires an `owner` contact object on transfer-in, and the gateway's `initiate_transfer(domain_name, epp_code)` signature carries no registrant data — threading it through means changing the base interface, both adapters, and `DomainService.initiate_transfer` (which *does* hold the `Customer`). Deliberately out of scope here. It now fails on a **missing contact** rather than on a field name, which is the error a sandbox run needs to surface.

## Scope — this cannot close #265

The issue's acceptance criteria require a **sandbox round-trip** against the live Gandi Domains API, plus body-shape tests and a per-registrar verified flag. This change fixes the shapes and adds request-body assertions; it cannot provide credentials. `REGISTRAR_ADAPTERS_VERIFIED` stays `false`, which is what gates these adapters from doing anything chargeable.

**Part of #265.**
